### PR TITLE
fix: normalize project name via GitHub API to prevent duplicate bypass via URL

### DIFF
--- a/gh-ctrl/client/src/components/Settings.tsx
+++ b/gh-ctrl/client/src/components/Settings.tsx
@@ -137,8 +137,8 @@ export function Settings() {
     e.preventDefault()
     setFormError('')
 
-    if (!fullName.includes('/')) {
-      setFormError('Format must be owner/repo')
+    if (!fullName.trim()) {
+      setFormError('Enter owner/repo or a GitHub URL')
       return
     }
 
@@ -214,7 +214,7 @@ export function Settings() {
               <input
                 className="input"
                 type="text"
-                placeholder="owner/repo"
+                placeholder="owner/repo or GitHub URL"
                 value={fullName}
                 onChange={(e) => setFullName(e.target.value)}
               />

--- a/gh-ctrl/src/routes/repos.ts
+++ b/gh-ctrl/src/routes/repos.ts
@@ -16,23 +16,32 @@ app.post('/', async (c) => {
   const body = await c.req.json()
   const { fullName, color, description } = body
 
-  if (!fullName || !fullName.includes('/')) {
-    return c.json({ error: 'fullName must be in "owner/repo" format' }, 400)
+  if (!fullName) {
+    return c.json({ error: 'fullName must be in "owner/repo" format or a GitHub URL' }, 400)
   }
 
-  const [owner, name] = fullName.split('/')
-
-  // Validate repo exists via gh CLI
-  const check = Bun.spawnSync(['gh', 'repo', 'view', fullName, '--json', 'name'])
+  // Validate repo exists via gh CLI and get canonical nameWithOwner
+  // This also normalizes URLs (e.g. https://github.com/owner/repo) to owner/repo format
+  const check = Bun.spawnSync(['gh', 'repo', 'view', fullName, '--json', 'nameWithOwner'])
   if (check.exitCode !== 0) {
     return c.json({ error: 'Repository not found on GitHub' }, 404)
   }
+
+  let canonicalFullName: string
+  try {
+    const ghData = JSON.parse(check.stdout.toString())
+    canonicalFullName = ghData.nameWithOwner
+  } catch {
+    return c.json({ error: 'Failed to parse GitHub API response' }, 500)
+  }
+
+  const [owner, name] = canonicalFullName.split('/')
 
   try {
     const result = await db.insert(repos).values({
       owner,
       name,
-      fullName,
+      fullName: canonicalFullName,
       description: description || null,
       color: color || '#00ff88',
     }).returning()


### PR DESCRIPTION
When adding a project via URL, the stored fullName was the raw URL string rather than the canonical owner/repo format, bypassing the UNIQUE constraint.

Now uses `gh repo view` with `--json nameWithOwner` to resolve the canonical owner/repo name regardless of whether the user provides a name or URL.

Fixes #142

Generated with [Claude Code](https://claude.ai/code)