### PR TITLE
feat: add global Intel FeedPanel to battlefield

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta } from './types'
+import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData } from './types'
 
 const BASE = '/api'
 
@@ -217,4 +217,6 @@ export const api = {
 
   deleteMap: (id: number) =>
     request<{ ok: boolean }>(`/maps/${id}`, { method: 'DELETE' }),
+
+  getFeed: () => request<FeedData>('/github/feed'),
 }

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -8,6 +8,7 @@ import type { ModalState } from './ActionModal'
 import { ConstructDialog } from './ConstructDialog'
 import { CreateBaseDialog } from './CreateBaseDialog'
 import { CloseIcon, RelocateIcon, RefreshIcon } from './Icons'
+import { FeedPanel } from './FeedPanel'
 import { useSound } from '../hooks/useSound'
 import { useAppStore } from '../store'
 
@@ -355,6 +356,7 @@ export function BattlefieldView() {
   const [activeMap, setActiveMap] = useState<GameMap | null>(null)
   const [allMaps, setAllMaps] = useState<GameMap[]>([])
   const [showMapSelector, setShowMapSelector] = useState(false)
+  const [showFeedPanel, setShowFeedPanel] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const zoomRef = useRef(zoom)
   const offsetRef = useRef(offset)
@@ -663,6 +665,14 @@ export function BattlefieldView() {
             </button>
           )}
           <span className="hud-zoom-sep" />
+          <button
+            className={`hud-btn${showFeedPanel ? ' active' : ''}`}
+            onClick={() => { play('peep'); setShowFeedPanel(v => !v) }}
+            title="Toggle Intel Feed panel"
+          >
+            ◈ FEED
+          </button>
+          <span className="hud-zoom-sep" />
           <button className="hud-btn hud-zoom-btn" onClick={handleZoomOut} disabled={zoom <= ZOOM_MIN} title="Zoom out">−</button>
           <span className="hud-zoom-level" title="Click to reset zoom" onClick={handleZoomReset}>{Math.round(zoom * 100)}%</span>
           <button className="hud-btn hud-zoom-btn" onClick={handleZoomIn} disabled={zoom >= ZOOM_MAX} title="Zoom in">+</button>
@@ -809,6 +819,13 @@ export function BattlefieldView() {
           onClose={() => setShowMapSelector(false)}
         />
       )}
+
+      {/* Intel Feed Panel */}
+      <FeedPanel
+        entries={entries}
+        isOpen={showFeedPanel}
+        onClose={() => setShowFeedPanel(false)}
+      />
     </div>
   )
 }

--- a/gh-ctrl/client/src/components/FeedPanel.tsx
+++ b/gh-ctrl/client/src/components/FeedPanel.tsx
@@ -1,0 +1,170 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { DashboardEntry, FeedItem } from '../types'
+import { api } from '../api'
+
+type FeedTab = 'mentions' | 'issues' | 'prs'
+
+interface FeedPanelProps {
+  entries: DashboardEntry[]
+  isOpen: boolean
+  onClose: () => void
+}
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.floor(hrs / 24)
+  return `${days}d ago`
+}
+
+function FeedItemRow({ item }: { item: FeedItem }) {
+  const typeIcon = item.type === 'pr' ? '⎇' : '●'
+  const typeClass = item.type === 'pr' ? 'feed-item-pr' : 'feed-item-issue'
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`feed-item ${typeClass}`}
+      title={`${item.repo}#${item.number}`}
+    >
+      <span className="feed-item-icon">{typeIcon}</span>
+      <div className="feed-item-body">
+        <div className="feed-item-title">{item.title}</div>
+        <div className="feed-item-meta">
+          <span className="feed-item-repo">{item.repo.split('/')[1] ?? item.repo}</span>
+          <span className="feed-item-num">#{item.number}</span>
+          {item.isDraft && <span className="feed-item-draft">DRAFT</span>}
+          {item.labels.slice(0, 2).map((l) => (
+            <span
+              key={l.name}
+              className="feed-item-label"
+              style={{ borderColor: `#${l.color}`, color: `#${l.color}` }}
+            >
+              {l.name}
+            </span>
+          ))}
+          <span className="feed-item-time">{timeAgo(item.updatedAt)}</span>
+        </div>
+      </div>
+    </a>
+  )
+}
+
+export function FeedPanel({ entries, isOpen, onClose }: FeedPanelProps) {
+  const [activeTab, setActiveTab] = useState<FeedTab>('mentions')
+  const [mentions, setMentions] = useState<FeedItem[]>([])
+  const [mentionsLoading, setMentionsLoading] = useState(false)
+  const [mentionsError, setMentionsError] = useState<string | null>(null)
+
+  const fetchMentions = useCallback(() => {
+    setMentionsLoading(true)
+    setMentionsError(null)
+    api.getFeed()
+      .then((data) => setMentions(data.mentions))
+      .catch((err) => setMentionsError(err.message ?? 'Failed to load mentions'))
+      .finally(() => setMentionsLoading(false))
+  }, [])
+
+  useEffect(() => {
+    if (isOpen && activeTab === 'mentions') {
+      fetchMentions()
+    }
+  }, [isOpen, activeTab, fetchMentions])
+
+  // Aggregate open issues from all entries
+  const allIssues: FeedItem[] = entries.flatMap((entry) =>
+    entry.data.issues.map((issue) => ({
+      type: 'issue' as const,
+      feedCategory: 'issue' as const,
+      number: issue.number,
+      title: issue.title,
+      url: `https://github.com/${entry.repo.fullName}/issues/${issue.number}`,
+      repo: entry.repo.fullName,
+      author: issue.author?.login ?? 'unknown',
+      updatedAt: issue.updatedAt,
+      labels: issue.labels,
+      state: issue.state,
+    }))
+  ).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+
+  // Aggregate open PRs from all entries
+  const allPRs: FeedItem[] = entries.flatMap((entry) =>
+    entry.data.prs.map((pr) => ({
+      type: 'pr' as const,
+      feedCategory: 'pr' as const,
+      number: pr.number,
+      title: pr.title,
+      url: `https://github.com/${entry.repo.fullName}/pull/${pr.number}`,
+      repo: entry.repo.fullName,
+      author: pr.author?.login ?? 'unknown',
+      updatedAt: pr.updatedAt,
+      labels: pr.labels,
+      isDraft: pr.isDraft,
+      state: pr.state,
+    }))
+  ).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+
+  const tabCounts = {
+    mentions: mentions.length,
+    issues: allIssues.length,
+    prs: allPRs.length,
+  }
+
+  const tabItems: Record<FeedTab, FeedItem[]> = {
+    mentions,
+    issues: allIssues,
+    prs: allPRs,
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="feed-panel" onMouseDown={(e) => e.stopPropagation()}>
+      <div className="feed-panel-header">
+        <span className="feed-panel-title">◈ INTEL FEED</span>
+        <button className="feed-panel-close" onClick={onClose} title="Close feed">✕</button>
+      </div>
+
+      <div className="feed-panel-tabs">
+        {(['mentions', 'issues', 'prs'] as FeedTab[]).map((tab) => (
+          <button
+            key={tab}
+            className={`feed-tab${activeTab === tab ? ' active' : ''}`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab === 'mentions' ? '@MENTIONS' : tab === 'issues' ? 'ISSUES' : 'PRS'}
+            {tabCounts[tab] > 0 && (
+              <span className="feed-tab-count">{tabCounts[tab]}</span>
+            )}
+          </button>
+        ))}
+        {activeTab === 'mentions' && (
+          <button className="feed-refresh-btn" onClick={fetchMentions} disabled={mentionsLoading} title="Refresh mentions">
+            {mentionsLoading ? '◌' : '↻'}
+          </button>
+        )}
+      </div>
+
+      <div className="feed-panel-body">
+        {activeTab === 'mentions' && mentionsLoading && (
+          <div className="feed-loading">◌ SCANNING MENTIONS...</div>
+        )}
+        {activeTab === 'mentions' && mentionsError && !mentionsLoading && (
+          <div className="feed-error">⚠ {mentionsError}</div>
+        )}
+        {tabItems[activeTab].length === 0 && !mentionsLoading && !mentionsError && (
+          <div className="feed-empty">
+            {activeTab === 'mentions' ? 'No open @mentions found.' : activeTab === 'issues' ? 'No open issues across tracked repos.' : 'No open PRs across tracked repos.'}
+          </div>
+        )}
+        {tabItems[activeTab].map((item) => (
+          <FeedItemRow key={`${item.repo}-${item.type}-${item.number}`} item={item} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -3714,3 +3714,242 @@ select.input {
   white-space: nowrap;
   max-width: 90px;
 }
+
+/* ── FeedPanel ──────────────────────────────────────────────────────────────── */
+
+.feed-panel {
+  position: absolute;
+  top: 56px;
+  right: 0;
+  width: 340px;
+  height: calc(100vh - 56px);
+  background: rgba(5, 8, 9, 0.97);
+  border-left: 1px solid rgba(57, 255, 20, 0.3);
+  display: flex;
+  flex-direction: column;
+  z-index: 20;
+  font-family: var(--font-mono);
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.6);
+}
+
+.feed-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid rgba(57, 255, 20, 0.2);
+  flex-shrink: 0;
+}
+
+.feed-panel-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  color: var(--crt-green);
+  text-shadow: 0 0 8px var(--crt-green);
+}
+
+.feed-panel-close {
+  background: transparent;
+  border: none;
+  color: var(--text-2);
+  font-size: 13px;
+  cursor: pointer;
+  padding: 2px 4px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.feed-panel-close:hover {
+  color: var(--crt-green);
+}
+
+.feed-panel-tabs {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid rgba(57, 255, 20, 0.15);
+  flex-shrink: 0;
+}
+
+.feed-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-2);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  padding: 8px 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.feed-tab:hover {
+  color: var(--crt-green);
+}
+
+.feed-tab.active {
+  color: var(--crt-green);
+  border-bottom-color: var(--crt-green);
+}
+
+.feed-tab-count {
+  background: rgba(57, 255, 20, 0.15);
+  color: var(--crt-green);
+  border-radius: 8px;
+  padding: 1px 5px;
+  font-size: 9px;
+}
+
+.feed-refresh-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-2);
+  font-size: 14px;
+  cursor: pointer;
+  padding: 4px 8px;
+  margin-left: auto;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.feed-refresh-btn:hover {
+  color: var(--crt-green);
+}
+
+.feed-refresh-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.feed-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.feed-panel-body::-webkit-scrollbar {
+  width: 4px;
+}
+
+.feed-panel-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.feed-panel-body::-webkit-scrollbar-thumb {
+  background: rgba(57, 255, 20, 0.2);
+  border-radius: 2px;
+}
+
+.feed-loading,
+.feed-empty,
+.feed-error {
+  padding: 24px 16px;
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-align: center;
+  color: var(--text-2);
+}
+
+.feed-error {
+  color: var(--crt-red);
+}
+
+.feed-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid rgba(57, 255, 20, 0.07);
+  text-decoration: none;
+  transition: background 0.12s;
+  cursor: pointer;
+}
+
+.feed-item:hover {
+  background: rgba(57, 255, 20, 0.05);
+}
+
+.feed-item-icon {
+  font-size: 12px;
+  margin-top: 1px;
+  flex-shrink: 0;
+}
+
+.feed-item-pr .feed-item-icon {
+  color: #a78bfa;
+}
+
+.feed-item-issue .feed-item-icon {
+  color: #4ade80;
+}
+
+.feed-item-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.feed-item-title {
+  font-size: 11px;
+  color: var(--text-1, #e2e8f0);
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  letter-spacing: 0.3px;
+}
+
+.feed-item:hover .feed-item-title {
+  color: var(--crt-green);
+}
+
+.feed-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 3px;
+  flex-wrap: wrap;
+}
+
+.feed-item-repo {
+  font-size: 9px;
+  color: var(--text-2);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.feed-item-num {
+  font-size: 9px;
+  color: var(--text-2);
+}
+
+.feed-item-draft {
+  font-size: 8px;
+  letter-spacing: 1px;
+  background: rgba(148, 163, 184, 0.15);
+  color: #94a3b8;
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+
+.feed-item-label {
+  font-size: 8px;
+  letter-spacing: 0.5px;
+  border: 1px solid;
+  padding: 0 4px;
+  border-radius: 2px;
+  max-width: 70px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.feed-item-time {
+  font-size: 9px;
+  color: var(--text-2);
+  margin-left: auto;
+  flex-shrink: 0;
+}

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -172,6 +172,24 @@ export interface RepoMeta {
   pushedAt: string
 }
 
+export interface FeedItem {
+  type: 'issue' | 'pr'
+  feedCategory: 'mention' | 'issue' | 'pr'
+  number: number
+  title: string
+  url: string
+  repo: string
+  author: string
+  updatedAt: string
+  labels: { name: string; color: string }[]
+  isDraft?: boolean
+  state?: string
+}
+
+export interface FeedData {
+  mentions: FeedItem[]
+}
+
 export interface MapTile {
   type: string
   color: string

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -833,4 +833,30 @@ app.get('/user-repos', async (c) => {
   return c.json({ repos: repoList, page, perPage, total, truncated, ghAvailable: true })
 })
 
+// GET /api/github/feed — global feed: @mentions via GitHub search API
+app.get('/feed', async (c) => {
+  const result = await gh(['api', 'search/issues?q=mentions%3A%40me+state%3Aopen&per_page=50'])
+
+  if (result.error) {
+    return c.json({ mentions: [], error: result.error })
+  }
+
+  const items: any[] = result.data?.items ?? []
+  const mentions = items.map((item: any) => ({
+    type: item.pull_request ? 'pr' : 'issue',
+    feedCategory: 'mention',
+    number: item.number,
+    title: item.title,
+    url: item.html_url,
+    repo: (item.repository_url ?? '').replace('https://api.github.com/repos/', ''),
+    author: item.user?.login ?? 'unknown',
+    updatedAt: item.updated_at ?? '',
+    labels: (item.labels ?? []).map((l: any) => ({ name: l.name, color: l.color })),
+    isDraft: item.draft ?? false,
+    state: item.state ?? 'open',
+  }))
+
+  return c.json({ mentions })
+})
+
 export default app


### PR DESCRIPTION
Implements a collapsible side panel on the battlefield that aggregates @mentions, open issues, and open PRs across all tracked repos.

Closes #178

Generated with [Claude Code](https://claude.ai/code)