### PR TITLE
feat: color coding of internal vs external pull requests

### DIFF
--- a/gh-ctrl/client/src/components/ActionModal.tsx
+++ b/gh-ctrl/client/src/components/ActionModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import type { GHLabel, IssueDetail, PRDetail } from '../types'
+import { getPROrigin } from '../types'
 import { api } from '../api'
 import { MarkdownContent } from './MarkdownContent'
 import { VoiceButton } from './VoiceButton'
@@ -734,6 +735,9 @@ function PRDetailView({ state, onClose, onError, onTransition }: {
             <h3 className="issue-detail-title">{pr.title}</h3>
             <div className="issue-detail-meta">
               <span className="issue-meta-author">opened by <strong>{pr.author.login}</strong></span>
+              {getPROrigin(pr) === 'external' && (
+                <span className="badge badge-external" title={`Author association: ${pr.authorAssociation ?? 'unknown'}`}>External Contributor</span>
+              )}
               <span className="issue-meta-date">on {formatDate(pr.createdAt)}</span>
               <span>{pr.headRefName} → {pr.baseRefName}</span>
               {pr.isDraft && <span>· Draft</span>}

--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import type { DashboardEntry, GHPR, GHIssue, Branch, WorkflowRun, RepoMeta } from '../types'
+import { getPROrigin } from '../types'
 import type { ModalState } from './ActionModal'
 import { CloseIcon, LinkIcon, LabelIcon, CommentIcon, RefreshIcon, ExternalLinkIcon, AssigneeIcon } from './Icons'
 import { api } from '../api'
@@ -760,6 +761,7 @@ function PRBuilding({ pr, position, repo, onModalOpen }: {
   const isApproved = pr.reviewDecision === 'APPROVED'
   const isReviewRequired = pr.reviewDecision === 'REVIEW_REQUIRED'
 
+  const isExternal = getPROrigin(pr) === 'external'
   const prColor = isConflict || isChangesRequested
     ? 'var(--crt-red)'
     : isApproved
@@ -768,6 +770,8 @@ function PRBuilding({ pr, position, repo, onModalOpen }: {
     ? 'var(--crt-amber)'
     : pr.isDraft
     ? 'var(--chrome-silver)'
+    : isExternal
+    ? 'var(--blue)'
     : repo.color
 
   const statusLabel = pr.isDraft ? 'DRAFT'
@@ -775,6 +779,7 @@ function PRBuilding({ pr, position, repo, onModalOpen }: {
     : isChangesRequested ? 'CHANGES'
     : isApproved ? 'APPROVED'
     : isReviewRequired ? 'REVIEW'
+    : isExternal ? 'EXT'
     : 'OPEN'
 
   const shortTitle = pr.title.length > 14 ? pr.title.slice(0, 12) + '…' : pr.title

--- a/gh-ctrl/client/src/components/RepoCard.tsx
+++ b/gh-ctrl/client/src/components/RepoCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { DashboardEntry, GHPR, GHIssue, Branch, WorkflowRun, ClaudeIssuePRInfo } from '../types'
+import { getPROrigin } from '../types'
 import { api } from '../api'
 import { ActionModal } from './ActionModal'
 import type { ModalState } from './ActionModal'
@@ -192,6 +193,7 @@ export function RepoCard({ entry }: Props) {
                   assignees={pr.assignees}
                   badge={<span className="badge badge-conflict">Conflict</span>}
                   previewUrl={pr.previewUrl}
+                  prOrigin={getPROrigin(pr)}
                   onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
@@ -214,6 +216,7 @@ export function RepoCard({ entry }: Props) {
                   assignees={pr.assignees}
                   badge={<span className="badge badge-review">Review</span>}
                   previewUrl={pr.previewUrl}
+                  prOrigin={getPROrigin(pr)}
                   onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
@@ -265,6 +268,7 @@ export function RepoCard({ entry }: Props) {
                   assignees={pr.assignees}
                   badge={pr.isDraft ? <span className="badge badge-draft">Draft</span> : pr.reviewDecision === 'APPROVED' ? <span className="badge badge-approved">Approved</span> : undefined}
                   previewUrl={pr.previewUrl}
+                  prOrigin={getPROrigin(pr)}
                   onClaude={() => openTriggerClaude(pr.number, 'pr')}
                   onComment={() => openComment(pr.number, 'pr')}
                   onLabel={() => openLabel(pr.number, 'pr', pr.labels.map((l) => l.name))}
@@ -360,7 +364,7 @@ function labelTextColor(hex: string): string {
 }
 
 function ItemRow({
-  number, title, labels, assignees, badge, previewUrl, isClaudeActive, isUntouched, onClaude, onComment, onLabel, onAssignee, onDetail, onCreatePR,
+  number, title, labels, assignees, badge, previewUrl, isClaudeActive, isUntouched, prOrigin, onClaude, onComment, onLabel, onAssignee, onDetail, onCreatePR,
 }: {
   number: number
   title: string
@@ -370,6 +374,7 @@ function ItemRow({
   previewUrl?: string | null
   isClaudeActive?: boolean
   isUntouched?: boolean
+  prOrigin?: 'internal' | 'external'
   onClaude: () => void
   onComment: () => void
   onLabel: () => void
@@ -377,8 +382,9 @@ function ItemRow({
   onDetail?: () => void
   onCreatePR?: () => void
 }) {
+  const originClass = prOrigin ? ` pr-${prOrigin}` : ''
   return (
-    <div className={`list-item${isUntouched ? ' untouched-issue' : ''}`}>
+    <div className={`list-item${isUntouched ? ' untouched-issue' : ''}${originClass}`}>
       <div className="list-item-left">
         <span className="list-item-number">#{number}</span>
         {isClaudeActive && (
@@ -418,6 +424,9 @@ function ItemRow({
         )}
       </div>
       <div className="list-item-right">
+        {prOrigin === 'external' && (
+          <span className="badge badge-external" title="External contributor">EXT</span>
+        )}
         {badge}
         {previewUrl && (
           <a

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -414,6 +414,20 @@ a:hover { text-decoration: underline; }
   color: var(--amber);
 }
 
+.badge-external {
+  background: rgba(88, 166, 255, 0.15);
+  color: var(--blue);
+  border: 1px solid rgba(88, 166, 255, 0.3);
+}
+
+.pr-external {
+  border-left: 3px solid var(--blue);
+}
+
+.pr-internal {
+  border-left: 3px solid var(--green-neon);
+}
+
 .item-claude-btn {
   opacity: 0;
   transition: opacity 0.15s;

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -8,6 +8,14 @@ export interface Repo {
   createdAt: string | number | null
 }
 
+export type AuthorAssociation = 'OWNER' | 'MEMBER' | 'COLLABORATOR' | 'CONTRIBUTOR' | 'FIRST_TIME_CONTRIBUTOR' | 'FIRST_TIMER' | 'NONE'
+export type PROrigin = 'internal' | 'external'
+
+export function getPROrigin(pr: { authorAssociation?: AuthorAssociation }): PROrigin {
+  const internal: AuthorAssociation[] = ['OWNER', 'MEMBER', 'COLLABORATOR']
+  return pr.authorAssociation && internal.includes(pr.authorAssociation) ? 'internal' : 'external'
+}
+
 export interface GHPR {
   number: number
   title: string
@@ -21,6 +29,7 @@ export interface GHPR {
   labels: { name: string; color: string }[]
   isDraft: boolean
   assignees: { login: string }[]
+  authorAssociation?: AuthorAssociation
   previewUrl?: string | null
 }
 
@@ -119,6 +128,7 @@ export interface PRDetail {
   headRefName: string
   baseRefName: string
   isDraft: boolean
+  authorAssociation?: AuthorAssociation
   comments: { author: { login: string }; body: string; createdAt: string }[]
 }
 

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -174,7 +174,7 @@ async function fetchRepoData(fullName: string) {
   const [prResult, issueResult] = await Promise.all([
     gh([
       'pr', 'list', '--repo', fullName, '--json',
-      'number,title,state,reviewDecision,mergeable,headRefName,author,createdAt,updatedAt,labels,isDraft,assignees',
+      'number,title,state,reviewDecision,mergeable,headRefName,author,createdAt,updatedAt,labels,isDraft,assignees,authorAssociation',
       '--limit', '30',
     ]),
     gh([
@@ -605,7 +605,7 @@ app.get('/pr/:owner/:name/:number', async (c) => {
 
   const result = await gh([
     'pr', 'view', number, '--repo', fullName,
-    '--json', 'number,title,body,state,labels,assignees,author,url,createdAt,comments,reviewDecision,mergeable,headRefName,baseRefName,isDraft',
+    '--json', 'number,title,body,state,labels,assignees,author,url,createdAt,comments,reviewDecision,mergeable,headRefName,baseRefName,isDraft,authorAssociation',
   ])
 
   if (result.error) return c.json({ error: result.error }, 500)


### PR DESCRIPTION
Implements visual color differentiation between internal PRs (team members/collaborators) and external PRs (outside contributors).

Closes #140

Generated with [Claude Code](https://claude.ai/code)