### PR TITLE
feat: add PR detail view so full PR content is readable

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail } from './types'
+import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail } from './types'
 
 const BASE = '/api'
 
@@ -107,6 +107,9 @@ export const api = {
 
   getIssue: (owner: string, name: string, number: number) =>
     request<IssueDetail>(`/github/issue/${owner}/${name}/${number}`),
+
+  getPR: (owner: string, name: string, number: number) =>
+    request<PRDetail>(`/github/pr/${owner}/${name}/${number}`),
 
   createIssue: (params: {
     fullName: string

--- a/gh-ctrl/client/src/components/ActionModal.tsx
+++ b/gh-ctrl/client/src/components/ActionModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import type { GHLabel, IssueDetail } from '../types'
+import type { GHLabel, IssueDetail, PRDetail } from '../types'
 import { api } from '../api'
 
 export type ModalState =
@@ -8,6 +8,7 @@ export type ModalState =
   | { mode: 'create-pr'; fullName: string; owner: string; repoName: string; head: string }
   | { mode: 'create-issue'; fullName: string; owner: string; repoName: string }
   | { mode: 'issue-detail'; fullName: string; owner: string; repoName: string; number: number }
+  | { mode: 'pr-detail'; fullName: string; owner: string; repoName: string; number: number }
   | { mode: 'trigger-claude'; fullName: string; number: number; type: 'pr' | 'issue' }
   | null
 
@@ -39,6 +40,9 @@ export function ActionModal({ state, onClose, onSuccess, onError }: Props) {
         )}
         {state.mode === 'issue-detail' && (
           <IssueDetailView state={state} onClose={onClose} onError={onError} />
+        )}
+        {state.mode === 'pr-detail' && (
+          <PRDetailView state={state} onClose={onClose} onError={onError} />
         )}
         {state.mode === 'trigger-claude' && (
           <TriggerClaudeForm state={state} onClose={onClose} onSuccess={onSuccess} onError={onError} />
@@ -452,6 +456,95 @@ function TriggerClaudeForm({ state, onClose, onSuccess, onError }: {
         </button>
       </div>
     </form>
+  )
+}
+
+function PRDetailView({ state, onClose, onError }: {
+  state: Extract<ModalState, { mode: 'pr-detail' }>
+  onClose: () => void
+  onError: (msg: string) => void
+}) {
+  const [pr, setPR] = useState<PRDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.getPR(state.owner, state.repoName, state.number)
+      .then(setPR)
+      .catch((err) => onError(`Failed to load PR: ${err.message}`))
+      .finally(() => setLoading(false))
+  }, [state.owner, state.repoName, state.number])
+
+  const formatDate = (dateStr: string) => {
+    try {
+      return new Date(dateStr).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+    } catch {
+      return dateStr
+    }
+  }
+
+  return (
+    <div>
+      <div className="modal-title">
+        PR #{state.number}
+        <span className="modal-subtitle">{state.fullName}</span>
+      </div>
+      {loading ? (
+        <div className="modal-loading">Loading PR...</div>
+      ) : !pr ? (
+        <div className="modal-loading">Failed to load PR.</div>
+      ) : (
+        <div className="issue-detail">
+          <div className="issue-detail-header">
+            <h3 className="issue-detail-title">{pr.title}</h3>
+            <div className="issue-detail-meta">
+              <span className="issue-meta-author">opened by <strong>{pr.author.login}</strong></span>
+              <span className="issue-meta-date">on {formatDate(pr.createdAt)}</span>
+              <span>{pr.headRefName} → {pr.baseRefName}</span>
+              {pr.isDraft && <span>· Draft</span>}
+              {pr.reviewDecision === 'APPROVED' && <span>· Approved</span>}
+              {pr.mergeable === 'CONFLICTING' && <span>· Conflict</span>}
+            </div>
+            {pr.labels.length > 0 && (
+              <div className="issue-detail-labels">
+                {pr.labels.map((l) => (
+                  <span
+                    key={l.name}
+                    className="inline-label"
+                    style={{ background: `#${l.color}22`, borderColor: `#${l.color}88`, color: `#${l.color}` }}
+                  >
+                    {l.name}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+          {pr.body && (
+            <div className="issue-detail-body">
+              <pre className="issue-body-text">{pr.body}</pre>
+            </div>
+          )}
+          {pr.comments.length > 0 && (
+            <div className="issue-detail-comments">
+              <div className="issue-comments-title">{pr.comments.length} comment{pr.comments.length !== 1 ? 's' : ''}</div>
+              {pr.comments.map((comment, i) => (
+                <div key={i} className="issue-comment">
+                  <div className="issue-comment-meta">
+                    <strong>{comment.author.login}</strong> · {formatDate(comment.createdAt)}
+                  </div>
+                  <pre className="issue-body-text">{comment.body}</pre>
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="modal-actions">
+            <a href={pr.url} target="_blank" rel="noopener noreferrer" className="btn btn-ghost">
+              View on GitHub ↗
+            </a>
+            <button type="button" className="btn btn-primary" onClick={onClose}>Close</button>
+          </div>
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/gh-ctrl/client/src/components/RepoCard.tsx
+++ b/gh-ctrl/client/src/components/RepoCard.tsx
@@ -46,6 +46,10 @@ export function RepoCard({ entry, onToast }: Props) {
     setModalState({ mode: 'issue-detail', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, number })
   }
 
+  const openPRDetail = (number: number) => {
+    setModalState({ mode: 'pr-detail', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, number })
+  }
+
   const toggleBranches = async () => {
     if (!showBranches && branches.length === 0) {
       setBranchesLoading(true)
@@ -127,6 +131,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
+                  onDetail={() => openPRDetail(pr.number)}
                 />
               ))}
             </div>
@@ -145,6 +150,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
+                  onDetail={() => openPRDetail(pr.number)}
                 />
               ))}
             </div>
@@ -184,6 +190,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
+                  onDetail={() => openPRDetail(pr.number)}
                 />
               ))}
             </div>

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -68,6 +68,24 @@ export interface DashboardEntry {
   data: RepoData
 }
 
+export interface PRDetail {
+  number: number
+  title: string
+  body: string
+  state: string
+  labels: { name: string; color: string }[]
+  assignees: { login: string }[]
+  author: { login: string }
+  url: string
+  createdAt: string
+  reviewDecision: 'APPROVED' | 'REVIEW_REQUIRED' | 'CHANGES_REQUESTED' | null
+  mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+  headRefName: string
+  baseRefName: string
+  isDraft: boolean
+  comments: { author: { login: string }; body: string; createdAt: string }[]
+}
+
 export interface IssueDetail {
   number: number
   title: string

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -283,6 +283,22 @@ app.post('/create-issue', async (c) => {
   return c.json({ ok: true, url })
 })
 
+// GET /api/github/pr/:owner/:name/:number — fetch PR details
+app.get('/pr/:owner/:name/:number', async (c) => {
+  const owner = c.req.param('owner')
+  const name = c.req.param('name')
+  const number = c.req.param('number')
+  const fullName = `${owner}/${name}`
+
+  const result = gh([
+    'pr', 'view', number, '--repo', fullName,
+    '--json', 'number,title,body,state,labels,assignees,author,url,createdAt,comments,reviewDecision,mergeable,headRefName,baseRefName,isDraft',
+  ])
+
+  if (result.error) return c.json({ error: result.error }, 500)
+  return c.json(result.data)
+})
+
 // POST /api/github/create-pr — create a PR from a branch
 app.post('/create-pr', async (c) => {
   const body = await c.req.json()


### PR DESCRIPTION
Add a clickable title to PR list items that opens a detail modal showing the full PR title, description, branch info, labels, and comments — mirroring the existing issue detail view.

- Backend: new GET /api/github/pr/:owner/:name/:number endpoint
- Types: new PRDetail interface
- API: new api.getPR() method
- ActionModal: new pr-detail mode + PRDetailView component
- RepoCard: openPRDetail handler wired to onDetail on all PR ItemRows

Closes #10