### PR TITLE
fix: remove duplicate assign button in Dashboard, add PR button to Battlefield

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -345,19 +345,23 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
       {data.claudeIssues.length > 0 && (
         <div className="bdp-section">
           <div className="bdp-section-title claude">&#x2605; CLAUDE ISSUES</div>
-          {data.claudeIssues.slice(0, 4).map((issue: GHIssue) => (
-            <BdpItemRow
-              key={issue.number}
-              number={issue.number}
-              title={issue.title}
-              type="issue"
-              repo={repo}
-              onModalOpen={onModalOpen}
-              labels={issue.labels}
-              assignees={issue.assignees}
-              isClaudeActive={activeClaudeSet.has(issue.number)}
-            />
-          ))}
+          {data.claudeIssues.slice(0, 4).map((issue: GHIssue) => {
+            const claudeBranch = (data.claudeIssueBranches ?? {})[issue.number]
+            return (
+              <BdpItemRow
+                key={issue.number}
+                number={issue.number}
+                title={issue.title}
+                type="issue"
+                repo={repo}
+                onModalOpen={onModalOpen}
+                labels={issue.labels}
+                assignees={issue.assignees}
+                isClaudeActive={activeClaudeSet.has(issue.number)}
+                onPR={() => onModalOpen({ mode: 'create-pr', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, head: claudeBranch || undefined })}
+              />
+            )
+          })}
           {data.claudeIssues.length > 4 && <div className="bdp-more">+{data.claudeIssues.length - 4} more</div>}
         </div>
       )}
@@ -427,6 +431,7 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
               assignees={issue.assignees}
               isClaudeActive={activeClaudeSet.has(issue.number)}
               isUntouched
+              onPR={() => onModalOpen({ mode: 'create-pr', fullName: repo.fullName, owner: repo.owner, repoName: repo.name })}
             />
           ))}
         </div>
@@ -540,7 +545,7 @@ function PRBuilding({ pr, position, repo, onModalOpen }: {
   )
 }
 
-function BdpItemRow({ number, title, type, repo, onModalOpen, previewUrl, labels, assignees, isClaudeActive, isUntouched }: {
+function BdpItemRow({ number, title, type, repo, onModalOpen, previewUrl, labels, assignees, isClaudeActive, isUntouched, onPR }: {
   number: number
   title: string
   type: 'pr' | 'issue'
@@ -551,6 +556,7 @@ function BdpItemRow({ number, title, type, repo, onModalOpen, previewUrl, labels
   assignees: { login: string }[]
   isClaudeActive?: boolean
   isUntouched?: boolean
+  onPR?: () => void
 }) {
   return (
     <div className={`bdp-item${isUntouched ? ' untouched-issue' : ''}`}>
@@ -609,6 +615,15 @@ function BdpItemRow({ number, title, type, repo, onModalOpen, previewUrl, labels
         >
           <CommentIcon size={12} />
         </button>
+        {onPR && (
+          <button
+            className="bdp-icon-btn"
+            title="Create pull request"
+            onClick={onPR}
+          >
+            PR
+          </button>
+        )}
         <button
           className="bdp-claude-btn"
           onClick={() => onModalOpen({ mode: 'trigger-claude', fullName: repo.fullName, number, type })}

--- a/gh-ctrl/client/src/components/RepoCard.tsx
+++ b/gh-ctrl/client/src/components/RepoCard.tsx
@@ -44,10 +44,6 @@ export function RepoCard({ entry }: Props) {
     setModalState({ mode: 'create-pr', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, head })
   }
 
-  const openAssign = (number: number, type: 'pr' | 'issue', currentAssignees: string[]) => {
-    setModalState({ mode: 'assign', fullName: repo.fullName, owner: repo.owner, repoName: repo.name, number, type, currentAssignees })
-  }
-
   const openCreateIssue = () => {
     setModalState({ mode: 'create-issue', fullName: repo.fullName, owner: repo.owner, repoName: repo.name })
   }
@@ -157,7 +153,6 @@ export function RepoCard({ entry }: Props) {
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
                   onAssignee={() => openAssignee(pr.number, 'pr', pr.assignees.map((a) => a.login))}
-                  onAssign={() => openAssign(pr.number, 'pr', pr.assignees.map((a) => a.login))}
                   onDetail={() => openPRDetail(pr.number)}
                 />
               ))}
@@ -180,7 +175,6 @@ export function RepoCard({ entry }: Props) {
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
                   onAssignee={() => openAssignee(pr.number, 'pr', pr.assignees.map((a) => a.login))}
-                  onAssign={() => openAssign(pr.number, 'pr', pr.assignees.map((a) => a.login))}
                   onDetail={() => openPRDetail(pr.number)}
                 />
               ))}
@@ -206,8 +200,7 @@ export function RepoCard({ entry }: Props) {
                     onComment={() => openComment(issue.number, 'issue')}
                     onLabel={() => openLabel(issue.number, 'issue', issue.labels.map((l) => l.name))}
                     onAssignee={() => openAssignee(issue.number, 'issue', issue.assignees.map((a) => a.login))}
-                    onAssign={() => openAssign(issue.number, 'issue', issue.assignees.map((a) => a.login))}
-                    onPR={() => openCreatePR(claudeBranch || undefined)}
+                      onPR={() => openCreatePR(claudeBranch || undefined)}
                     onDetail={() => openIssueDetail(issue.number)}
                     onCreatePR={showCreatePR ? () => openCreatePR(claudeBranch) : undefined}
                   />
@@ -235,7 +228,6 @@ export function RepoCard({ entry }: Props) {
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
                   onAssignee={() => openAssignee(pr.number, 'pr', pr.assignees.map((a) => a.login))}
-                  onAssign={() => openAssign(pr.number, 'pr', pr.assignees.map((a) => a.login))}
                   onDetail={() => openPRDetail(pr.number)}
                 />
               ))}
@@ -261,7 +253,6 @@ export function RepoCard({ entry }: Props) {
                   onComment={() => openComment(issue.number, 'issue')}
                   onLabel={() => openLabel(issue.number, 'issue', issue.labels.map((l) => l.name))}
                   onAssignee={() => openAssignee(issue.number, 'issue', issue.assignees.map((a) => a.login))}
-                  onAssign={() => openAssign(issue.number, 'issue', issue.assignees.map((a) => a.login))}
                   onPR={() => openCreatePR()}
                   onDetail={() => openIssueDetail(issue.number)}
                 />
@@ -324,7 +315,7 @@ function labelTextColor(hex: string): string {
 }
 
 function ItemRow({
-  number, title, labels, assignees, badge, previewUrl, isClaudeActive, isUntouched, onClaude, onComment, onLabel, onAssignee, onDetail, onCreatePR, onPR, onAssign,
+  number, title, labels, assignees, badge, previewUrl, isClaudeActive, isUntouched, onClaude, onComment, onLabel, onAssignee, onDetail, onCreatePR, onPR,
 }: {
   number: number
   title: string
@@ -341,7 +332,6 @@ function ItemRow({
   onDetail?: () => void
   onCreatePR?: () => void
   onPR?: () => void
-  onAssign?: () => void
 }) {
   return (
     <div className={`list-item${isUntouched ? ' untouched-issue' : ''}`}>
@@ -403,11 +393,6 @@ function ItemRow({
             title="Create pull request from Claude branch"
           >
             Create PR
-          </button>
-        )}
-        {onAssign && (
-          <button className="btn btn-ghost btn-xs item-claude-btn" onClick={onAssign} title="Assign">
-            Assign
           </button>
         )}
         <button className="btn btn-ghost btn-xs item-claude-btn" onClick={onLabel} title="Manage labels">


### PR DESCRIPTION
Fixes #106

- Remove duplicate text "Assign" button from Dashboard item rows (keep only icon button)
- Add PR button to Battlefield item rows for issues

Generated with [Claude Code](https://claude.ai/code)