### PR TITLE
feat: add logo and favicon with updated color scheme

### DIFF
--- a/gh-ctrl/client/index.html
+++ b/gh-ctrl/client/index.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>V&amp;C - Gitaltert</title>
+    <title>V&amp;C - Command Center</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/logo.svg" />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&family=Syne:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>

--- a/gh-ctrl/client/public/favicon.svg
+++ b/gh-ctrl/client/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- Dark background -->
+  <rect width="64" height="64" rx="8" fill="#080b08"/>
+  <!-- Radar circle outer -->
+  <circle cx="32" cy="32" r="28" fill="none" stroke="#1a4d1a" stroke-width="1"/>
+  <!-- Radar circle inner -->
+  <circle cx="32" cy="32" r="20" fill="none" stroke="#1a4d1a" stroke-width="1"/>
+  <circle cx="32" cy="32" r="12" fill="none" stroke="#1a4d1a" stroke-width="1"/>
+  <!-- Radar scan lines -->
+  <line x1="4" y1="32" x2="60" y2="32" stroke="#1a4d1a" stroke-width="0.5"/>
+  <line x1="32" y1="4" x2="32" y2="60" stroke="#1a4d1a" stroke-width="0.5"/>
+  <!-- Terminal prompt >_ symbol in neon green -->
+  <text x="32" y="37" font-family="monospace" font-size="16" font-weight="bold" fill="#39ff6e" text-anchor="middle" dominant-baseline="middle">&#62;_</text>
+  <!-- Outer glow ring -->
+  <circle cx="32" cy="32" r="29" fill="none" stroke="#39ff6e" stroke-width="0.8" opacity="0.4"/>
+</svg>

--- a/gh-ctrl/client/public/logo.svg
+++ b/gh-ctrl/client/public/logo.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" width="240" height="240">
+  <defs>
+    <radialGradient id="radar-glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#39ff6e" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#39ff6e" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="240" height="240" rx="12" fill="#080b08"/>
+
+  <!-- Radar glow -->
+  <circle cx="120" cy="120" r="100" fill="url(#radar-glow)"/>
+
+  <!-- Radar rings -->
+  <circle cx="120" cy="120" r="96" fill="none" stroke="#1a4d1a" stroke-width="1.5"/>
+  <circle cx="120" cy="120" r="72" fill="none" stroke="#1a4d1a" stroke-width="1"/>
+  <circle cx="120" cy="120" r="48" fill="none" stroke="#1a4d1a" stroke-width="1"/>
+  <circle cx="120" cy="120" r="24" fill="none" stroke="#1a4d1a" stroke-width="1"/>
+
+  <!-- Radar cross lines -->
+  <line x1="24" y1="120" x2="216" y2="120" stroke="#1a4d1a" stroke-width="0.8"/>
+  <line x1="120" y1="24" x2="120" y2="216" stroke="#1a4d1a" stroke-width="0.8"/>
+  <line x1="52" y1="52" x2="188" y2="188" stroke="#1a4d1a" stroke-width="0.5" opacity="0.5"/>
+  <line x1="188" y1="52" x2="52" y2="188" stroke="#1a4d1a" stroke-width="0.5" opacity="0.5"/>
+
+  <!-- Outer neon ring -->
+  <circle cx="120" cy="120" r="98" fill="none" stroke="#39ff6e" stroke-width="1.5" opacity="0.6" filter="url(#glow)"/>
+
+  <!-- Star at top -->
+  <polygon points="120,30 123,40 134,40 125,47 128,57 120,51 112,57 115,47 106,40 117,40"
+           fill="#39ff6e" opacity="0.8"/>
+
+  <!-- Sword/arrow shapes (simplified crossed swords from logo) -->
+  <line x1="60" y1="60" x2="180" y2="180" stroke="#4a7a4a" stroke-width="4" stroke-linecap="round"/>
+  <line x1="180" y1="60" x2="60" y2="180" stroke="#4a7a4a" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Circuit board lines (top right area) -->
+  <g stroke="#39ff6e" stroke-width="1" opacity="0.4" fill="none">
+    <rect x="155" y="35" width="30" height="20" rx="2"/>
+    <line x1="160" y1="40" x2="180" y2="40"/>
+    <line x1="160" y1="45" x2="175" y2="45"/>
+    <line x1="160" y1="50" x2="180" y2="50"/>
+    <circle cx="183" cy="40" r="1.5" fill="#39ff6e"/>
+    <circle cx="177" cy="45" r="1.5" fill="#39ff6e"/>
+    <circle cx="183" cy="50" r="1.5" fill="#39ff6e"/>
+  </g>
+
+  <!-- Terminal prompt in center -->
+  <text x="120" y="128" font-family="monospace" font-size="28" font-weight="bold"
+        fill="#39ff6e" text-anchor="middle" dominant-baseline="middle" filter="url(#glow)">&#62;_</text>
+
+  <!-- "VIBE AND CONQUER" text -->
+  <text x="120" y="12" font-family="monospace" font-size="10" font-weight="bold"
+        fill="#39ff6e" text-anchor="middle" letter-spacing="2" opacity="0.9">VIBE AND CONQUER</text>
+
+  <!-- "COMMAND CENTER" curved around top -->
+  <text x="120" y="175" font-family="monospace" font-size="7" font-weight="bold"
+        fill="#39ff6e" text-anchor="middle" letter-spacing="1.5" opacity="0.7">COMMAND CENTER</text>
+
+  <!-- "EST. 2026" bottom -->
+  <text x="120" y="228" font-family="monospace" font-size="8"
+        fill="#39ff6e" text-anchor="middle" letter-spacing="1" opacity="0.7">EST. 2026</text>
+
+  <!-- Laurel wreath simplified (left side) -->
+  <g fill="none" stroke="#4a7a4a" stroke-width="1.5" opacity="0.6">
+    <ellipse cx="20" cy="100" rx="6" ry="10" transform="rotate(-20, 20, 100)"/>
+    <ellipse cx="18" cy="115" rx="6" ry="10" transform="rotate(-10, 18, 115)"/>
+    <ellipse cx="18" cy="130" rx="6" ry="10" transform="rotate(0, 18, 130)"/>
+    <ellipse cx="20" cy="145" rx="6" ry="10" transform="rotate(10, 20, 145)"/>
+  </g>
+  <!-- Laurel wreath right side -->
+  <g fill="none" stroke="#4a7a4a" stroke-width="1.5" opacity="0.6">
+    <ellipse cx="220" cy="100" rx="6" ry="10" transform="rotate(20, 220, 100)"/>
+    <ellipse cx="222" cy="115" rx="6" ry="10" transform="rotate(10, 222, 115)"/>
+    <ellipse cx="222" cy="130" rx="6" ry="10" transform="rotate(0, 222, 130)"/>
+    <ellipse cx="220" cy="145" rx="6" ry="10" transform="rotate(-10, 220, 145)"/>
+  </g>
+</svg>

--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -80,7 +80,10 @@ export default function App() {
   return (
     <div className="app-layout">
       <aside className="sidebar">
-        <div className="sidebar-logo">V&amp;C - Gitaltert</div>
+        <div className="sidebar-logo">
+          <img src="/logo.svg" alt="V&C Command Center" className="sidebar-logo-img" />
+          <span>V&amp;C</span>
+        </div>
 
         <nav className="sidebar-nav">
           <button

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1,14 +1,17 @@
 :root {
-  --bg: #080b10;
-  --bg-2: #0d1117;
-  --bg-3: #161b22;
-  --border: #21262d;
-  --border-2: #30363d;
-  --text: #e6edf3;
-  --text-2: #8b949e;
-  --text-3: #484f58;
+  /* Dark military terminal aesthetic inspired by V&C logo */
+  --bg: #080c08;
+  --bg-2: #0c110c;
+  --bg-3: #141c14;
+  --border: #1e2a1e;
+  --border-2: #2a3a2a;
+  --text: #d4e8d4;
+  --text-2: #7a9e7a;
+  --text-3: #3d5c3d;
 
-  --green: #39d353;
+  /* Neon green primary — matches logo's vivid terminal green */
+  --green: #39ff6e;
+  --green-dim: #1fcc4d;
   --amber: #f0883e;
   --red: #f85149;
   --blue: #58a6ff;
@@ -47,6 +50,7 @@ a:hover { text-decoration: underline; }
 .sidebar {
   background: var(--bg-2);
   border-right: 1px solid var(--border);
+  box-shadow: 2px 0 12px rgba(57, 255, 110, 0.05);
   padding: 20px 16px;
   display: flex;
   flex-direction: column;
@@ -57,11 +61,22 @@ a:hover { text-decoration: underline; }
 }
 
 .sidebar-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   font-family: var(--font-display);
   font-weight: 800;
   font-size: 22px;
   letter-spacing: 2px;
   color: var(--green);
+  text-shadow: 0 0 12px rgba(57, 255, 110, 0.4);
+}
+
+.sidebar-logo-img {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 6px rgba(57, 255, 110, 0.5));
 }
 
 .sidebar-nav {


### PR DESCRIPTION
Adds SVG logo and favicon inspired by the V&C Command Center brand identity, and updates the app color scheme to match the logo's vivid neon green and dark military aesthetic.

Closes #43

Generated with [Claude Code](https://claude.ai/code)