### PR TITLE
feat: show GitHub label colors in PR/issue list

### DIFF
--- a/gh-ctrl/client/src/components/RepoCard.tsx
+++ b/gh-ctrl/client/src/components/RepoCard.tsx
@@ -122,7 +122,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   key={pr.number}
                   number={pr.number}
                   title={pr.title}
-                  labels={pr.labels.map((l) => l.name)}
+                  labels={pr.labels}
                   badge={<span className="badge badge-conflict">Conflict</span>}
                   onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
@@ -140,7 +140,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   key={pr.number}
                   number={pr.number}
                   title={pr.title}
-                  labels={pr.labels.map((l) => l.name)}
+                  labels={pr.labels}
                   badge={<span className="badge badge-review">Review</span>}
                   onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
@@ -158,7 +158,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   key={issue.number}
                   number={issue.number}
                   title={issue.title}
-                  labels={issue.labels.map((l) => l.name)}
+                  labels={issue.labels}
                   onClaude={() => openTriggerClaude(issue.number, 'issue')}
                   onComment={() => openComment(issue.number, 'issue')}
                   onLabel={() => openLabel(issue.number, 'issue', issue.labels.map((l) => l.name))}
@@ -179,7 +179,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   key={pr.number}
                   number={pr.number}
                   title={pr.title}
-                  labels={pr.labels.map((l) => l.name)}
+                  labels={pr.labels}
                   badge={pr.isDraft ? <span className="badge badge-draft">Draft</span> : pr.reviewDecision === 'APPROVED' ? <span className="badge badge-approved">Approved</span> : undefined}
                   onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
@@ -200,7 +200,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   key={issue.number}
                   number={issue.number}
                   title={issue.title}
-                  labels={issue.labels.map((l) => l.name)}
+                  labels={issue.labels}
                   onClaude={() => openTriggerClaude(issue.number, 'issue')}
                   onComment={() => openComment(issue.number, 'issue')}
                   onLabel={() => openLabel(issue.number, 'issue', issue.labels.map((l) => l.name))}
@@ -249,12 +249,22 @@ export function RepoCard({ entry, onToast }: Props) {
   )
 }
 
+function labelTextColor(hex: string): string {
+  const h = hex.replace('#', '')
+  const r = parseInt(h.substring(0, 2), 16)
+  const g = parseInt(h.substring(2, 4), 16)
+  const b = parseInt(h.substring(4, 6), 16)
+  // WCAG relative luminance
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+  return luminance > 0.5 ? '#000000' : '#ffffff'
+}
+
 function ItemRow({
   number, title, labels, badge, onClaude, onComment, onLabel, onDetail,
 }: {
   number: number
   title: string
-  labels: string[]
+  labels: { name: string; color: string }[]
   badge?: React.ReactNode
   onClaude: () => void
   onComment: () => void
@@ -272,9 +282,19 @@ function ItemRow({
         ) : (
           <span className="list-item-title">{title}</span>
         )}
-        {labels.map((l) => (
-          <span key={l} className="inline-label">{l}</span>
-        ))}
+        {labels.map((l) => {
+          const bg = l.color ? `#${l.color.replace('#', '')}` : undefined
+          const fg = bg ? labelTextColor(bg) : undefined
+          return (
+            <span
+              key={l.name}
+              className="inline-label"
+              style={bg ? { background: bg, color: fg, borderColor: bg } : undefined}
+            >
+              {l.name}
+            </span>
+          )
+        })}
       </div>
       <div className="list-item-right">
         {badge}

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -17,7 +17,7 @@ export interface GHPR {
   headRefName: string
   author: { login: string }
   updatedAt: string
-  labels: { name: string }[]
+  labels: { name: string; color: string }[]
   isDraft: boolean
 }
 
@@ -25,7 +25,7 @@ export interface GHIssue {
   number: number
   title: string
   state: string
-  labels: { name: string }[]
+  labels: { name: string; color: string }[]
   assignees: { login: string }[]
   updatedAt: string
   author: { login: string }


### PR DESCRIPTION
Labels in the PR and issue list now render with their actual GitHub background colors, with auto-computed foreground (black/white) for contrast. Types updated to include the `color` field that the gh CLI already returns.