### PR TITLE
feat: add zoom to battlefield

### DIFF
--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -19,6 +19,9 @@ const BASE_SPACING_X = 260
 const BASE_SPACING_Y = 220
 const COLS = 4
 const MAP_PADDING = 100
+const ZOOM_MIN = 0.25
+const ZOOM_MAX = 2.5
+const ZOOM_STEP = 0.15
 
 function getDefaultPositions(entries: DashboardEntry[]): Record<number, Position> {
   const positions: Record<number, Position> = {}
@@ -48,6 +51,7 @@ function savePositions(positions: Record<number, Position>) {
 
 export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props) {
   const [offset, setOffset] = useState<Position>({ x: 0, y: 0 })
+  const [zoom, setZoom] = useState(1)
   const [isDraggingMap, setIsDraggingMap] = useState(false)
   const [dragStart, setDragStart] = useState<Position>({ x: 0, y: 0 })
   const [positions, setPositions] = useState<Record<number, Position>>(() => {
@@ -60,6 +64,10 @@ export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props)
   const [constructTarget, setConstructTarget] = useState<DashboardEntry | null>(null)
   const [isRelocateMode, setIsRelocateMode] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
+  const zoomRef = useRef(zoom)
+  const offsetRef = useRef(offset)
+  useEffect(() => { zoomRef.current = zoom }, [zoom])
+  useEffect(() => { offsetRef.current = offset }, [offset])
 
   // Update positions when entries change (new repos)
   useEffect(() => {
@@ -83,8 +91,8 @@ export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props)
     if (isDraggingMap) {
       setOffset({ x: e.clientX - dragStart.x, y: e.clientY - dragStart.y })
     } else if (relocatingId !== null && relocatingStart !== null) {
-      const dx = e.clientX - relocatingStart.mouseX
-      const dy = e.clientY - relocatingStart.mouseY
+      const dx = (e.clientX - relocatingStart.mouseX) / zoomRef.current
+      const dy = (e.clientY - relocatingStart.mouseY) / zoomRef.current
       setPositions(prev => ({
         ...prev,
         [relocatingId]: {
@@ -94,6 +102,53 @@ export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props)
       }))
     }
   }, [isDraggingMap, dragStart, relocatingId, relocatingStart])
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault()
+    const delta = -Math.sign(e.deltaY) * ZOOM_STEP
+    setZoom(prevZoom => {
+      const newZoom = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, prevZoom + delta))
+      // Zoom toward cursor position
+      const cursorX = e.clientX
+      const cursorY = e.clientY
+      setOffset(prevOffset => ({
+        x: cursorX - (cursorX - prevOffset.x) * (newZoom / prevZoom),
+        y: cursorY - (cursorY - prevOffset.y) * (newZoom / prevZoom),
+      }))
+      return newZoom
+    })
+  }, [])
+
+  const handleZoomIn = useCallback(() => {
+    setZoom(prev => {
+      const newZoom = Math.min(ZOOM_MAX, prev + ZOOM_STEP)
+      const cx = window.innerWidth / 2
+      const cy = window.innerHeight / 2
+      setOffset(prevOffset => ({
+        x: cx - (cx - prevOffset.x) * (newZoom / prev),
+        y: cy - (cy - prevOffset.y) * (newZoom / prev),
+      }))
+      return newZoom
+    })
+  }, [])
+
+  const handleZoomOut = useCallback(() => {
+    setZoom(prev => {
+      const newZoom = Math.max(ZOOM_MIN, prev - ZOOM_STEP)
+      const cx = window.innerWidth / 2
+      const cy = window.innerHeight / 2
+      setOffset(prevOffset => ({
+        x: cx - (cx - prevOffset.x) * (newZoom / prev),
+        y: cy - (cy - prevOffset.y) * (newZoom / prev),
+      }))
+      return newZoom
+    })
+  }, [])
+
+  const handleZoomReset = useCallback(() => {
+    setZoom(1)
+    setOffset({ x: 0, y: 0 })
+  }, [])
 
   const handleMapMouseUp = useCallback(() => {
     setIsDraggingMap(false)
@@ -123,6 +178,7 @@ export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props)
       onMouseMove={handleMapMouseMove}
       onMouseUp={handleMapMouseUp}
       onMouseLeave={handleMapMouseUp}
+      onWheel={handleWheel}
       ref={containerRef}
       style={{ cursor: isDraggingMap ? 'grabbing' : (isRelocateMode ? 'crosshair' : 'grab') }}
     >
@@ -151,13 +207,17 @@ export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props)
           >
             {isRelocateMode ? '✕ CANCEL RELOCATE' : '&#x2295; RELOCATE BASE'}
           </button>
+          <span className="hud-zoom-sep" />
+          <button className="hud-btn hud-zoom-btn" onClick={handleZoomOut} disabled={zoom <= ZOOM_MIN} title="Zoom out">−</button>
+          <span className="hud-zoom-level" title="Click to reset zoom" onClick={handleZoomReset}>{Math.round(zoom * 100)}%</span>
+          <button className="hud-btn hud-zoom-btn" onClick={handleZoomIn} disabled={zoom >= ZOOM_MAX} title="Zoom in">+</button>
         </div>
       </div>
 
       {/* Scrollable map layer */}
       <div
         className="battlefield-map"
-        style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}
+        style={{ transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})`, transformOrigin: '0 0' }}
       >
         {entries.map((entry) => {
           const pos = positions[entry.repo.id] ?? { x: 0, y: 0 }
@@ -178,7 +238,7 @@ export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props)
 
       {/* Minimap */}
       {entries.length > 0 && (
-        <Minimap entries={entries} positions={positions} offset={offset} onJump={setOffset} />
+        <Minimap entries={entries} positions={positions} offset={offset} zoom={zoom} onJump={setOffset} />
       )}
 
       {/* Empty state */}
@@ -220,10 +280,11 @@ interface MinimapProps {
   entries: DashboardEntry[]
   positions: Record<number, Position>
   offset: Position
+  zoom: number
   onJump: (pos: Position) => void
 }
 
-function Minimap({ entries, positions, offset, onJump }: MinimapProps) {
+function Minimap({ entries, positions, offset, zoom, onJump }: MinimapProps) {
   const MINIMAP_W = 160
   const MINIMAP_H = 100
   const SCALE = 0.12
@@ -233,7 +294,7 @@ function Minimap({ entries, positions, offset, onJump }: MinimapProps) {
     const rect = e.currentTarget.getBoundingClientRect()
     const mx = (e.clientX - rect.left) / SCALE
     const my = (e.clientY - rect.top) / SCALE
-    onJump({ x: -mx + window.innerWidth / 2, y: -my + window.innerHeight / 2 })
+    onJump({ x: -mx * zoom + window.innerWidth / 2, y: -my * zoom + window.innerHeight / 2 })
   }
 
   return (
@@ -267,10 +328,10 @@ function Minimap({ entries, positions, offset, onJump }: MinimapProps) {
       <div
         className="minimap-viewport"
         style={{
-          left: -offset.x * SCALE,
-          top: -offset.y * SCALE + 12,
-          width: window.innerWidth * SCALE,
-          height: window.innerHeight * SCALE,
+          left: -offset.x / zoom * SCALE,
+          top: -offset.y / zoom * SCALE + 12,
+          width: window.innerWidth / zoom * SCALE,
+          height: window.innerHeight / zoom * SCALE,
         }}
       />
     </div>

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1163,6 +1163,33 @@ select.input {
   color: var(--crt-red);
 }
 
+.hud-zoom-sep {
+  width: 1px;
+  height: 14px;
+  background: rgba(57, 211, 83, 0.25);
+  margin: 0 4px;
+}
+
+.hud-zoom-btn {
+  padding: 2px 7px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.hud-zoom-level {
+  font-size: 10px;
+  color: var(--text-2);
+  min-width: 34px;
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  letter-spacing: 0.5px;
+}
+
+.hud-zoom-level:hover {
+  color: var(--crt-green);
+}
+
 /* Relocate mode banner */
 .battlefield-relocate-banner {
   position: absolute;


### PR DESCRIPTION
Adds zoom functionality to the battlefield view.

- Mouse wheel zooms in/out centered on cursor
- HUD −/+ buttons for zoom control
- Click zoom level display to reset to 100%
- Zoom range: 25%–250%, step 15%
- Node relocate drag correctly accounts for zoom
- Minimap viewport reflects zoom level

Closes #30

Generated with [Claude Code](https://claude.ai/code)