### PR TITLE
fix: resolve 'failed to get authenticated GitHub user' when creating repo

### DIFF
--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -398,11 +398,11 @@ app.post('/create-repo', async (c) => {
   }
 
   // Get authenticated user to build fullName
-  const userResult = gh(['api', 'user', '--jq', '.login'])
-  if (userResult.error || !userResult.data) {
+  const userResult = gh(['api', 'user'])
+  if (userResult.error || !userResult.data?.login) {
     return c.json({ error: 'Failed to get authenticated GitHub user' }, 500)
   }
-  const owner = userResult.data.trim ? userResult.data.trim() : String(userResult.data).trim()
+  const owner = userResult.data.login
   const fullName = `${owner}/${name}`
 
   const args = ['repo', 'create', name, `--${visibility}`]


### PR DESCRIPTION
Fixes #69

The gh() helper always JSON.parses output, but `gh api user --jq .login` returns a plain string (not valid JSON), causing parse failure and the "failed to get authenticated GitHub user" error when creating a new base. Fix calls `gh api user` and reads .login from the JSON response.

Generated with [Claude Code](https://claude.ai/code)