### PR TITLE
feat: add customizable Claude message modal per interaction

### DIFF
--- a/gh-ctrl/client/src/components/ActionModal.tsx
+++ b/gh-ctrl/client/src/components/ActionModal.tsx
@@ -8,6 +8,7 @@ export type ModalState =
   | { mode: 'create-pr'; fullName: string; owner: string; repoName: string; head: string }
   | { mode: 'create-issue'; fullName: string; owner: string; repoName: string }
   | { mode: 'issue-detail'; fullName: string; owner: string; repoName: string; number: number }
+  | { mode: 'trigger-claude'; fullName: string; number: number; type: 'pr' | 'issue' }
   | null
 
 interface Props {
@@ -38,6 +39,9 @@ export function ActionModal({ state, onClose, onSuccess, onError }: Props) {
         )}
         {state.mode === 'issue-detail' && (
           <IssueDetailView state={state} onClose={onClose} onError={onError} />
+        )}
+        {state.mode === 'trigger-claude' && (
+          <TriggerClaudeForm state={state} onClose={onClose} onSuccess={onSuccess} onError={onError} />
         )}
       </div>
     </div>
@@ -388,6 +392,63 @@ function CreateIssueForm({ state, onClose, onSuccess, onError }: {
         <button type="button" className="btn btn-ghost" onClick={onClose}>Cancel</button>
         <button type="submit" className="btn btn-primary" disabled={submitting || !title.trim()}>
           {submitting ? 'Creating...' : 'Create Issue'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+function TriggerClaudeForm({ state, onClose, onSuccess, onError }: {
+  state: Extract<ModalState, { mode: 'trigger-claude' }>
+  onClose: () => void
+  onSuccess: (msg: string) => void
+  onError: (msg: string) => void
+}) {
+  const [message, setMessage] = useState('@claude ')
+  const [submitting, setSubmitting] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    const el = textareaRef.current
+    if (el) {
+      el.focus()
+      el.setSelectionRange(el.value.length, el.value.length)
+    }
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!message.trim()) return
+    setSubmitting(true)
+    try {
+      await api.triggerClaude({ fullName: state.fullName, number: state.number, type: state.type, message: message.trim() })
+      onSuccess(`@claude triggered on ${state.type} #${state.number}`)
+      onClose()
+    } catch (err: any) {
+      onError(`Failed: ${err.message}`)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="modal-title">
+        Trigger Claude on {state.type} #{state.number}
+        <span className="modal-subtitle">{state.fullName}</span>
+      </div>
+      <textarea
+        ref={textareaRef}
+        className="input modal-textarea"
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        placeholder="@claude ..."
+        rows={5}
+      />
+      <div className="modal-actions">
+        <button type="button" className="btn btn-ghost" onClick={onClose}>Cancel</button>
+        <button type="submit" className="btn btn-claude" disabled={submitting || !message.trim()}>
+          {submitting ? 'Triggering...' : 'Trigger @claude'}
         </button>
       </div>
     </form>

--- a/gh-ctrl/client/src/components/RepoCard.tsx
+++ b/gh-ctrl/client/src/components/RepoCard.tsx
@@ -22,13 +22,8 @@ export function RepoCard({ entry, onToast }: Props) {
 
   const hasConflicts = stats.conflicts > 0
 
-  const handleTriggerClaude = async (number: number, type: 'pr' | 'issue') => {
-    try {
-      await api.triggerClaude({ fullName: repo.fullName, number, type })
-      onToast(`@claude triggered on #${number}`, 'success')
-    } catch (err: any) {
-      onToast(`Failed: ${err.message}`, 'error')
-    }
+  const openTriggerClaude = (number: number, type: 'pr' | 'issue') => {
+    setModalState({ mode: 'trigger-claude', fullName: repo.fullName, number, type })
   }
 
   const openComment = (number: number, type: 'pr' | 'issue') => {
@@ -129,7 +124,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   title={pr.title}
                   labels={pr.labels.map((l) => l.name)}
                   badge={<span className="badge badge-conflict">Conflict</span>}
-                  onClaude={() => handleTriggerClaude(pr.number, 'pr')}
+                  onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
                 />
@@ -147,7 +142,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   title={pr.title}
                   labels={pr.labels.map((l) => l.name)}
                   badge={<span className="badge badge-review">Review</span>}
-                  onClaude={() => handleTriggerClaude(pr.number, 'pr')}
+                  onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
                 />
@@ -164,7 +159,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   number={issue.number}
                   title={issue.title}
                   labels={issue.labels.map((l) => l.name)}
-                  onClaude={() => handleTriggerClaude(issue.number, 'issue')}
+                  onClaude={() => openTriggerClaude(issue.number, 'issue')}
                   onComment={() => openComment(issue.number, 'issue')}
                   onLabel={() => openLabel(issue.number, 'issue', issue.labels.map((l) => l.name))}
                   onDetail={() => openIssueDetail(issue.number)}
@@ -186,7 +181,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   title={pr.title}
                   labels={pr.labels.map((l) => l.name)}
                   badge={pr.isDraft ? <span className="badge badge-draft">Draft</span> : pr.reviewDecision === 'APPROVED' ? <span className="badge badge-approved">Approved</span> : undefined}
-                  onClaude={() => handleTriggerClaude(pr.number, 'pr')}
+                  onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
                 />
@@ -206,7 +201,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   number={issue.number}
                   title={issue.title}
                   labels={issue.labels.map((l) => l.name)}
-                  onClaude={() => handleTriggerClaude(issue.number, 'issue')}
+                  onClaude={() => openTriggerClaude(issue.number, 'issue')}
                   onComment={() => openComment(issue.number, 'issue')}
                   onLabel={() => openLabel(issue.number, 'issue', issue.labels.map((l) => l.name))}
                   onDetail={() => openIssueDetail(issue.number)}


### PR DESCRIPTION
Replace the immediate @claude trigger with a modal that lets users type a custom message (pre-filled with "@claude ") before posting.

Closes #8

Generated with [Claude Code](https://claude.ai/code)