### PR TITLE
fix: attach isometric terrain grid to the map layer

### DIFF
--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -189,8 +189,7 @@ export function BattlefieldView({ entries, loading, onRefresh, onReposChange, on
       ref={containerRef}
       style={{ cursor: isDraggingMap ? 'grabbing' : (isRelocateMode ? 'crosshair' : 'grab') }}
     >
-      {/* Terrain layers */}
-      <div className="battlefield-terrain" />
+      {/* Scanlines — fixed to viewport */}
       <div className="battlefield-scanlines" />
 
       {/* HUD */}
@@ -232,6 +231,8 @@ export function BattlefieldView({ entries, loading, onRefresh, onReposChange, on
         className="battlefield-map"
         style={{ transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})`, transformOrigin: '0 0' }}
       >
+        {/* Terrain grid — inside map layer so it pans/zooms with the bases */}
+        <div className="battlefield-terrain" />
         {entries.map((entry) => {
           const pos = positions[entry.repo.id] ?? { x: 0, y: 0 }
           return (


### PR DESCRIPTION
Fixes #46

Moves `.battlefield-terrain` inside `.battlefield-map` so the isometric grid pans and zooms together with the base nodes, fixing the visual detachment where the grid stayed fixed while bases moved.

Generated with [Claude Code](https://claude.ai/code)