### PR TITLE
feat: rename application title to Agent Provocateur 🍆

### DIFF
--- a/gh-ctrl/client/index.html
+++ b/gh-ctrl/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GH-CTRL — GitHub Command Center</title>
+    <title>Agent Provocateur 🍆</title>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&family=Syne:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>

--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -68,7 +68,7 @@ export default function App() {
   return (
     <div className="app-layout">
       <aside className="sidebar">
-        <div className="sidebar-logo">GH-CTRL</div>
+        <div className="sidebar-logo">Agent Provocateur 🍆</div>
 
         <nav className="sidebar-nav">
           <button


### PR DESCRIPTION
Renames the application title from "GH-CTRL" to "Agent Provocateur 🍆" in both the browser tab title and the sidebar logo.

Closes #13

Generated with [Claude Code](https://claude.ai/code)