### PR TITLE
feat: add view on github to repo title in dashboard

### DIFF
--- a/gh-ctrl/client/src/components/RepoCard.tsx
+++ b/gh-ctrl/client/src/components/RepoCard.tsx
@@ -83,7 +83,18 @@ export function RepoCard({ entry, onToast }: Props) {
         <div className="card-body">
           <div className="card-header">
             <div>
-              <div className="card-repo-name">{repo.name}</div>
+              <div className="card-repo-name">
+                {repo.name}
+                <a
+                  href={`https://github.com/${repo.fullName}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="repo-github-link"
+                  title="View on GitHub"
+                >
+                  ↗
+                </a>
+              </div>
               <div className="card-repo-full">{repo.fullName}</div>
             </div>
             <button className="btn btn-ghost btn-sm" onClick={openCreateIssue} title="Create new issue">

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -219,6 +219,23 @@ a:hover { text-decoration: underline; }
   font-family: var(--font-display);
   font-weight: 600;
   font-size: 16px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.repo-github-link {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-3);
+  text-decoration: none;
+  transition: color 0.15s;
+  line-height: 1;
+}
+
+.repo-github-link:hover {
+  color: var(--blue);
+  text-decoration: none;
 }
 
 .card-repo-full {


### PR DESCRIPTION
Adds a "View on GitHub" link next to the repo name in each dashboard card, opening in a new tab.

Closes #14

Generated with [Claude Code](https://claude.ai/code)