### PR TITLE
fix: return 401 with clear auth error when gh CLI is unauthenticated

### DIFF
--- a/gh-ctrl/src/routes/repos.ts
+++ b/gh-ctrl/src/routes/repos.ts
@@ -25,6 +25,11 @@ app.post('/', async (c) => {
   // Validate repo exists via gh CLI
   const check = Bun.spawnSync(['gh', 'repo', 'view', fullName, '--json', 'name'])
   if (check.exitCode !== 0) {
+    const stderr = check.stderr.toString()
+    const isAuthError = /not logged in|auth login|authentication|401|403|credentials|token/i.test(stderr)
+    if (isAuthError) {
+      return c.json({ error: 'Not authenticated with GitHub CLI. Please run "gh auth login" to authenticate.' }, 401)
+    }
     return c.json({ error: 'Repository not found on GitHub' }, 404)
   }
 


### PR DESCRIPTION
When adding a project via the gh CLI without authentication, the command was returning a generic 404 "Repository not found" error. This fix detects authentication-related error patterns in gh's stderr and returns a 401 with a clear message directing the user to run `gh auth login`.

Closes #141

Generated with [Claude Code](https://claude.ai/code)