### PR TITLE
feat: battlefield add new base = new repository on github (with visibility options)

### DIFF
--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -146,6 +146,7 @@ export default function App() {
             entries={entries}
             loading={loading}
             onRefresh={loadDashboard}
+            onReposChange={handleReposChange}
             onToast={addToast}
           />
         )}

--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -121,4 +121,14 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(params),
     }),
+
+  createRepo: (params: {
+    name: string
+    description?: string
+    visibility: 'public' | 'private'
+  }) =>
+    request<{ ok: boolean; repo: import('./types').Repo }>('/github/create-repo', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
 }

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -2,11 +2,13 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import type { DashboardEntry } from '../types'
 import { BaseNode } from './BaseNode'
 import { ConstructDialog } from './ConstructDialog'
+import { CreateBaseDialog } from './CreateBaseDialog'
 
 interface Props {
   entries: DashboardEntry[]
   loading: boolean
   onRefresh: () => void
+  onReposChange: () => void
   onToast: (message: string, type: 'success' | 'error' | 'info') => void
 }
 
@@ -46,7 +48,7 @@ function savePositions(positions: Record<number, Position>) {
   localStorage.setItem('battlefield-positions', JSON.stringify(positions))
 }
 
-export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props) {
+export function BattlefieldView({ entries, loading, onRefresh, onReposChange, onToast }: Props) {
   const [offset, setOffset] = useState<Position>({ x: 0, y: 0 })
   const [isDraggingMap, setIsDraggingMap] = useState(false)
   const [dragStart, setDragStart] = useState<Position>({ x: 0, y: 0 })
@@ -59,6 +61,7 @@ export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props)
   const [relocatingStart, setRelocatingStart] = useState<{ mouseX: number; mouseY: number; nodeX: number; nodeY: number } | null>(null)
   const [constructTarget, setConstructTarget] = useState<DashboardEntry | null>(null)
   const [isRelocateMode, setIsRelocateMode] = useState(false)
+  const [showCreateBase, setShowCreateBase] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
   // Update positions when entries change (new repos)
@@ -151,6 +154,12 @@ export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props)
           >
             {isRelocateMode ? '✕ CANCEL RELOCATE' : '&#x2295; RELOCATE BASE'}
           </button>
+          <button
+            className="hud-btn hud-btn-new-base"
+            onClick={() => setShowCreateBase(true)}
+          >
+            &#x2b; NEW BASE
+          </button>
         </div>
       </div>
 
@@ -209,6 +218,19 @@ export function BattlefieldView({ entries, loading, onRefresh, onToast }: Props)
           entry={constructTarget}
           onClose={() => setConstructTarget(null)}
           onSuccess={(msg) => { onToast(msg, 'success'); setConstructTarget(null) }}
+          onError={(msg) => onToast(msg, 'error')}
+        />
+      )}
+
+      {/* Create new base dialog */}
+      {showCreateBase && (
+        <CreateBaseDialog
+          onClose={() => setShowCreateBase(false)}
+          onSuccess={(msg) => {
+            onToast(msg, 'success')
+            setShowCreateBase(false)
+            onReposChange()
+          }}
           onError={(msg) => onToast(msg, 'error')}
         />
       )}

--- a/gh-ctrl/client/src/components/CreateBaseDialog.tsx
+++ b/gh-ctrl/client/src/components/CreateBaseDialog.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect, useRef } from 'react'
+import { api } from '../api'
+
+interface Props {
+  onClose: () => void
+  onSuccess: (message: string) => void
+  onError: (message: string) => void
+}
+
+const BOOT_SEQUENCE = `> COMMAND CENTER ONLINE
+> SECURE CHANNEL ESTABLISHED
+> READY TO ESTABLISH NEW BASE...`
+
+export function CreateBaseDialog({ onClose, onSuccess, onError }: Props) {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [visibility, setVisibility] = useState<'public' | 'private'>('private')
+  const [submitting, setSubmitting] = useState(false)
+  const [bootText, setBootText] = useState('')
+  const [bootDone, setBootDone] = useState(false)
+  const nameRef = useRef<HTMLInputElement>(null)
+
+  // Typewriter boot sequence
+  useEffect(() => {
+    let i = 0
+    const interval = setInterval(() => {
+      if (i <= BOOT_SEQUENCE.length) {
+        setBootText(BOOT_SEQUENCE.slice(0, i))
+        i++
+      } else {
+        clearInterval(interval)
+        setBootDone(true)
+        nameRef.current?.focus()
+      }
+    }, 16)
+    return () => clearInterval(interval)
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmedName = name.trim()
+    if (!trimmedName) return
+    setSubmitting(true)
+    try {
+      const result = await api.createRepo({
+        name: trimmedName,
+        description: description.trim() || undefined,
+        visibility,
+      })
+      onSuccess(`BASE ESTABLISHED: ${result.repo.fullName} (${visibility.toUpperCase()})`)
+    } catch (err: any) {
+      onError(`BASE CONSTRUCTION FAILED: ${err.message}`)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleOverlayKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') onClose()
+  }
+
+  const isValidName = /^[a-zA-Z0-9._-]+$/.test(name.trim())
+
+  return (
+    <div
+      className="construct-overlay"
+      onClick={onClose}
+      onKeyDown={handleOverlayKeyDown}
+    >
+      <div
+        className="construct-dialog"
+        onClick={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="construct-header">
+          <div className="construct-title-bar">
+            <span className="construct-icon">&#x25a0;&#x25a0;</span>
+            <span className="construct-title">ESTABLISH NEW BASE</span>
+            <span className="construct-subtitle">// NEW GITHUB REPOSITORY</span>
+            <button className="construct-close" onClick={onClose}>✕</button>
+          </div>
+          <pre className="construct-boot">
+            {bootText}
+            {!bootDone && <span className="construct-cursor">_</span>}
+          </pre>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="construct-form">
+          <div className="construct-field">
+            <label className="construct-label">&#x25b6; BASE DESIGNATION (repo name):</label>
+            <input
+              ref={nameRef}
+              className="construct-input"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-new-repo"
+              autoComplete="off"
+              pattern="[a-zA-Z0-9._-]+"
+            />
+            {name.trim() && !isValidName && (
+              <div className="construct-field-error">
+                Only letters, numbers, hyphens, underscores, and dots allowed
+              </div>
+            )}
+          </div>
+
+          <div className="construct-field">
+            <label className="construct-label">&#x25b6; INTEL BRIEF (description):</label>
+            <input
+              className="construct-input"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional description..."
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="construct-field">
+            <label className="construct-label">&#x25b6; CLEARANCE LEVEL:</label>
+            <div className="create-base-visibility">
+              <button
+                type="button"
+                className={`create-base-vis-btn${visibility === 'private' ? ' selected' : ''}`}
+                onClick={() => setVisibility('private')}
+              >
+                <span className="create-base-vis-icon">&#x1F512;</span>
+                <span className="create-base-vis-label">PRIVATE</span>
+                <span className="create-base-vis-desc">Only you and collaborators</span>
+              </button>
+              <button
+                type="button"
+                className={`create-base-vis-btn${visibility === 'public' ? ' selected' : ''}`}
+                onClick={() => setVisibility('public')}
+              >
+                <span className="create-base-vis-icon">&#x1F30D;</span>
+                <span className="create-base-vis-label">PUBLIC</span>
+                <span className="create-base-vis-desc">Visible to everyone</span>
+              </button>
+            </div>
+          </div>
+
+          <div className="construct-actions">
+            <button type="button" className="construct-btn abort" onClick={onClose}>
+              [ ABORT MISSION ]
+            </button>
+            <button
+              type="submit"
+              className="construct-btn deploy"
+              disabled={submitting || !name.trim() || !isValidName}
+            >
+              {submitting ? '[ CONSTRUCTING... ]' : '[ ESTABLISH BASE ]'}
+            </button>
+          </div>
+        </form>
+
+        <div className="construct-footer">
+          &#x25a0; NEW REPOSITORY &nbsp;·&nbsp; COMMAND CENTER READY
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1860,3 +1860,74 @@ select.input {
   text-align: center;
   background: rgba(57, 211, 83, 0.02);
 }
+
+.construct-field-error {
+  font-size: 10px;
+  color: var(--red);
+  margin-top: 4px;
+  letter-spacing: 0.5px;
+}
+
+/* HUD new base button */
+.hud-btn-new-base {
+  border-color: rgba(88, 166, 255, 0.5);
+  color: var(--blue);
+}
+
+.hud-btn-new-base:hover {
+  border-color: var(--blue);
+  background: rgba(88, 166, 255, 0.08);
+  color: var(--blue);
+}
+
+/* Create base visibility selector */
+.create-base-visibility {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.create-base-vis-btn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 8px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border-2);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: var(--font-mono);
+  color: var(--text-2);
+}
+
+.create-base-vis-btn:hover {
+  background: rgba(57, 211, 83, 0.04);
+  border-color: rgba(57, 211, 83, 0.3);
+  color: var(--text);
+}
+
+.create-base-vis-btn.selected {
+  background: rgba(57, 211, 83, 0.08);
+  border-color: rgba(57, 211, 83, 0.6);
+  color: var(--green);
+}
+
+.create-base-vis-icon {
+  font-size: 20px;
+}
+
+.create-base-vis-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+}
+
+.create-base-vis-desc {
+  font-size: 9px;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+  text-align: center;
+}

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -358,6 +358,54 @@ app.get('/pr/:owner/:name/:number', async (c) => {
   return c.json(result.data)
 })
 
+// POST /api/github/create-repo — create a new GitHub repository and track it
+app.post('/create-repo', async (c) => {
+  const body = await c.req.json()
+  const { name, description, visibility } = body
+
+  if (!name) {
+    return c.json({ error: 'Missing required field: name' }, 400)
+  }
+
+  if (visibility !== 'public' && visibility !== 'private') {
+    return c.json({ error: 'visibility must be "public" or "private"' }, 400)
+  }
+
+  // Get authenticated user to build fullName
+  const userResult = gh(['api', 'user', '--jq', '.login'])
+  if (userResult.error || !userResult.data) {
+    return c.json({ error: 'Failed to get authenticated GitHub user' }, 500)
+  }
+  const owner = userResult.data.trim ? userResult.data.trim() : String(userResult.data).trim()
+  const fullName = `${owner}/${name}`
+
+  const args = ['repo', 'create', name, `--${visibility}`]
+  if (description) args.push('--description', description)
+
+  const proc = Bun.spawnSync(['gh', ...args], { env: { ...process.env } })
+  if (proc.exitCode !== 0) {
+    return c.json({ error: proc.stderr.toString() }, 500)
+  }
+
+  // Add the newly created repo to the tracked repos DB
+  try {
+    const result = await db.insert(repos).values({
+      owner,
+      name,
+      fullName,
+      description: description || null,
+      color: '#00ff88',
+    }).returning()
+
+    return c.json({ ok: true, repo: result[0] }, 201)
+  } catch (err: any) {
+    if (err.message?.includes('UNIQUE')) {
+      return c.json({ error: 'Repository already tracked' }, 409)
+    }
+    return c.json({ error: 'Repository created but failed to track it' }, 500)
+  }
+})
+
 // POST /api/github/create-pr — create a PR from a branch
 app.post('/create-pr', async (c) => {
   const body = await c.req.json()


### PR DESCRIPTION
Implements #issue-34: adds a "+ NEW BASE" button to the Battlefield HUD that opens a dialog to create a new GitHub repository with public/private visibility selection. The new repo is automatically tracked and appears on the battlefield immediately.

Closes #34

Generated with [Claude Code](https://claude.ai/code)