### PR TITLE
fix: prevent map zoom when scrolling inside modal windows

### DIFF
--- a/gh-ctrl/client/src/components/ActionModal.tsx
+++ b/gh-ctrl/client/src/components/ActionModal.tsx
@@ -26,7 +26,7 @@ export function ActionModal({ state, onClose, onSuccess, onError }: Props) {
   if (!state) return null
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay" onClick={onClose} onWheel={(e) => e.stopPropagation()}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <button className="modal-close" onClick={onClose}><CloseIcon size={12} /></button>
         {state.mode === 'comment' && (

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -255,7 +255,7 @@ interface LoadBattlefieldMapDialogProps {
 
 function LoadBattlefieldMapDialog({ maps, activeMapId, onLoad, onClose }: LoadBattlefieldMapDialogProps) {
   return (
-    <div className="map-dialog-overlay" onClick={onClose}>
+    <div className="map-dialog-overlay" onClick={onClose} onWheel={(e) => e.stopPropagation()}>
       <div className="map-dialog map-dialog-load" onClick={e => e.stopPropagation()}>
         <div className="map-dialog-title">&#x25a0; SELECT MAP FOR BATTLEFIELD</div>
         {maps.length === 0 ? (

--- a/gh-ctrl/client/src/components/ConstructDialog.tsx
+++ b/gh-ctrl/client/src/components/ConstructDialog.tsx
@@ -86,6 +86,7 @@ export function ConstructDialog({ entry, onClose, onSuccess, onError }: Props) {
       className="construct-overlay"
       onClick={onClose}
       onKeyDown={handleOverlayKeyDown}
+      onWheel={(e) => e.stopPropagation()}
     >
       <div
         className="construct-dialog"

--- a/gh-ctrl/client/src/components/CreateBaseDialog.tsx
+++ b/gh-ctrl/client/src/components/CreateBaseDialog.tsx
@@ -67,6 +67,7 @@ export function CreateBaseDialog({ onClose, onSuccess, onError }: Props) {
       className="construct-overlay"
       onClick={onClose}
       onKeyDown={handleOverlayKeyDown}
+      onWheel={(e) => e.stopPropagation()}
     >
       <div
         className="construct-dialog"


### PR DESCRIPTION
Stop wheel events from bubbling up to the battlefield container when the user scrolls inside any modal/dialog overlay, so scrolling inside the issue window no longer zooms the map.