### PR TITLE
feat: battlefield bases decorated with repo meta (language, stack, commits, contributors, stars)

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap } from './types'
+import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta } from './types'
 
 const BASE = '/api'
 
@@ -42,6 +42,9 @@ export const api = {
 
   getBranches: (owner: string, name: string) =>
     request<BranchesData>(`/github/branches/${owner}/${name}`),
+
+  getRepoMeta: (owner: string, name: string) =>
+    request<RepoMeta>(`/github/meta/${owner}/${name}`),
 
   triggerClaude: (params: {
     fullName: string

--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import type { DashboardEntry, GHPR, GHIssue, Branch, WorkflowRun } from '../types'
+import type { DashboardEntry, GHPR, GHIssue, Branch, WorkflowRun, RepoMeta } from '../types'
 import type { ModalState } from './ActionModal'
 import { CloseIcon, LinkIcon, LabelIcon, CommentIcon, RefreshIcon, ExternalLinkIcon, AssigneeIcon } from './Icons'
 import { api } from '../api'
@@ -176,6 +176,9 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
         <div className="base-building">
           <IsoBaseBuilding />
         </div>
+
+        {/* Repo meta strip — always visible below base */}
+        <RepoMetaPanel owner={repo.owner} name={repo.name} repoColor={repo.color} />
 
         {/* Floating HUD toolbar — appears on hover */}
         <div className="base-hud">
@@ -485,6 +488,160 @@ function BaseDetailPanel({ entry, position, onClose, onModalOpen }: {
 
       {data.error && (
         <div className="bdp-error">&#x26A0; {data.error}</div>
+      )}
+    </div>
+  )
+}
+
+// ── Repo Meta Panel ───────────────────────────────────────────────────────────
+
+function CommitSparkline({ weeks }: { weeks: number[] }) {
+  if (!weeks.length) return null
+  const max = Math.max(...weeks, 1)
+  return (
+    <div className="meta-sparkline" title="Commit activity (last 26 weeks)">
+      {weeks.map((count, i) => (
+        <div
+          key={i}
+          className="meta-spark-bar"
+          style={{ height: `${Math.round((count / max) * 100)}%`, opacity: count === 0 ? 0.15 : 0.85 }}
+        />
+      ))}
+    </div>
+  )
+}
+
+function RepoMetaPanel({ owner, name, repoColor }: { owner: string; name: string; repoColor: string }) {
+  const [meta, setMeta] = useState<RepoMeta | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    api.getRepoMeta(owner, name)
+      .then((data) => { if (!cancelled) setMeta(data) })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [owner, name])
+
+  if (loading) {
+    return (
+      <div className="repo-meta-strip">
+        <span className="meta-loading">⌛ loading intel…</span>
+      </div>
+    )
+  }
+
+  if (!meta) return null
+
+  const topLang = meta.primaryLanguage
+  const topTopics = meta.topics.slice(0, 4)
+  const topContributors = meta.contributors.slice(0, 4)
+
+  return (
+    <div className="repo-meta-strip" onClick={(e) => e.stopPropagation()}>
+      {/* Always-visible summary row */}
+      <div className="meta-summary-row">
+        {meta.stars > 0 && (
+          <span className="meta-badge meta-stars" title="Stars">⭐ {meta.stars.toLocaleString()}</span>
+        )}
+        {topLang && (
+          <span className="meta-badge meta-lang" title={`Primary language: ${topLang.name}`}>
+            <span className="meta-lang-dot" style={{ background: topLang.color || repoColor }} />
+            {topLang.name}
+          </span>
+        )}
+        {meta.forks > 0 && (
+          <span className="meta-badge meta-forks" title="Forks">⑂ {meta.forks}</span>
+        )}
+        <button
+          className="meta-expand-btn"
+          onClick={(e) => { e.stopPropagation(); setExpanded(v => !v) }}
+          title={expanded ? 'Collapse intel' : 'Expand intel'}
+        >
+          {expanded ? '▾ LESS' : '▸ MORE'}
+        </button>
+      </div>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div className="meta-expanded">
+          {/* Commit sparkline */}
+          {meta.commitWeeks.length > 0 && (
+            <div className="meta-row">
+              <span className="meta-row-label">COMMITS</span>
+              <CommitSparkline weeks={meta.commitWeeks} />
+            </div>
+          )}
+
+          {/* Language breakdown */}
+          {meta.languages.length > 1 && (
+            <div className="meta-row">
+              <span className="meta-row-label">STACK</span>
+              <div className="meta-lang-bar">
+                {meta.languages.slice(0, 6).map((lang) => (
+                  <div
+                    key={lang.name}
+                    className="meta-lang-seg"
+                    style={{ width: `${lang.percentage}%`, background: lang.color || '#555' }}
+                    title={`${lang.name}: ${lang.percentage}%`}
+                  />
+                ))}
+              </div>
+              <div className="meta-lang-legend">
+                {meta.languages.slice(0, 4).map((lang) => (
+                  <span key={lang.name} className="meta-legend-item">
+                    <span className="meta-lang-dot" style={{ background: lang.color || '#555' }} />
+                    {lang.name} {lang.percentage}%
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Topics / tech stack */}
+          {topTopics.length > 0 && (
+            <div className="meta-row">
+              <span className="meta-row-label">TOPICS</span>
+              <div className="meta-topics">
+                {topTopics.map((topic) => (
+                  <span key={topic} className="meta-topic-tag">{topic}</span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Contributors */}
+          {topContributors.length > 0 && (
+            <div className="meta-row">
+              <span className="meta-row-label">CREW</span>
+              <div className="meta-contributors">
+                {topContributors.map((c) => (
+                  <a
+                    key={c.login}
+                    href={`https://github.com/${c.login}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="meta-contributor"
+                    title={`${c.login} (${c.contributions} commits)`}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <img
+                      src={c.avatarUrl}
+                      alt={c.login}
+                      className="meta-avatar"
+                      width={20}
+                      height={20}
+                    />
+                    <span className="meta-contrib-login">{c.login}</span>
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       )}
     </div>
   )

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -3090,3 +3090,189 @@ select.input {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
 }
+
+/* ── Repo Meta Strip ─────────────────────────────────────────────────────── */
+
+.repo-meta-strip {
+  position: relative;
+  width: 100%;
+  background: rgba(10, 21, 16, 0.88);
+  border: 1px solid rgba(57, 255, 20, 0.18);
+  border-top: none;
+  padding: 4px 6px;
+  font-size: 9px;
+  font-family: var(--font-mono);
+  color: var(--text-2);
+  pointer-events: all;
+}
+
+.meta-loading {
+  color: var(--text-3);
+  font-size: 9px;
+  opacity: 0.7;
+}
+
+.meta-summary-row {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.meta-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 9px;
+  color: var(--text-2);
+  white-space: nowrap;
+}
+
+.meta-stars { color: #e3b341; }
+.meta-forks { color: var(--text-3); }
+.meta-lang  { color: var(--text-2); }
+
+.meta-lang-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.meta-expand-btn {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 8px;
+  cursor: pointer;
+  padding: 0;
+  margin-left: auto;
+  letter-spacing: 0.5px;
+}
+
+.meta-expand-btn:hover { color: var(--text); }
+
+.meta-expanded {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-top: 5px;
+  border-top: 1px solid rgba(57, 255, 20, 0.1);
+  padding-top: 5px;
+}
+
+.meta-row {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.meta-row-label {
+  font-size: 8px;
+  color: var(--text-3);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+/* Commit sparkline */
+.meta-sparkline {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 22px;
+  width: 100%;
+}
+
+.meta-spark-bar {
+  flex: 1;
+  background: var(--green-neon);
+  min-height: 1px;
+  border-radius: 1px 1px 0 0;
+}
+
+/* Language bar */
+.meta-lang-bar {
+  display: flex;
+  height: 5px;
+  border-radius: 2px;
+  overflow: hidden;
+  width: 100%;
+  gap: 1px;
+}
+
+.meta-lang-seg {
+  height: 100%;
+  border-radius: 1px;
+  min-width: 2px;
+}
+
+.meta-lang-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  margin-top: 2px;
+}
+
+.meta-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 8px;
+  color: var(--text-3);
+  white-space: nowrap;
+}
+
+/* Topics */
+.meta-topics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+}
+
+.meta-topic-tag {
+  background: rgba(57, 255, 20, 0.07);
+  border: 1px solid rgba(57, 255, 20, 0.2);
+  border-radius: 2px;
+  padding: 1px 4px;
+  font-size: 8px;
+  color: var(--text-2);
+  white-space: nowrap;
+}
+
+/* Contributors */
+.meta-contributors {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.meta-contributor {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: none;
+  color: var(--text-2);
+  font-size: 9px;
+}
+
+.meta-contributor:hover { color: var(--text); text-decoration: none; }
+
+.meta-avatar {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid rgba(57, 255, 20, 0.25);
+  display: block;
+  object-fit: cover;
+}
+
+.meta-contrib-login {
+  font-size: 9px;
+  color: var(--text-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 90px;
+}

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -119,6 +119,31 @@ export interface IssueDetail {
   comments: { author: { login: string }; body: string; createdAt: string }[]
 }
 
+export interface RepoMetaLanguage {
+  name: string
+  color: string
+  percentage: number
+}
+
+export interface RepoMetaContributor {
+  login: string
+  avatarUrl: string
+  contributions: number
+}
+
+export interface RepoMeta {
+  stars: number
+  forks: number
+  watchers: number
+  primaryLanguage: { name: string; color: string } | null
+  languages: RepoMetaLanguage[]
+  topics: string[]
+  contributors: RepoMetaContributor[]
+  commitWeeks: number[] // last 26 weeks of commit counts
+  createdAt: string
+  pushedAt: string
+}
+
 export interface MapTile {
   type: string
   color: string

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -214,6 +214,80 @@ app.get('/repo/:owner/:name', async (c) => {
   return c.json(data)
 })
 
+// GET /api/github/meta/:owner/:name — fetch repo meta: stars, languages, topics, contributors, commit history
+app.get('/meta/:owner/:name', async (c) => {
+  const owner = c.req.param('owner')
+  const name = c.req.param('name')
+  const fullName = `${owner}/${name}`
+
+  // Fetch repo info + languages + topics via GraphQL
+  const graphqlQuery = `{
+    repository(owner: "${owner}", name: "${name}") {
+      stargazerCount
+      forkCount
+      watchers { totalCount }
+      createdAt
+      pushedAt
+      primaryLanguage { name color }
+      languages(first: 10, orderBy: { field: SIZE, direction: DESC }) {
+        totalSize
+        edges {
+          size
+          node { name color }
+        }
+      }
+      repositoryTopics(first: 15) {
+        nodes { topic { name } }
+      }
+    }
+  }`
+
+  const repoResult = gh(['api', 'graphql', '-f', `query=${graphqlQuery}`])
+
+  // Fetch top contributors
+  const contributorsResult = gh(['api', `repos/${fullName}/contributors?per_page=5&anon=false`])
+
+  // Fetch weekly commit activity (last 52 weeks)
+  const commitActivityResult = gh(['api', `repos/${fullName}/stats/commit_activity`])
+
+  const repoData = repoResult.data?.data?.repository
+
+  // Build languages array with percentages
+  const totalSize: number = repoData?.languages?.totalSize || 1
+  const languages = (repoData?.languages?.edges || []).map((edge: any) => ({
+    name: edge.node.name,
+    color: edge.node.color || '#8b8b8b',
+    percentage: Math.round((edge.size / totalSize) * 1000) / 10,
+  }))
+
+  // Topics
+  const topics = (repoData?.repositoryTopics?.nodes || []).map((n: any) => n.topic.name)
+
+  // Contributors
+  const contributors = (contributorsResult.data || []).slice(0, 5).map((u: any) => ({
+    login: u.login,
+    avatarUrl: u.avatar_url,
+    contributions: u.contributions,
+  }))
+
+  // Commit weeks — last 26 weeks (commitActivity gives 52 weeks of {week, total, days[]})
+  const allWeeks: any[] = commitActivityResult.data || []
+  const commitWeeks = allWeeks.slice(-26).map((w: any) => w.total || 0)
+
+  return c.json({
+    stars: repoData?.stargazerCount ?? 0,
+    forks: repoData?.forkCount ?? 0,
+    watchers: repoData?.watchers?.totalCount ?? 0,
+    primaryLanguage: repoData?.primaryLanguage ?? null,
+    languages,
+    topics,
+    contributors,
+    commitWeeks,
+    createdAt: repoData?.createdAt ?? '',
+    pushedAt: repoData?.pushedAt ?? '',
+  })
+})
+
 // GET /api/github/labels/:owner/:name — list available labels for a repo
 app.get('/labels/:owner/:name', async (c) => {
   const owner = c.req.param('owner')


### PR DESCRIPTION
Closes #117

Decorates each battlefield base with a compact repo intel strip showing stars, primary language, forks always, and on expand: commit sparkline, language breakdown, topics, and top contributors.

Generated with [Claude Code](https://claude.ai/code)