### PR TITLE
feat: add create issue per repo and issue detail modal

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData } from './types'
+import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail } from './types'
 
 const BASE = '/api'
 
@@ -103,5 +103,19 @@ export const api = {
     request<{ ok: boolean }>('/github/label-trigger', {
       method: 'POST',
       body: JSON.stringify({ fullName, number }),
+    }),
+
+  getIssue: (owner: string, name: string, number: number) =>
+    request<IssueDetail>(`/github/issue/${owner}/${name}/${number}`),
+
+  createIssue: (params: {
+    fullName: string
+    title: string
+    issueBody?: string
+    labels?: string[]
+  }) =>
+    request<{ ok: boolean; url: string }>('/github/create-issue', {
+      method: 'POST',
+      body: JSON.stringify(params),
     }),
 }

--- a/gh-ctrl/client/src/components/ActionModal.tsx
+++ b/gh-ctrl/client/src/components/ActionModal.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useRef } from 'react'
-import type { GHLabel } from '../types'
+import type { GHLabel, IssueDetail } from '../types'
 import { api } from '../api'
 
 export type ModalState =
   | { mode: 'comment'; fullName: string; number: number; type: 'pr' | 'issue' }
   | { mode: 'label'; fullName: string; number: number; type: 'pr' | 'issue'; currentLabels: string[] }
   | { mode: 'create-pr'; fullName: string; owner: string; repoName: string; head: string }
+  | { mode: 'create-issue'; fullName: string; owner: string; repoName: string }
+  | { mode: 'issue-detail'; fullName: string; owner: string; repoName: string; number: number }
   | null
 
 interface Props {
@@ -30,6 +32,12 @@ export function ActionModal({ state, onClose, onSuccess, onError }: Props) {
         )}
         {state.mode === 'create-pr' && (
           <CreatePRForm state={state} onClose={onClose} onSuccess={onSuccess} onError={onError} />
+        )}
+        {state.mode === 'create-issue' && (
+          <CreateIssueForm state={state} onClose={onClose} onSuccess={onSuccess} onError={onError} />
+        )}
+        {state.mode === 'issue-detail' && (
+          <IssueDetailView state={state} onClose={onClose} onError={onError} />
         )}
       </div>
     </div>
@@ -229,6 +237,7 @@ function CreatePRForm({ state, onClose, onSuccess, onError }: {
         Open Pull Request
         <span className="modal-subtitle">{state.fullName}</span>
       </div>
+
       <div className="modal-field">
         <label className="modal-label">Head branch</label>
         <div className="input modal-readonly">{state.head}</div>
@@ -276,5 +285,199 @@ function CreatePRForm({ state, onClose, onSuccess, onError }: {
         </button>
       </div>
     </form>
+  )
+}
+
+function CreateIssueForm({ state, onClose, onSuccess, onError }: {
+  state: Extract<ModalState, { mode: 'create-issue' }>
+  onClose: () => void
+  onSuccess: (msg: string) => void
+  onError: (msg: string) => void
+}) {
+  const [title, setTitle] = useState('')
+  const [issueBody, setIssueBody] = useState('')
+  const [availableLabels, setAvailableLabels] = useState<GHLabel[]>([])
+  const [selectedLabels, setSelectedLabels] = useState<Set<string>>(new Set())
+  const [submitting, setSubmitting] = useState(false)
+  const [labelsLoading, setLabelsLoading] = useState(true)
+  const titleRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    titleRef.current?.focus()
+    api.getLabels(state.owner, state.repoName)
+      .then(setAvailableLabels)
+      .catch(() => {/* labels are optional */})
+      .finally(() => setLabelsLoading(false))
+  }, [state.owner, state.repoName])
+
+  const toggleLabel = (name: string) => {
+    setSelectedLabels((prev) => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) return
+    setSubmitting(true)
+    try {
+      const result = await api.createIssue({
+        fullName: state.fullName,
+        title: title.trim(),
+        issueBody: issueBody.trim() || undefined,
+        labels: selectedLabels.size > 0 ? [...selectedLabels] : undefined,
+      })
+      onSuccess(`Issue created: ${result.url || title}`)
+      onClose()
+    } catch (err: any) {
+      onError(`Failed: ${err.message}`)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="modal-title">
+        Create Issue
+        <span className="modal-subtitle">{state.fullName}</span>
+      </div>
+      <div className="modal-field">
+        <label className="modal-label">Title</label>
+        <input
+          ref={titleRef}
+          className="input"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Issue title"
+        />
+      </div>
+      <div className="modal-field">
+        <label className="modal-label">Description (optional)</label>
+        <textarea
+          className="input modal-textarea"
+          value={issueBody}
+          onChange={(e) => setIssueBody(e.target.value)}
+          placeholder="Describe the issue..."
+          rows={4}
+        />
+      </div>
+      {!labelsLoading && availableLabels.length > 0 && (
+        <div className="modal-field">
+          <label className="modal-label">Labels (optional)</label>
+          <div className="label-grid">
+            {availableLabels.map((label) => (
+              <button
+                key={label.name}
+                type="button"
+                className={`label-chip${selectedLabels.has(label.name) ? ' selected' : ''}`}
+                style={{ '--label-color': `#${label.color}` } as React.CSSProperties}
+                onClick={() => toggleLabel(label.name)}
+              >
+                <span className="label-dot" style={{ background: `#${label.color}` }} />
+                {label.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="modal-actions">
+        <button type="button" className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button type="submit" className="btn btn-primary" disabled={submitting || !title.trim()}>
+          {submitting ? 'Creating...' : 'Create Issue'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+function IssueDetailView({ state, onClose, onError }: {
+  state: Extract<ModalState, { mode: 'issue-detail' }>
+  onClose: () => void
+  onError: (msg: string) => void
+}) {
+  const [issue, setIssue] = useState<IssueDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.getIssue(state.owner, state.repoName, state.number)
+      .then(setIssue)
+      .catch((err) => onError(`Failed to load issue: ${err.message}`))
+      .finally(() => setLoading(false))
+  }, [state.owner, state.repoName, state.number])
+
+  const formatDate = (dateStr: string) => {
+    try {
+      return new Date(dateStr).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+    } catch {
+      return dateStr
+    }
+  }
+
+  return (
+    <div>
+      <div className="modal-title">
+        Issue #{state.number}
+        <span className="modal-subtitle">{state.fullName}</span>
+      </div>
+      {loading ? (
+        <div className="modal-loading">Loading issue...</div>
+      ) : !issue ? (
+        <div className="modal-loading">Failed to load issue.</div>
+      ) : (
+        <div className="issue-detail">
+          <div className="issue-detail-header">
+            <h3 className="issue-detail-title">{issue.title}</h3>
+            <div className="issue-detail-meta">
+              <span className="issue-meta-author">opened by <strong>{issue.author.login}</strong></span>
+              <span className="issue-meta-date">on {formatDate(issue.createdAt)}</span>
+              {issue.assignees.length > 0 && (
+                <span className="issue-meta-assignees">· assigned to {issue.assignees.map(a => a.login).join(', ')}</span>
+              )}
+            </div>
+            {issue.labels.length > 0 && (
+              <div className="issue-detail-labels">
+                {issue.labels.map((l) => (
+                  <span
+                    key={l.name}
+                    className="inline-label"
+                    style={{ background: `#${l.color}22`, borderColor: `#${l.color}88`, color: `#${l.color}` }}
+                  >
+                    {l.name}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+          {issue.body && (
+            <div className="issue-detail-body">
+              <pre className="issue-body-text">{issue.body}</pre>
+            </div>
+          )}
+          {issue.comments.length > 0 && (
+            <div className="issue-detail-comments">
+              <div className="issue-comments-title">{issue.comments.length} comment{issue.comments.length !== 1 ? 's' : ''}</div>
+              {issue.comments.map((comment, i) => (
+                <div key={i} className="issue-comment">
+                  <div className="issue-comment-meta">
+                    <strong>{comment.author.login}</strong> · {formatDate(comment.createdAt)}
+                  </div>
+                  <pre className="issue-body-text">{comment.body}</pre>
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="modal-actions">
+            <a href={issue.url} target="_blank" rel="noopener noreferrer" className="btn btn-ghost">
+              View on GitHub ↗
+            </a>
+            <button type="button" className="btn btn-primary" onClick={onClose}>Close</button>
+          </div>
+        </div>
+      )}
+    </div>
   )
 }

--- a/gh-ctrl/client/src/components/RepoCard.tsx
+++ b/gh-ctrl/client/src/components/RepoCard.tsx
@@ -43,6 +43,14 @@ export function RepoCard({ entry, onToast }: Props) {
     setModalState({ mode: 'create-pr', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, head })
   }
 
+  const openCreateIssue = () => {
+    setModalState({ mode: 'create-issue', fullName: repo.fullName, owner: repo.owner, repoName: repo.name })
+  }
+
+  const openIssueDetail = (number: number) => {
+    setModalState({ mode: 'issue-detail', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, number })
+  }
+
   const toggleBranches = async () => {
     if (!showBranches && branches.length === 0) {
       setBranchesLoading(true)
@@ -83,6 +91,9 @@ export function RepoCard({ entry, onToast }: Props) {
               <div className="card-repo-name">{repo.name}</div>
               <div className="card-repo-full">{repo.fullName}</div>
             </div>
+            <button className="btn btn-ghost btn-sm" onClick={openCreateIssue} title="Create new issue">
+              + Issue
+            </button>
           </div>
 
           {data.error && (
@@ -156,6 +167,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   onClaude={() => handleTriggerClaude(issue.number, 'issue')}
                   onComment={() => openComment(issue.number, 'issue')}
                   onLabel={() => openLabel(issue.number, 'issue', issue.labels.map((l) => l.name))}
+                  onDetail={() => openIssueDetail(issue.number)}
                 />
               ))}
             </div>
@@ -197,6 +209,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   onClaude={() => handleTriggerClaude(issue.number, 'issue')}
                   onComment={() => openComment(issue.number, 'issue')}
                   onLabel={() => openLabel(issue.number, 'issue', issue.labels.map((l) => l.name))}
+                  onDetail={() => openIssueDetail(issue.number)}
                 />
               ))}
             </div>
@@ -242,7 +255,7 @@ export function RepoCard({ entry, onToast }: Props) {
 }
 
 function ItemRow({
-  number, title, labels, badge, onClaude, onComment, onLabel,
+  number, title, labels, badge, onClaude, onComment, onLabel, onDetail,
 }: {
   number: number
   title: string
@@ -251,12 +264,19 @@ function ItemRow({
   onClaude: () => void
   onComment: () => void
   onLabel: () => void
+  onDetail?: () => void
 }) {
   return (
     <div className="list-item">
       <div className="list-item-left">
         <span className="list-item-number">#{number}</span>
-        <span className="list-item-title">{title}</span>
+        {onDetail ? (
+          <button className="list-item-title list-item-title-btn" onClick={onDetail} title="View details">
+            {title}
+          </button>
+        ) : (
+          <span className="list-item-title">{title}</span>
+        )}
         {labels.map((l) => (
           <span key={l} className="inline-label">{l}</span>
         ))}

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -852,3 +852,105 @@ select.input {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--text-3);
 }
+
+/* Clickable issue title button */
+.list-item-title-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: text-decoration-color 0.15s;
+}
+
+.list-item-title-btn:hover {
+  text-decoration-color: var(--text-3);
+}
+
+/* Issue detail modal */
+.issue-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.issue-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.issue-detail-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.issue-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+.issue-detail-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.issue-detail-body {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  background: var(--bg-2);
+}
+
+.issue-body-text {
+  margin: 0;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+}
+
+.issue-detail-comments {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.issue-comments-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.issue-comment {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  background: var(--bg-2);
+}
+
+.issue-comment-meta {
+  font-size: 12px;
+  color: var(--text-3);
+  margin-bottom: 6px;
+}

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -67,3 +67,16 @@ export interface DashboardEntry {
   repo: Repo
   data: RepoData
 }
+
+export interface IssueDetail {
+  number: number
+  title: string
+  body: string
+  state: string
+  labels: { name: string; color: string }[]
+  assignees: { login: string }[]
+  author: { login: string }
+  url: string
+  createdAt: string
+  comments: { author: { login: string }; body: string; createdAt: string }[]
+}

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -242,6 +242,47 @@ app.post('/label-trigger', async (c) => {
   return c.json({ ok: true })
 })
 
+// GET /api/github/issue/:owner/:name/:number — fetch issue details
+app.get('/issue/:owner/:name/:number', async (c) => {
+  const owner = c.req.param('owner')
+  const name = c.req.param('name')
+  const number = c.req.param('number')
+  const fullName = `${owner}/${name}`
+
+  const result = gh([
+    'issue', 'view', number, '--repo', fullName,
+    '--json', 'number,title,body,state,labels,assignees,author,url,createdAt,comments',
+  ])
+
+  if (result.error) return c.json({ error: result.error }, 500)
+  return c.json(result.data)
+})
+
+// POST /api/github/create-issue — create a new issue
+app.post('/create-issue', async (c) => {
+  const body = await c.req.json()
+  const { fullName, title, issueBody, labels } = body
+
+  if (!fullName || !title) {
+    return c.json({ error: 'Missing required fields: fullName, title' }, 400)
+  }
+
+  const args = ['issue', 'create', '--repo', fullName, '--title', title]
+  if (issueBody) args.push('--body', issueBody)
+  if (labels && labels.length > 0) {
+    args.push('--label', labels.join(','))
+  }
+
+  const proc = Bun.spawnSync(['gh', ...args], { env: { ...process.env } })
+
+  if (proc.exitCode !== 0) {
+    return c.json({ error: proc.stderr.toString() }, 500)
+  }
+
+  const url = proc.stdout.toString().trim()
+  return c.json({ ok: true, url })
+})
+
 // POST /api/github/create-pr — create a PR from a branch
 app.post('/create-pr', async (c) => {
   const body = await c.req.json()


### PR DESCRIPTION
- Add "New Issue" button to each repo card header that opens a create issue modal with title, body, and label selection
- Make issue titles clickable to open an issue detail modal showing body, labels, assignees, and comments
- Add GET /api/github/issue/:owner/:name/:number endpoint to fetch full issue details
- Add POST /api/github/create-issue endpoint to create issues via gh CLI
- Add IssueDetail type and new api methods (getIssue, createIssue)
- Add CSS for clickable title button and issue detail modal layout

Closes #6