### PR TITLE
fix: Save button broken - displays as '&#25ce; SAVE'

### DIFF
--- a/gh-ctrl/client/src/components/MapEditor.tsx
+++ b/gh-ctrl/client/src/components/MapEditor.tsx
@@ -802,7 +802,7 @@ export function MapEditor() {
             onClick={handleSave}
             disabled={!currentMap || !isDirty || isSaving}
           >
-            {isSaving ? '◌ SAVING...' : '&#x25ce; SAVE'}
+            {isSaving ? '◌ SAVING...' : '◎ SAVE'}
           </button>
           <button
             className="hud-btn"


### PR DESCRIPTION
Fixes #143

The Save button in MapEditor was rendering as `&#25ce; SAVE` instead of `◎ SAVE`.

**Root cause:** The HTML entity `&#25ce;` was used inside a JavaScript string literal in JSX, where HTML entities are not decoded.

**Fix:** Replaced the HTML entity with the direct Unicode character `◎` (U+25CE BULLSEYE).

Generated with [Claude Code](https://claude.ai/code)