### PR TITLE
feat: increase Claude status indicator size on battlefield building

### DIFF
--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1410,6 +1410,7 @@ select.input {
 .beacon-claude {
   color: var(--purple);
   text-shadow: 0 0 6px var(--purple);
+  font-size: 20px;
 }
 
 /* Building graphic */


### PR DESCRIPTION
Increases the Claude active status beacon (★) from 12px to 20px so it's more visible on the building graphic in the battlefield view.

Closes #54

Generated with [Claude Code](https://claude.ai/code)