### PR TITLE
fix: correct dialog positioning in battlefield view

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
 import type { DashboardEntry, GHPR, GHIssue, Branch } from '../types'
-import { ActionModal } from './ActionModal'
 import type { ModalState } from './ActionModal'
 import { CloseIcon, LinkIcon, LabelIcon, CommentIcon, RefreshIcon, ExternalLinkIcon } from './Icons'
 import { api } from '../api'
@@ -18,13 +17,13 @@ interface Props {
   onConstruct: () => void
   onStartRelocate: (mouseX: number, mouseY: number) => void
   onToast: (message: string, type: 'success' | 'error' | 'info') => void
+  onModalOpen: (state: ModalState) => void
 }
 
-export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, onConstruct, onStartRelocate, onToast }: Props) {
+export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, onConstruct, onStartRelocate, onToast, onModalOpen }: Props) {
   const { repo, data } = entry
   const { stats } = data
   const [showDetail, setShowDetail] = useState(false)
-  const [modalState, setModalState] = useState<ModalState>(null)
 
   const hasConflicts = stats.conflicts > 0
   const hasReviews = stats.needsReview > 0
@@ -57,13 +56,6 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
 
   return (
     <>
-      <ActionModal
-        state={modalState}
-        onClose={() => setModalState(null)}
-        onSuccess={(msg) => onToast(msg, 'success')}
-        onError={(msg) => onToast(msg, 'error')}
-      />
-
       <div
         className={`base-node ${statusClass}${isBeingRelocated ? ' relocating' : ''}${isRelocateMode ? ' relocate-mode' : ''}`}
         style={{
@@ -143,7 +135,7 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
           entry={entry}
           position={position}
           onClose={() => setShowDetail(false)}
-          onModalOpen={setModalState}
+          onModalOpen={onModalOpen}
         />
       )}
     </>

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import type { DashboardEntry } from '../types'
 import { BaseNode } from './BaseNode'
+import { ActionModal } from './ActionModal'
+import type { ModalState } from './ActionModal'
 import { ConstructDialog } from './ConstructDialog'
 import { CreateBaseDialog } from './CreateBaseDialog'
 import { CloseIcon, RelocateIcon, RefreshIcon } from './Icons'
@@ -97,6 +99,7 @@ export function BattlefieldView({ entries, loading, onRefresh, onReposChange, on
   const [constructTarget, setConstructTarget] = useState<DashboardEntry | null>(null)
   const [isRelocateMode, setIsRelocateMode] = useState(false)
   const [showCreateBase, setShowCreateBase] = useState(false)
+  const [modalState, setModalState] = useState<ModalState>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const zoomRef = useRef(zoom)
   const offsetRef = useRef(offset)
@@ -307,6 +310,7 @@ export function BattlefieldView({ entries, loading, onRefresh, onReposChange, on
               onConstruct={() => setConstructTarget(entry)}
               onStartRelocate={(mouseX, mouseY) => handleStartRelocate(entry.repo.id, mouseX, mouseY)}
               onToast={onToast}
+              onModalOpen={setModalState}
             />
           )
         })}
@@ -338,6 +342,14 @@ export function BattlefieldView({ entries, loading, onRefresh, onReposChange, on
           &#x2295; RELOCATE MODE — Drag a base to reposition it. Click again to cancel.
         </div>
       )}
+
+      {/* Action modal — rendered outside the transformed map to ensure correct fixed positioning */}
+      <ActionModal
+        state={modalState}
+        onClose={() => setModalState(null)}
+        onSuccess={(msg) => onToast(msg, 'success')}
+        onError={(msg) => onToast(msg, 'error')}
+      />
 
       {/* Construction dialog */}
       {constructTarget && (


### PR DESCRIPTION
Fixes #072

Dialogs were appearing in the bottom-right corner instead of centered on screen.

**Root cause:** `ActionModal` (using `position: fixed`) was rendered inside `BaseNode`, which lives inside `battlefield-map` — a div with a CSS `transform: translate() scale()` applied. CSS `position: fixed` elements inside a transformed ancestor are positioned relative to that container, not the viewport.

**Fix:** Lifted `modalState` up to `BattlefieldView` and render `ActionModal` outside the transformed map div so it correctly uses viewport-fixed positioning.

Generated with [Claude Code](https://claude.ai/code)