### PR TITLE
feat: rename Agent Provocateur to BattleGit

### DIFF
--- a/gh-ctrl/client/index.html
+++ b/gh-ctrl/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Agent Provocateur 🍆</title>
+    <title>BattleGit</title>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&family=Syne:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>

--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -80,7 +80,7 @@ export default function App() {
   return (
     <div className="app-layout">
       <aside className="sidebar">
-        <div className="sidebar-logo">Agent Provocateur 🍆</div>
+        <div className="sidebar-logo">BattleGit</div>
 
         <nav className="sidebar-nav">
           <button

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -132,7 +132,7 @@ export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props)
 
       {/* HUD */}
       <div className="battlefield-hud">
-        <div className="hud-brand">&#x25a0; AGENT PROVOCATEUR — TACTICAL COMMAND</div>
+        <div className="hud-brand">&#x25a0; C&amp;C GITAGENTS — TACTICAL COMMAND</div>
         <div className="hud-controls">
           <span className="hud-stat">BASES: <strong>{entries.length}</strong></span>
           {totalConflicts > 0 && (


### PR DESCRIPTION
Renames "Agent Provocateur" to "BattleGit" / "C&C GitAgents" across the UI.

Closes #28

Generated with [Claude Code](https://claude.ai/code)