### PR TITLE
feat: visualize branches as buildings in Battlefield view

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -3,6 +3,7 @@ import type { DashboardEntry, GHPR, GHIssue, Branch, WorkflowRun, RepoMeta } fro
 import type { ModalState } from './ActionModal'
 import { CloseIcon, LinkIcon, LabelIcon, CommentIcon, RefreshIcon, ExternalLinkIcon, AssigneeIcon } from './Icons'
 import { api } from '../api'
+import { BranchBuilding, getBranchState } from './BranchBuilding'
 
 // ── Canvas color utilities ────────────────────────────────────────────────────
 
@@ -136,6 +137,11 @@ const PR_BUILDING_COL_WIDTH = 80
 const PR_BUILDING_ROW_HEIGHT = 100
 const MAX_PR_BUILDINGS = 8
 
+const BRANCH_BUILDING_OFFSET_X = -10
+const BRANCH_BUILDING_OFFSET_Y = 130
+const BRANCH_BUILDING_COL_WIDTH = 46
+const MAX_BRANCH_BUILDINGS = 10
+
 export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, onConstruct, onStartRelocate, onRefreshRepo, onToast, onModalOpen }: Props) {
   const { repo, data } = entry
   const { stats } = data
@@ -184,6 +190,15 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
   }, [isRelocateMode])
 
   const visiblePRs = data.prs.slice(0, MAX_PR_BUILDINGS)
+
+  // Branch buildings: exclude default branch, sort stale first, cap at MAX_BRANCH_BUILDINGS
+  const nonDefaultBranches = (data.branches ?? []).filter(b => b.name !== (data.defaultBranch ?? 'main'))
+  const sortedBranches = [...nonDefaultBranches].sort((a, b) => {
+    const stateOrder = { 'very-stale': 0, 'stale': 1, 'active': 2 }
+    return stateOrder[getBranchState(a.committedDate)] - stateOrder[getBranchState(b.committedDate)]
+  })
+  const visibleBranches = sortedBranches.slice(0, MAX_BRANCH_BUILDINGS)
+  const extraBranches = sortedBranches.length - visibleBranches.length
 
   return (
     <>
@@ -291,6 +306,30 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
           )}
         </div>
       </div>
+
+      {/* Branch buildings — rendered below base node in a row */}
+      {visibleBranches.map((branch, i) => (
+        <BranchBuilding
+          key={branch.name}
+          branch={branch}
+          position={{
+            x: position.x + BRANCH_BUILDING_OFFSET_X + i * BRANCH_BUILDING_COL_WIDTH,
+            y: position.y + BRANCH_BUILDING_OFFSET_Y,
+          }}
+          repoFullName={repo.fullName}
+        />
+      ))}
+      {extraBranches > 0 && (
+        <div
+          className="branch-overflow-label"
+          style={{
+            left: position.x + BRANCH_BUILDING_OFFSET_X + visibleBranches.length * BRANCH_BUILDING_COL_WIDTH,
+            top: position.y + BRANCH_BUILDING_OFFSET_Y + 10,
+          }}
+        >
+          +{extraBranches}
+        </div>
+      )}
 
       {/* Floating detail panel */}
       {showDetail && !isRelocateMode && (

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import type { DashboardEntry, GameMap, MapTile } from '../types'
 import { api } from '../api'
+import { getBranchState } from './BranchBuilding'
 import { BaseNode } from './BaseNode'
 import { ActionModal } from './ActionModal'
 import type { ModalState } from './ActionModal'
@@ -543,6 +544,16 @@ export function BattlefieldView() {
   const loadedFullNames = new Set(entries.map((e) => e.repo.fullName))
   const pendingRepos = loading ? repos.filter((r) => !loadedFullNames.has(r.fullName)) : []
 
+  // Stale branch counts across all repos
+  const staleBranchStats = entries.reduce((acc, e) => {
+    const defaultBranch = e.data.defaultBranch ?? 'main'
+    const nonDefault = (e.data.branches ?? []).filter(b => b.name !== defaultBranch)
+    const stale = nonDefault.filter(b => getBranchState(b.committedDate) === 'stale' || getBranchState(b.committedDate) === 'very-stale')
+    if (stale.length > 0) acc.repos++
+    acc.total += stale.length
+    return acc
+  }, { total: 0, repos: 0 })
+
 
   return (
     <div
@@ -567,6 +578,11 @@ export function BattlefieldView() {
           )}
           {totalRunningActions > 0 && (
             <span className="hud-stat hud-actions spinning-process" title="Running GitHub Actions across all bases">&#x2699; PROCESSES: <strong>{totalRunningActions}</strong></span>
+          )}
+          {staleBranchStats.total > 0 && (
+            <span className="hud-stat hud-stale-branches" title={`${staleBranchStats.total} stale branch(es) across ${staleBranchStats.repos} repo(s)`}>
+              &#x2387; STALE: <strong>{staleBranchStats.total}</strong>
+            </span>
           )}
           <button
             className="hud-btn"
@@ -810,10 +826,14 @@ function Minimap({ entries, positions, offset, zoom, onJump }: MinimapProps) {
         const pos = positions[entry.repo.id]
         if (!pos) return null
         const hasConflicts = entry.data.stats.conflicts > 0
+        const defaultBranch = entry.data.defaultBranch ?? 'main'
+        const hasStale = (entry.data.branches ?? []).some(
+          b => b.name !== defaultBranch && (getBranchState(b.committedDate) === 'stale' || getBranchState(b.committedDate) === 'very-stale')
+        )
         return (
           <div
             key={entry.repo.id}
-            className={`minimap-base${hasConflicts ? ' alert' : ''}`}
+            className={`minimap-base${hasConflicts ? ' alert' : hasStale ? ' stale' : ''}`}
             style={{
               left: toMiniX(pos.x),
               top: toMiniY(pos.y),

--- a/gh-ctrl/client/src/components/BranchBuilding.tsx
+++ b/gh-ctrl/client/src/components/BranchBuilding.tsx
@@ -1,0 +1,59 @@
+import type { Branch } from '../types'
+
+const STALE_THRESHOLD_DAYS = 30
+const VERY_STALE_THRESHOLD_DAYS = 90
+
+export type BranchState = 'active' | 'stale' | 'very-stale'
+
+export function getBranchState(committedDate: string): BranchState {
+  if (!committedDate) return 'stale'
+  const daysSince = (Date.now() - new Date(committedDate).getTime()) / (1000 * 60 * 60 * 24)
+  if (daysSince > VERY_STALE_THRESHOLD_DAYS) return 'very-stale'
+  if (daysSince > STALE_THRESHOLD_DAYS) return 'stale'
+  return 'active'
+}
+
+function getDaysSince(committedDate: string): number {
+  if (!committedDate) return 0
+  return Math.floor((Date.now() - new Date(committedDate).getTime()) / (1000 * 60 * 60 * 24))
+}
+
+interface BranchBuildingProps {
+  branch: Branch
+  position: { x: number; y: number }
+  repoFullName: string
+}
+
+export function BranchBuilding({ branch, position, repoFullName }: BranchBuildingProps) {
+  const state = getBranchState(branch.committedDate)
+  const daysSince = getDaysSince(branch.committedDate)
+  const commitDateStr = branch.committedDate
+    ? new Date(branch.committedDate).toLocaleDateString()
+    : 'unknown'
+
+  const tooltip = [
+    `⎇ ${branch.name}`,
+    `Last commit: ${commitDateStr}`,
+    daysSince > 0 ? `${daysSince} days ago` : 'Today',
+    state === 'very-stale' ? '⚠ Very stale branch' : state === 'stale' ? '⚠ Stale branch' : '✓ Active branch',
+  ].join('\n')
+
+  return (
+    <div
+      className={`branch-building branch-building-${state}`}
+      style={{ left: position.x, top: position.y }}
+      title={tooltip}
+      onClick={(e) => {
+        e.stopPropagation()
+        window.open(`https://github.com/${repoFullName}/tree/${encodeURIComponent(branch.name)}`, '_blank', 'noopener,noreferrer')
+      }}
+    >
+      <div className="branch-bld-tower">
+        <div className="branch-bld-top" />
+        <div className="branch-bld-body" />
+        <div className="branch-bld-base" />
+      </div>
+      <div className="branch-bld-label">{branch.name.length > 10 ? branch.name.slice(0, 9) + '…' : branch.name}</div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -2257,6 +2257,101 @@ select.input {
   font-style: italic;
 }
 
+/* ---- Branch Buildings ---- */
+.branch-building {
+  position: absolute;
+  width: 40px;
+  cursor: pointer;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  transition: z-index 0s;
+}
+
+.branch-building:hover {
+  z-index: 4;
+}
+
+.branch-bld-tower {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.5));
+  transition: filter 0.15s;
+}
+
+.branch-building:hover .branch-bld-tower {
+  filter: drop-shadow(0 3px 8px currentColor);
+}
+
+.branch-bld-top {
+  width: 4px;
+  height: 14px;
+  background: currentColor;
+  border-radius: 1px 1px 0 0;
+}
+
+.branch-bld-body {
+  width: 12px;
+  height: 18px;
+  background: currentColor;
+  opacity: 0.85;
+  clip-path: polygon(15% 0%, 85% 0%, 100% 100%, 0% 100%);
+}
+
+.branch-bld-base {
+  width: 22px;
+  height: 6px;
+  background: currentColor;
+  opacity: 0.6;
+  border-radius: 1px;
+}
+
+.branch-bld-label {
+  font-family: var(--font-mono);
+  font-size: 7px;
+  color: currentColor;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 40px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+.branch-building-active {
+  color: #00d4ff;
+}
+
+.branch-building-stale {
+  color: #ffaa00;
+}
+
+.branch-building-very-stale {
+  color: #ff4444;
+}
+
+.branch-building-very-stale .branch-bld-tower {
+  animation: blink 2s ease-in-out infinite;
+}
+
+.branch-overflow-label {
+  position: absolute;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: rgba(57, 255, 20, 0.6);
+  pointer-events: none;
+}
+
+/* HUD stale branch badge */
+.hud-stale-branches {
+  color: #ffaa00;
+}
+
 /* ---- Minimap ---- */
 .minimap {
   position: absolute;
@@ -2295,6 +2390,11 @@ select.input {
 
 .minimap-base.alert {
   animation: blink 1s ease-in-out infinite;
+}
+
+.minimap-base.stale {
+  outline: 1px solid #ffaa00;
+  outline-offset: 1px;
 }
 
 .minimap-viewport {

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -96,6 +96,8 @@ export interface RepoData {
   activeClaudeIssues: number[]
   claudeIssuePRLinks: Record<number, ClaudeIssuePRInfo>
   runningWorkflows: WorkflowRun[]
+  branches: Branch[]
+  defaultBranch: string
   error: string | null
 }
 

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -169,6 +169,43 @@ async function fetchRunningWorkflows(fullName: string): Promise<RunningWorkflows
   return { activeClaudeIssues: Array.from(activeIssues), runningWorkflows }
 }
 
+async function fetchRepoBranches(fullName: string): Promise<{ branches: { name: string; committedDate: string }[]; defaultBranch: string }> {
+  const [owner, name] = fullName.split('/')
+  const graphqlQuery = `{
+    repository(owner: "${owner}", name: "${name}") {
+      defaultBranchRef { name }
+      refs(refPrefix: "refs/heads/", first: 100) {
+        nodes {
+          name
+          target {
+            ... on Commit {
+              committedDate
+            }
+          }
+        }
+      }
+    }
+  }`
+  const result = await gh(['api', 'graphql', '-f', `query=${graphqlQuery}`])
+  if (result.error || !result.data?.data?.repository) {
+    return { branches: [], defaultBranch: 'main' }
+  }
+  const repo = result.data.data.repository
+  const defaultBranch: string = repo.defaultBranchRef?.name || 'main'
+  const branches = (repo.refs?.nodes || [])
+    .map((node: any) => ({
+      name: node.name,
+      committedDate: node.target?.committedDate || '',
+    }))
+    .sort((a: any, b: any) => {
+      if (!a.committedDate && !b.committedDate) return 0
+      if (!a.committedDate) return 1
+      if (!b.committedDate) return -1
+      return new Date(b.committedDate).getTime() - new Date(a.committedDate).getTime()
+    })
+  return { branches, defaultBranch }
+}
+
 async function fetchRepoData(fullName: string) {
   // PRs and issues are independent — fetch in parallel
   const [prResult, issueResult] = await Promise.all([
@@ -196,6 +233,8 @@ async function fetchRepoData(fullName: string) {
       activeClaudeIssues: [],
       claudeIssuePRLinks: {},
       runningWorkflows: [],
+      branches: [],
+      defaultBranch: 'main',
       error: prResult.error || issueResult.error,
     }
   }
@@ -204,10 +243,11 @@ async function fetchRepoData(fullName: string) {
   const issues = issueResult.data || []
 
   // Netlify URLs depend on prs, but workflows and branches are independent
-  const [previewUrls, { activeClaudeIssues, runningWorkflows }, claudeIssueBranches] = await Promise.all([
+  const [previewUrls, { activeClaudeIssues, runningWorkflows }, claudeIssueBranches, { branches, defaultBranch }] = await Promise.all([
     fetchNetlifyUrls(fullName, prs),
     fetchRunningWorkflows(fullName),
     fetchClaudeIssueBranches(fullName),
+    fetchRepoBranches(fullName),
   ])
 
   const enrichedPrs = prs.map((pr: any) => ({
@@ -251,6 +291,8 @@ async function fetchRepoData(fullName: string) {
     activeClaudeIssues,
     claudeIssuePRLinks,
     runningWorkflows,
+    branches,
+    defaultBranch,
     error: null,
   }
 }


### PR DESCRIPTION
Implements branch visualization as isometric tower buildings in the Battlefield view.

- Backend fetches branches in parallel with the dashboard stream
- Each non-default branch rendered as a small tower below the repo base node
- Color-coded: cyan=active, amber=stale (30d+), red=very-stale (90d+)
- Stale branches sorted first, capped at 10 with overflow count
- HUD badge shows total stale branch count
- Minimap dots show amber outline for repos with stale branches

Closes #139

Generated with [Claude Code](https://claude.ai/code)