### PR TITLE
fix: battlefield bases hidden when refreshing

### DIFF
--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -416,11 +416,11 @@ export function BattlefieldView() {
     setPositions(prev => {
       const stored = loadPositions()
       const defaults = getDefaultPositions(entries)
-      // Priority: in-memory (prev) > stored (localStorage) > defaults
-      const merged = { ...defaults, ...stored, ...prev }
-      const valid: Record<number, Position> = {}
-      entries.forEach(e => { valid[e.repo.id] = merged[e.repo.id] ?? defaults[e.repo.id] })
-      return valid
+      // Preserve ALL known positions so ghost nodes for pending repos stay at their
+      // saved spots during streaming. Filtering to only current entries was causing
+      // ghost nodes to jump to default fallback positions when the user had panned away.
+      // Priority: in-memory (prev) > stored (localStorage) > computed defaults
+      return { ...defaults, ...stored, ...prev }
     })
   }, [entries])
 


### PR DESCRIPTION
Fixes #138

During SSE streaming, entries arrive one at a time. The positions effect was filtering state to only include repos already in entries, dropping positions for pending repos. Ghost nodes for those repos fell back to default grid positions, appearing "hidden" if the user had panned/zoomed away from the default layout.

Fix: return the full merged position map so all known positions are preserved throughout the stream.

Generated with [Claude Code](https://claude.ai/code)