### PR TITLE
feat: rename application to V&C - Gitaltert "Vibe and Conquer"

### DIFF
--- a/gh-ctrl/client/index.html
+++ b/gh-ctrl/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BattleGit</title>
+    <title>V&amp;C - Gitaltert</title>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&family=Syne:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>

--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -80,7 +80,7 @@ export default function App() {
   return (
     <div className="app-layout">
       <aside className="sidebar">
-        <div className="sidebar-logo">BattleGit</div>
+        <div className="sidebar-logo">V&amp;C - Gitaltert</div>
 
         <nav className="sidebar-nav">
           <button


### PR DESCRIPTION
Renames the application from "BattleGit" to "V&C - Gitaltert" ("Vibe and Conquer") in the browser title and sidebar logo.

Closes #39

Generated with [Claude Code](https://claude.ai/code)