### PR TITLE
feat: battlefield - add dashboard Claude functions to base detail panel

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import type { DashboardEntry } from '../types'
+import type { DashboardEntry, GHPR, GHIssue } from '../types'
 import { ActionModal } from './ActionModal'
 import type { ModalState } from './ActionModal'
 
@@ -138,8 +138,17 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
   onModalOpen: (state: ModalState) => void
 }) {
   const { repo, data } = entry
+  const [showAllPRs, setShowAllPRs] = useState(false)
+  const [showAllIssues, setShowAllIssues] = useState(false)
   const panelX = position.x + 145
   const panelY = position.y
+
+  const activeClaudeSet = new Set(data.activeClaudeIssues ?? [])
+  const conflictSet = new Set(data.conflicts.map((p) => p.number))
+  const reviewSet = new Set(data.needsReview.map((p) => p.number))
+  const claudeSet = new Set(data.claudeIssues.map((i) => i.number))
+  const remainingPRs = data.prs.filter((p) => !conflictSet.has(p.number) && !reviewSet.has(p.number))
+  const remainingIssues = data.issues.filter((i) => !claudeSet.has(i.number))
 
   return (
     <div
@@ -157,6 +166,13 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
         >
           {repo.fullName} &#x2197;
         </a>
+        <button
+          className="bdp-action-btn"
+          onClick={() => onModalOpen({ mode: 'create-issue', fullName: repo.fullName, owner: repo.owner, repoName: repo.name })}
+          title="Create new issue"
+        >
+          + Issue
+        </button>
         <button className="bdp-close" onClick={onClose}>✕</button>
       </div>
 
@@ -170,17 +186,17 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
       {data.conflicts.length > 0 && (
         <div className="bdp-section">
           <div className="bdp-section-title conflict">&#x26a0; CONFLICTS</div>
-          {data.conflicts.slice(0, 4).map(pr => (
-            <div key={pr.number} className="bdp-item">
-              <span className="bdp-num">#{pr.number}</span>
-              <span className="bdp-text">{pr.title}</span>
-              <button
-                className="bdp-claude-btn"
-                onClick={() => onModalOpen({ mode: 'trigger-claude', fullName: repo.fullName, number: pr.number, type: 'pr' })}
-              >
-                @claude
-              </button>
-            </div>
+          {data.conflicts.slice(0, 4).map((pr: GHPR) => (
+            <BdpItemRow
+              key={pr.number}
+              number={pr.number}
+              title={pr.title}
+              previewUrl={pr.previewUrl}
+              type="pr"
+              repo={repo}
+              onModalOpen={onModalOpen}
+              labels={pr.labels}
+            />
           ))}
         </div>
       )}
@@ -188,17 +204,17 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
       {data.needsReview.length > 0 && (
         <div className="bdp-section">
           <div className="bdp-section-title review">&#x25cf; NEEDS REVIEW</div>
-          {data.needsReview.slice(0, 4).map(pr => (
-            <div key={pr.number} className="bdp-item">
-              <span className="bdp-num">#{pr.number}</span>
-              <span className="bdp-text">{pr.title}</span>
-              <button
-                className="bdp-claude-btn"
-                onClick={() => onModalOpen({ mode: 'trigger-claude', fullName: repo.fullName, number: pr.number, type: 'pr' })}
-              >
-                @claude
-              </button>
-            </div>
+          {data.needsReview.slice(0, 4).map((pr: GHPR) => (
+            <BdpItemRow
+              key={pr.number}
+              number={pr.number}
+              title={pr.title}
+              previewUrl={pr.previewUrl}
+              type="pr"
+              repo={repo}
+              onModalOpen={onModalOpen}
+              labels={pr.labels}
+            />
           ))}
         </div>
       )}
@@ -206,29 +222,57 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
       {data.claudeIssues.length > 0 && (
         <div className="bdp-section">
           <div className="bdp-section-title claude">&#x2605; CLAUDE ISSUES</div>
-          {data.claudeIssues.slice(0, 4).map(issue => (
-            <div key={issue.number} className="bdp-item">
-              <span className="bdp-num">#{issue.number}</span>
-              <span className="bdp-text">{issue.title}</span>
-              <button
-                className="bdp-claude-btn"
-                onClick={() => onModalOpen({ mode: 'trigger-claude', fullName: repo.fullName, number: issue.number, type: 'issue' })}
-              >
-                @claude
-              </button>
-            </div>
+          {data.claudeIssues.slice(0, 4).map((issue: GHIssue) => (
+            <BdpItemRow
+              key={issue.number}
+              number={issue.number}
+              title={issue.title}
+              type="issue"
+              repo={repo}
+              onModalOpen={onModalOpen}
+              labels={issue.labels}
+              isClaudeActive={activeClaudeSet.has(issue.number)}
+            />
           ))}
         </div>
       )}
 
-      {data.prs.length > 0 && data.conflicts.length === 0 && data.needsReview.length === 0 && (
+      {remainingPRs.length > 0 && (
         <div className="bdp-section">
-          <div className="bdp-section-title">OPEN PRS</div>
-          {data.prs.slice(0, 3).map(pr => (
-            <div key={pr.number} className="bdp-item">
-              <span className="bdp-num">#{pr.number}</span>
-              <span className="bdp-text">{pr.title}</span>
-            </div>
+          <button className="bdp-toggle" onClick={() => setShowAllPRs((v) => !v)}>
+            <span>{showAllPRs ? '▾' : '▸'}</span> All PRs ({remainingPRs.length})
+          </button>
+          {showAllPRs && remainingPRs.slice(0, 5).map((pr: GHPR) => (
+            <BdpItemRow
+              key={pr.number}
+              number={pr.number}
+              title={pr.title}
+              previewUrl={pr.previewUrl}
+              type="pr"
+              repo={repo}
+              onModalOpen={onModalOpen}
+              labels={pr.labels}
+            />
+          ))}
+        </div>
+      )}
+
+      {remainingIssues.length > 0 && (
+        <div className="bdp-section">
+          <button className="bdp-toggle" onClick={() => setShowAllIssues((v) => !v)}>
+            <span>{showAllIssues ? '▾' : '▸'}</span> All Issues ({remainingIssues.length})
+          </button>
+          {showAllIssues && remainingIssues.slice(0, 5).map((issue: GHIssue) => (
+            <BdpItemRow
+              key={issue.number}
+              number={issue.number}
+              title={issue.title}
+              type="issue"
+              repo={repo}
+              onModalOpen={onModalOpen}
+              labels={issue.labels}
+              isClaudeActive={activeClaudeSet.has(issue.number)}
+            />
           ))}
         </div>
       )}
@@ -236,6 +280,72 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
       {data.error && (
         <div className="bdp-error">&#x26A0; {data.error}</div>
       )}
+    </div>
+  )
+}
+
+function BdpItemRow({ number, title, type, repo, onModalOpen, previewUrl, labels, isClaudeActive }: {
+  number: number
+  title: string
+  type: 'pr' | 'issue'
+  repo: DashboardEntry['repo']
+  onModalOpen: (state: ModalState) => void
+  previewUrl?: string | null
+  labels: { name: string; color: string }[]
+  isClaudeActive?: boolean
+}) {
+  return (
+    <div className="bdp-item">
+      <div className="bdp-item-left">
+        <span className="bdp-num">#{number}</span>
+        {isClaudeActive && (
+          <span className="claude-active-indicator spinning" title="Claude is working on this">⟳</span>
+        )}
+        <button
+          className="bdp-text-btn"
+          onClick={() => onModalOpen(
+            type === 'issue'
+              ? { mode: 'issue-detail', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, number }
+              : { mode: 'pr-detail', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, number }
+          )}
+          title="View details"
+        >
+          {title}
+        </button>
+      </div>
+      <div className="bdp-item-right">
+        {previewUrl && (
+          <a
+            href={previewUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bdp-icon-btn"
+            title="Open preview"
+          >
+            &#x1F517;
+          </a>
+        )}
+        <button
+          className="bdp-icon-btn"
+          title="Manage labels"
+          onClick={() => onModalOpen({ mode: 'label', fullName: repo.fullName, number, type, currentLabels: labels.map((l) => l.name) })}
+        >
+          &#x1F3F7;
+        </button>
+        <button
+          className="bdp-icon-btn"
+          title="Post comment"
+          onClick={() => onModalOpen({ mode: 'comment', fullName: repo.fullName, number, type })}
+        >
+          &#x1F4AC;
+        </button>
+        <button
+          className="bdp-claude-btn"
+          onClick={() => onModalOpen({ mode: 'trigger-claude', fullName: repo.fullName, number, type })}
+        >
+          @claude
+        </button>
+      </div>
     </div>
   )
 }

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1544,9 +1544,25 @@ select.input {
 .bdp-item {
   display: flex;
   align-items: center;
-  gap: 6px;
+  justify-content: space-between;
+  gap: 4px;
   padding: 3px 0;
   font-size: 11px;
+}
+
+.bdp-item-left {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+
+.bdp-item-right {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
 }
 
 .bdp-num {
@@ -1562,6 +1578,81 @@ select.input {
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 11px;
+}
+
+.bdp-text-btn {
+  background: none;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 0;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1;
+}
+
+.bdp-text-btn:hover {
+  color: var(--crt-green);
+  text-decoration: underline;
+}
+
+.bdp-icon-btn {
+  background: none;
+  border: 1px solid rgba(57, 211, 83, 0.2);
+  color: var(--text-3);
+  font-size: 9px;
+  padding: 2px 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all 0.15s;
+  line-height: 1;
+}
+
+.bdp-icon-btn:hover {
+  color: var(--text);
+  border-color: rgba(57, 211, 83, 0.5);
+  background: rgba(57, 211, 83, 0.08);
+}
+
+.bdp-action-btn {
+  background: rgba(57, 211, 83, 0.08);
+  border: 1px solid rgba(57, 211, 83, 0.3);
+  color: var(--crt-green);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  padding: 2px 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all 0.15s;
+  letter-spacing: 0.5px;
+}
+
+.bdp-action-btn:hover {
+  background: rgba(57, 211, 83, 0.18);
+}
+
+.bdp-toggle {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 2px 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 3px;
+  letter-spacing: 0.5px;
+}
+
+.bdp-toggle:hover {
+  color: var(--text);
 }
 
 .bdp-claude-btn {


### PR DESCRIPTION
Adds all dashboard Claude functions to the battlefield base detail panel: comment, label, preview, detail view, create issue, collapsible all PRs/Issues sections, and active Claude indicator.

Closes #33

Generated with [Claude Code](https://claude.ai/code)