### PR TITLE
feat: display open PRs as buildings nearby base

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -20,6 +20,12 @@ interface Props {
   onModalOpen: (state: ModalState) => void
 }
 
+const PR_BUILDING_OFFSET_X = 148
+const PR_BUILDING_OFFSET_Y = -5
+const PR_BUILDING_COL_WIDTH = 80
+const PR_BUILDING_ROW_HEIGHT = 76
+const MAX_PR_BUILDINGS = 8
+
 export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, onConstruct, onStartRelocate, onToast, onModalOpen }: Props) {
   const { repo, data } = entry
   const { stats } = data
@@ -54,8 +60,28 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
     setShowDetail(v => !v)
   }, [isRelocateMode])
 
+  const visiblePRs = data.prs.slice(0, MAX_PR_BUILDINGS)
+
   return (
     <>
+      {/* PR buildings — rendered before base so base appears on top */}
+      {visiblePRs.map((pr, i) => {
+        const col = i % 2
+        const row = Math.floor(i / 2)
+        return (
+          <PRBuilding
+            key={pr.number}
+            pr={pr}
+            position={{
+              x: position.x + PR_BUILDING_OFFSET_X + col * PR_BUILDING_COL_WIDTH,
+              y: position.y + PR_BUILDING_OFFSET_Y + row * PR_BUILDING_ROW_HEIGHT,
+            }}
+            repo={repo}
+            onModalOpen={onModalOpen}
+          />
+        )
+      })}
+
       <div
         className={`base-node ${statusClass}${isBeingRelocated ? ' relocating' : ''}${isRelocateMode ? ' relocate-mode' : ''}`}
         style={{
@@ -366,6 +392,67 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
       {data.error && (
         <div className="bdp-error">&#x26A0; {data.error}</div>
       )}
+    </div>
+  )
+}
+
+function PRBuilding({ pr, position, repo, onModalOpen }: {
+  pr: GHPR
+  position: Position
+  repo: DashboardEntry['repo']
+  onModalOpen: (state: ModalState) => void
+}) {
+  const isConflict = pr.mergeable === 'CONFLICTING'
+  const isChangesRequested = pr.reviewDecision === 'CHANGES_REQUESTED'
+  const isApproved = pr.reviewDecision === 'APPROVED'
+  const isReviewRequired = pr.reviewDecision === 'REVIEW_REQUIRED'
+
+  const prColor = isConflict || isChangesRequested
+    ? 'var(--crt-red)'
+    : isApproved
+    ? 'var(--crt-green)'
+    : isReviewRequired
+    ? 'var(--crt-amber)'
+    : pr.isDraft
+    ? 'var(--chrome-silver)'
+    : repo.color
+
+  const statusLabel = pr.isDraft ? 'DRAFT'
+    : isConflict ? 'CONFLICT'
+    : isChangesRequested ? 'CHANGES'
+    : isApproved ? 'APPROVED'
+    : isReviewRequired ? 'REVIEW'
+    : 'OPEN'
+
+  const shortTitle = pr.title.length > 14 ? pr.title.slice(0, 12) + '…' : pr.title
+
+  return (
+    <div
+      className="pr-building"
+      style={{
+        left: position.x,
+        top: position.y,
+        '--pr-color': prColor,
+      } as React.CSSProperties}
+      onClick={(e) => {
+        e.stopPropagation()
+        onModalOpen({ mode: 'pr-detail', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, number: pr.number })
+      }}
+      title={`#${pr.number} — ${pr.title}`}
+    >
+      <div className="pr-bld-graphic">
+        <div className="pr-bld-roof" />
+        <div className="pr-bld-body">
+          <div className="pr-bld-win pr-bld-wl" />
+          <div className="pr-bld-door" />
+          <div className="pr-bld-win pr-bld-wr" />
+        </div>
+      </div>
+      <div className="pr-bld-info">
+        <span className="pr-bld-num">#{pr.number}</span>
+        <span className="pr-bld-status">{statusLabel}</span>
+      </div>
+      <div className="pr-bld-title">{shortTitle}</div>
     </div>
   )
 }

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1601,6 +1601,151 @@ select.input {
   display: block;
 }
 
+/* ---- PR Buildings ---- */
+.pr-building {
+  position: absolute;
+  width: 72px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 6px 4px 5px;
+  background: rgba(13, 17, 23, 0.88);
+  border-top: 1px solid var(--pr-color, var(--crt-green));
+  border-left: 1px solid var(--pr-color, var(--crt-green));
+  border-right: 1px solid color-mix(in srgb, var(--pr-color, var(--crt-green)) 30%, #000);
+  border-bottom: 1px solid color-mix(in srgb, var(--pr-color, var(--crt-green)) 30%, #000);
+  box-shadow:
+    2px 2px 0 color-mix(in srgb, var(--pr-color, var(--crt-green)) 15%, #000),
+    4px 4px 0 color-mix(in srgb, var(--pr-color, var(--crt-green)) 6%, #000),
+    0 0 8px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  transition: box-shadow 0.15s;
+  z-index: 2;
+}
+
+.pr-building::before {
+  content: '';
+  position: absolute;
+  top: 5px;
+  left: 100%;
+  width: 5px;
+  height: 100%;
+  background: color-mix(in srgb, var(--pr-color, var(--crt-green)) 5%, rgba(0, 0, 0, 0.85));
+  border-top: 1px solid color-mix(in srgb, var(--pr-color, var(--crt-green)) 25%, transparent);
+  transform: skewY(30deg);
+  transform-origin: top left;
+  pointer-events: none;
+}
+
+.pr-building::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 5px;
+  width: 100%;
+  height: 5px;
+  background: color-mix(in srgb, var(--pr-color, var(--crt-green)) 4%, rgba(0, 0, 0, 0.82));
+  border-left: 1px solid color-mix(in srgb, var(--pr-color, var(--crt-green)) 18%, transparent);
+  transform: skewX(30deg);
+  transform-origin: top left;
+  pointer-events: none;
+}
+
+.pr-building:hover {
+  box-shadow:
+    2px 2px 0 color-mix(in srgb, var(--pr-color, var(--crt-green)) 25%, #000),
+    4px 4px 0 color-mix(in srgb, var(--pr-color, var(--crt-green)) 12%, #000),
+    0 0 14px var(--pr-color, var(--crt-green));
+  z-index: 4;
+}
+
+.pr-bld-graphic {
+  position: relative;
+  width: 46px;
+  height: 36px;
+  flex-shrink: 0;
+}
+
+.pr-bld-roof {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 26px;
+  height: 14px;
+  background: var(--bg-3);
+  border: 1px solid var(--pr-color, var(--crt-green));
+  border-bottom: none;
+}
+
+.pr-bld-body {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 40px;
+  height: 22px;
+  background: var(--bg-3);
+  border: 1px solid var(--pr-color, var(--crt-green));
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 0 4px;
+}
+
+.pr-bld-win {
+  width: 7px;
+  height: 7px;
+  background: color-mix(in srgb, var(--pr-color, var(--crt-green)) 30%, var(--bg-3));
+  border: 1px solid var(--pr-color, var(--crt-green));
+  opacity: 0.75;
+  margin-bottom: 3px;
+}
+
+.pr-bld-door {
+  width: 7px;
+  height: 11px;
+  background: var(--bg);
+  border: 1px solid var(--pr-color, var(--crt-green));
+  border-bottom: none;
+}
+
+.pr-bld-info {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  justify-content: center;
+}
+
+.pr-bld-num {
+  font-size: 8px;
+  color: var(--pr-color, var(--crt-green));
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+
+.pr-bld-status {
+  font-size: 7px;
+  color: var(--pr-color, var(--crt-green));
+  opacity: 0.75;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.pr-bld-title {
+  font-size: 8px;
+  color: var(--text-2);
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  letter-spacing: 0.2px;
+}
+
 /* ---- Base Detail Panel ---- */
 .base-detail-panel {
   position: absolute;


### PR DESCRIPTION
Each open PR is rendered as a small isometric outpost building positioned to the right of its repo base node in a 2-column grid layout.

Closes #77

Generated with [Claude Code](https://claude.ai/code)