### PR TITLE
feat: highlight issues with no @claude interaction

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -271,7 +271,7 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
       {remainingIssues.length > 0 && (
         <div className="bdp-section">
           <button className="bdp-toggle" onClick={() => setShowAllIssues((v) => !v)}>
-            <span>{showAllIssues ? '▾' : '▸'}</span> All Issues ({remainingIssues.length})
+            <span>{showAllIssues ? '▾' : '▸'}</span> All Issues ({remainingIssues.length}) <span className="untouched-count-badge" title="Issues with no @claude interaction">● {remainingIssues.length} untouched</span>
           </button>
           {showAllIssues && remainingIssues.slice(0, 5).map((issue: GHIssue) => (
             <BdpItemRow
@@ -283,6 +283,7 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
               onModalOpen={onModalOpen}
               labels={issue.labels}
               isClaudeActive={activeClaudeSet.has(issue.number)}
+              isUntouched
             />
           ))}
         </div>
@@ -295,7 +296,7 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
   )
 }
 
-function BdpItemRow({ number, title, type, repo, onModalOpen, previewUrl, labels, isClaudeActive }: {
+function BdpItemRow({ number, title, type, repo, onModalOpen, previewUrl, labels, isClaudeActive, isUntouched }: {
   number: number
   title: string
   type: 'pr' | 'issue'
@@ -304,13 +305,17 @@ function BdpItemRow({ number, title, type, repo, onModalOpen, previewUrl, labels
   previewUrl?: string | null
   labels: { name: string; color: string }[]
   isClaudeActive?: boolean
+  isUntouched?: boolean
 }) {
   return (
-    <div className="bdp-item">
+    <div className={`bdp-item${isUntouched ? ' untouched-issue' : ''}`}>
       <div className="bdp-item-left">
         <span className="bdp-num">#{number}</span>
         {isClaudeActive && (
           <span className="claude-active-indicator spinning" title="Claude is working on this">⟳</span>
+        )}
+        {isUntouched && (
+          <span className="untouched-indicator" title="No @claude interaction yet">●</span>
         )}
         <button
           className="bdp-text-btn"

--- a/gh-ctrl/client/src/components/RepoCard.tsx
+++ b/gh-ctrl/client/src/components/RepoCard.tsx
@@ -220,7 +220,7 @@ export function RepoCard({ entry, onToast }: Props) {
             <div className="card-section">
               <button className="section-toggle" onClick={() => setShowAllIssues((v) => !v)}>
                 <span>{showAllIssues ? '▾' : '▸'}</span>
-                All Issues ({remainingIssues.length} more)
+                All Issues ({remainingIssues.length} more) <span className="untouched-count-badge" title="Issues with no @claude interaction">● {remainingIssues.length} untouched</span>
               </button>
               {showAllIssues && remainingIssues.map((issue: GHIssue) => (
                 <ItemRow
@@ -230,6 +230,7 @@ export function RepoCard({ entry, onToast }: Props) {
                   labels={issue.labels}
                   assignees={issue.assignees}
                   isClaudeActive={activeClaudeSet.has(issue.number)}
+                  isUntouched
                   onClaude={() => openTriggerClaude(issue.number, 'issue')}
                   onComment={() => openComment(issue.number, 'issue')}
                   onLabel={() => openLabel(issue.number, 'issue', issue.labels.map((l) => l.name))}
@@ -289,7 +290,7 @@ function labelTextColor(hex: string): string {
 }
 
 function ItemRow({
-  number, title, labels, assignees, badge, previewUrl, isClaudeActive, onClaude, onComment, onLabel, onDetail,
+  number, title, labels, assignees, badge, previewUrl, isClaudeActive, isUntouched, onClaude, onComment, onLabel, onDetail,
 }: {
   number: number
   title: string
@@ -298,17 +299,21 @@ function ItemRow({
   badge?: React.ReactNode
   previewUrl?: string | null
   isClaudeActive?: boolean
+  isUntouched?: boolean
   onClaude: () => void
   onComment: () => void
   onLabel: () => void
   onDetail?: () => void
 }) {
   return (
-    <div className="list-item">
+    <div className={`list-item${isUntouched ? ' untouched-issue' : ''}`}>
       <div className="list-item-left">
         <span className="list-item-number">#{number}</span>
         {isClaudeActive && (
           <span className="claude-active-indicator spinning" title="Claude is working on this">⟳</span>
+        )}
+        {isUntouched && (
+          <span className="untouched-indicator" title="No @claude interaction yet">●</span>
         )}
         {onDetail ? (
           <button className="list-item-title list-item-title-btn" onClick={onDetail} title="View details">

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -476,6 +476,30 @@ a:hover { text-decoration: underline; }
   vertical-align: middle;
 }
 
+.untouched-indicator {
+  display: inline-block;
+  color: var(--amber);
+  font-size: 8px;
+  margin-right: 2px;
+  vertical-align: middle;
+  opacity: 0.7;
+}
+
+.untouched-issue {
+  border-left: 2px solid rgba(240, 136, 62, 0.35);
+}
+
+.untouched-issue:hover {
+  border-left-color: rgba(240, 136, 62, 0.65);
+}
+
+.untouched-count-badge {
+  font-size: 10px;
+  color: var(--amber);
+  opacity: 0.7;
+  margin-left: 4px;
+}
+
 @keyframes spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }


### PR DESCRIPTION
Add visual indicators to distinguish issues that haven't been touched by @claude. Untouched issues show an amber left border, a small dot indicator, and an "untouched" count badge in the section header.

Closes #59

Generated with [Claude Code](https://claude.ai/code)