### PR TITLE
feat: sort branches by commit date; add branches to battlefield view

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, useEffect } from 'react'
-import type { DashboardEntry, GHPR, GHIssue } from '../types'
+import type { DashboardEntry, GHPR, GHIssue, Branch } from '../types'
 import { ActionModal } from './ActionModal'
 import type { ModalState } from './ActionModal'
+import { api } from '../api'
 
 interface Position {
   x: number
@@ -140,8 +141,28 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
   const { repo, data } = entry
   const [showAllPRs, setShowAllPRs] = useState(false)
   const [showAllIssues, setShowAllIssues] = useState(false)
+  const [showBranches, setShowBranches] = useState(false)
+  const [branches, setBranches] = useState<Branch[]>([])
+  const [defaultBranch, setDefaultBranch] = useState('main')
+  const [branchesLoading, setBranchesLoading] = useState(false)
   const panelX = position.x + 145
   const panelY = position.y
+
+  const toggleBranches = async () => {
+    if (!showBranches && branches.length === 0) {
+      setBranchesLoading(true)
+      try {
+        const result = await api.getBranches(repo.owner, repo.name)
+        setBranches(result.branches)
+        setDefaultBranch(result.defaultBranch)
+      } catch {
+        // silently fail — branches section will show empty
+      } finally {
+        setBranchesLoading(false)
+      }
+    }
+    setShowBranches((v) => !v)
+  }
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -287,6 +308,49 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
           ))}
         </div>
       )}
+
+      <div className="bdp-section">
+        <button className="bdp-toggle" onClick={toggleBranches}>
+          <span>{showBranches ? '▾' : '▸'}</span>
+          {' '}&#x2387; BRANCHES {branchesLoading ? '(loading...)' : branches.length > 0 ? `(${branches.length})` : ''}
+        </button>
+        {showBranches && !branchesLoading && (
+          branches.length === 0 ? (
+            <div className="bdp-more">No branches found</div>
+          ) : (
+            branches.slice(0, 8).map((branch) => (
+              <div key={branch.name} className="bdp-item">
+                <div className="bdp-item-left">
+                  <span className="branch-icon">⎇</span>
+                  <span className="bdp-text-btn" style={{ cursor: 'default' }}>{branch.name}</span>
+                  {branch.name === defaultBranch && (
+                    <span className="bdp-branch-default">default</span>
+                  )}
+                </div>
+                <div className="bdp-item-right">
+                  {branch.committedDate && (
+                    <span className="bdp-branch-date" title={branch.committedDate}>
+                      {new Date(branch.committedDate).toLocaleDateString()}
+                    </span>
+                  )}
+                  {branch.name !== defaultBranch && (
+                    <button
+                      className="bdp-icon-btn"
+                      title="Open PR for this branch"
+                      onClick={() => onModalOpen({ mode: 'create-pr', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, head: branch.name })}
+                    >
+                      PR
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))
+          )
+        )}
+        {showBranches && !branchesLoading && branches.length > 8 && (
+          <div className="bdp-more">+{branches.length - 8} more</div>
+        )}
+      </div>
 
       {data.error && (
         <div className="bdp-error">&#x26A0; {data.error}</div>

--- a/gh-ctrl/client/src/components/RepoCard.tsx
+++ b/gh-ctrl/client/src/components/RepoCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { DashboardEntry, GHPR, GHIssue } from '../types'
+import type { DashboardEntry, GHPR, GHIssue, Branch } from '../types'
 import { api } from '../api'
 import { ActionModal } from './ActionModal'
 import type { ModalState } from './ActionModal'
@@ -16,7 +16,7 @@ export function RepoCard({ entry, onToast }: Props) {
   const [showAllPRs, setShowAllPRs] = useState(false)
   const [showAllIssues, setShowAllIssues] = useState(false)
   const [showBranches, setShowBranches] = useState(false)
-  const [branches, setBranches] = useState<string[]>([])
+  const [branches, setBranches] = useState<Branch[]>([])
   const [defaultBranch, setDefaultBranch] = useState('main')
   const [branchesLoading, setBranchesLoading] = useState(false)
 
@@ -249,19 +249,24 @@ export function RepoCard({ entry, onToast }: Props) {
                 <div className="no-items">No branches found</div>
               ) : (
                 branches.map((branch) => (
-                  <div key={branch} className="list-item">
+                  <div key={branch.name} className="list-item">
                     <div className="list-item-left">
                       <span className="branch-icon">⎇</span>
-                      <span className="list-item-title">{branch}</span>
-                      {branch === defaultBranch && (
+                      <span className="list-item-title">{branch.name}</span>
+                      {branch.name === defaultBranch && (
                         <span className="badge badge-default">default</span>
                       )}
                     </div>
                     <div className="list-item-right">
-                      {branch !== defaultBranch && (
+                      {branch.committedDate && (
+                        <span className="branch-date" title={branch.committedDate}>
+                          {new Date(branch.committedDate).toLocaleDateString()}
+                        </span>
+                      )}
+                      {branch.name !== defaultBranch && (
                         <button
                           className="btn btn-ghost btn-sm item-claude-btn"
-                          onClick={() => openCreatePR(branch)}
+                          onClick={() => openCreatePR(branch.name)}
                         >
                           Open PR
                         </button>

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1736,6 +1736,28 @@ select.input {
   text-align: right;
 }
 
+.bdp-branch-date {
+  font-size: 9px;
+  color: var(--text-3);
+  letter-spacing: 0.3px;
+}
+
+.bdp-branch-default {
+  font-size: 8px;
+  color: var(--blue);
+  background: rgba(88, 166, 255, 0.1);
+  border: 1px solid rgba(88, 166, 255, 0.3);
+  border-radius: 2px;
+  padding: 0 3px;
+  letter-spacing: 0.5px;
+}
+
+.branch-date {
+  font-size: 10px;
+  color: var(--text-3);
+  margin-right: 4px;
+}
+
 .bdp-text-btn {
   background: none;
   border: none;

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -39,8 +39,13 @@ export interface GHLabel {
   description: string
 }
 
+export interface Branch {
+  name: string
+  committedDate: string
+}
+
 export interface BranchesData {
-  branches: string[]
+  branches: Branch[]
   defaultBranch: string
 }
 

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -176,19 +176,45 @@ app.get('/labels/:owner/:name', async (c) => {
   return c.json(result.data || [])
 })
 
-// GET /api/github/branches/:owner/:name — list branches for a repo
+// GET /api/github/branches/:owner/:name — list branches for a repo, sorted by commit date desc
 app.get('/branches/:owner/:name', async (c) => {
   const owner = c.req.param('owner')
   const name = c.req.param('name')
-  const fullName = `${owner}/${name}`
 
-  const branchResult = gh(['api', `repos/${fullName}/branches?per_page=100`, '--jq', '[.[].name]'])
-  const repoResult = gh(['repo', 'view', fullName, '--json', 'defaultBranchRef'])
+  const graphqlQuery = `{
+    repository(owner: "${owner}", name: "${name}") {
+      defaultBranchRef { name }
+      refs(refPrefix: "refs/heads/", first: 100) {
+        nodes {
+          name
+          target {
+            ... on Commit {
+              committedDate
+            }
+          }
+        }
+      }
+    }
+  }`
 
-  if (branchResult.error) return c.json({ error: branchResult.error }, 500)
+  const result = gh(['api', 'graphql', '-f', `query=${graphqlQuery}`])
+  if (result.error) return c.json({ error: result.error }, 500)
 
-  const branches: string[] = branchResult.data || []
-  const defaultBranch: string = repoResult.data?.defaultBranchRef?.name || 'main'
+  const repo = result.data?.data?.repository
+  if (!repo) return c.json({ error: 'Failed to fetch branches' }, 500)
+
+  const defaultBranch: string = repo.defaultBranchRef?.name || 'main'
+  const branches: { name: string; committedDate: string }[] = (repo.refs?.nodes || [])
+    .map((node: any) => ({
+      name: node.name,
+      committedDate: node.target?.committedDate || '',
+    }))
+    .sort((a: any, b: any) => {
+      if (!a.committedDate && !b.committedDate) return 0
+      if (!a.committedDate) return 1
+      if (!b.committedDate) return -1
+      return new Date(b.committedDate).getTime() - new Date(a.committedDate).getTime()
+    })
 
   return c.json({ branches, defaultBranch })
 })


### PR DESCRIPTION
Closes #52

**Changes:**
- Backend: use GitHub GraphQL API to fetch branches with committedDate, sort descending
- Types: add Branch interface with name + committedDate
- RepoCard: show commit date next to each branch
- BaseNode (battlefield): add collapsible Branches section with on-demand loading

Generated with [Claude Code](https://claude.ai/code)