### PR TITLE
feat: add branch hover popover with behind/ahead info

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -62,6 +62,9 @@ export const api = {
   getBranches: (owner: string, name: string) =>
     request<BranchesData>(`/github/branches/${owner}/${name}`),
 
+  getBranchCompare: (owner: string, repoName: string, branch: string, base: string) =>
+    request<{ ahead: number; behind: number }>(`/github/branch-compare/${owner}/${repoName}/${encodeURIComponent(branch)}?base=${encodeURIComponent(base)}`),
+
   getRepoMeta: (owner: string, name: string) =>
     request<RepoMeta>(`/github/meta/${owner}/${name}`),
 

--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -323,6 +323,7 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
               y: position.y + BRANCH_BUILDING_OFFSET_Y + row * BRANCH_BUILDING_ROW_HEIGHT,
             }}
             repoFullName={repo.fullName}
+            defaultBranch={data.defaultBranch ?? 'main'}
           />
         )
       })}

--- a/gh-ctrl/client/src/components/BranchBuilding.tsx
+++ b/gh-ctrl/client/src/components/BranchBuilding.tsx
@@ -1,5 +1,6 @@
-import { useRef, useEffect } from 'react'
+import { useRef, useEffect, useState, useCallback } from 'react'
 import type { Branch } from '../types'
+import { api } from '../api'
 
 const STALE_THRESHOLD_DAYS = 30
 const VERY_STALE_THRESHOLD_DAYS = 90
@@ -82,27 +83,47 @@ interface BranchBuildingProps {
   branch: Branch
   position: { x: number; y: number }
   repoFullName: string
+  defaultBranch: string
 }
 
-export function BranchBuilding({ branch, position, repoFullName }: BranchBuildingProps) {
+interface CompareData {
+  ahead: number
+  behind: number
+}
+
+export function BranchBuilding({ branch, position, repoFullName, defaultBranch }: BranchBuildingProps) {
   const state = getBranchState(branch.committedDate)
   const daysSince = getDaysSince(branch.committedDate)
   const commitDateStr = branch.committedDate
     ? new Date(branch.committedDate).toLocaleDateString()
     : 'unknown'
 
-  const tooltip = [
-    `⎇ ${branch.name}`,
-    `Last commit: ${commitDateStr}`,
-    daysSince > 0 ? `${daysSince} days ago` : 'Today',
-    state === 'very-stale' ? '⚠ Very stale branch' : state === 'stale' ? '⚠ Stale branch' : '✓ Active branch',
-  ].join('\n')
+  const [compare, setCompare] = useState<CompareData | null>(null)
+  const [compareLoading, setCompareLoading] = useState(false)
+  const fetchedRef = useRef(false)
+
+  const handleMouseEnter = useCallback(() => {
+    if (fetchedRef.current) return
+    fetchedRef.current = true
+    setCompareLoading(true)
+    const [owner, name] = repoFullName.split('/')
+    api.getBranchCompare(owner, name, branch.name, defaultBranch)
+      .then(data => setCompare(data))
+      .catch(() => { /* silently ignore */ })
+      .finally(() => setCompareLoading(false))
+  }, [repoFullName, branch.name, defaultBranch])
+
+  const stateLabel = state === 'very-stale'
+    ? '⚠ Very stale'
+    : state === 'stale'
+    ? '⚠ Stale'
+    : '✓ Active'
 
   return (
     <div
       className={`branch-building branch-building-${state}`}
       style={{ left: position.x, top: position.y }}
-      title={tooltip}
+      onMouseEnter={handleMouseEnter}
       onClick={(e) => {
         e.stopPropagation()
         window.open(`https://github.com/${repoFullName}/tree/${encodeURIComponent(branch.name)}`, '_blank', 'noopener,noreferrer')
@@ -112,6 +133,38 @@ export function BranchBuilding({ branch, position, repoFullName }: BranchBuildin
         <ColorizedSilo state={state} />
       </div>
       <div className="branch-bld-label">{branch.name.length > 10 ? branch.name.slice(0, 9) + '…' : branch.name}</div>
+
+      <div className="branch-bld-popover">
+        <div className="branch-bld-popover-name">⎇ {branch.name}</div>
+        <div className="branch-bld-popover-row">
+          <span className="branch-bld-popover-label">Last commit</span>
+          <span className="branch-bld-popover-value">{commitDateStr}</span>
+        </div>
+        <div className="branch-bld-popover-row">
+          <span className="branch-bld-popover-label">Age</span>
+          <span className="branch-bld-popover-value">{daysSince > 0 ? `${daysSince}d ago` : 'Today'}</span>
+        </div>
+        <div className="branch-bld-popover-row">
+          <span className="branch-bld-popover-status">{stateLabel}</span>
+        </div>
+        <div className="branch-bld-popover-divider" />
+        {compareLoading ? (
+          <div className="branch-bld-popover-row">
+            <span className="branch-bld-popover-loading">Loading…</span>
+          </div>
+        ) : compare ? (
+          <div className="branch-bld-popover-compare">
+            <span className="branch-bld-popover-behind" title={`${compare.behind} commits behind ${defaultBranch}`}>
+              ↓{compare.behind}
+            </span>
+            <span className="branch-bld-popover-sep">|</span>
+            <span className="branch-bld-popover-ahead" title={`${compare.ahead} commits ahead of ${defaultBranch}`}>
+              ↑{compare.ahead}
+            </span>
+            <span className="branch-bld-popover-base">vs {defaultBranch}</span>
+          </div>
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -2329,6 +2329,98 @@ select.input {
   animation: blink 2s ease-in-out infinite;
 }
 
+/* Branch building popover */
+.branch-bld-popover {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  background: rgba(8, 12, 18, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: #ccc;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s, transform 0.15s;
+  white-space: nowrap;
+  z-index: 10;
+  min-width: 130px;
+}
+
+.branch-building:hover .branch-bld-popover {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.branch-bld-popover-name {
+  font-size: 9px;
+  font-weight: bold;
+  color: currentColor;
+  margin-bottom: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 160px;
+}
+
+.branch-bld-popover-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 2px;
+}
+
+.branch-bld-popover-label {
+  color: #888;
+  flex-shrink: 0;
+}
+
+.branch-bld-popover-value {
+  color: #ddd;
+}
+
+.branch-bld-popover-status {
+  color: currentColor;
+  opacity: 0.85;
+}
+
+.branch-bld-popover-loading {
+  color: #666;
+  font-style: italic;
+}
+
+.branch-bld-popover-divider {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin: 4px 0;
+}
+
+.branch-bld-popover-compare {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.branch-bld-popover-behind {
+  color: #ff9944;
+}
+
+.branch-bld-popover-ahead {
+  color: #44dd88;
+}
+
+.branch-bld-popover-sep {
+  color: #555;
+}
+
+.branch-bld-popover-base {
+  color: #666;
+  font-size: 8px;
+  margin-left: 2px;
+}
+
 .branch-overflow-label {
   position: absolute;
   font-family: var(--font-mono);

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -467,6 +467,22 @@ app.get('/branches/:owner/:name', async (c) => {
   return c.json({ branches, defaultBranch })
 })
 
+// GET /api/github/branch-compare/:owner/:name/:branch — ahead/behind vs default branch
+app.get('/branch-compare/:owner/:name/:branch', async (c) => {
+  const owner = c.req.param('owner')
+  const name = c.req.param('name')
+  const branch = decodeURIComponent(c.req.param('branch'))
+  const base = c.req.query('base') || 'main'
+
+  const result = await gh(['api', `repos/${owner}/${name}/compare/${base}...${branch}`])
+  if (result.error) return c.json({ error: result.error }, 500)
+
+  return c.json({
+    ahead: result.data?.ahead_by ?? 0,
+    behind: result.data?.behind_by ?? 0,
+  })
+})
+
 // POST /api/github/trigger-claude — post @claude comment
 app.post('/trigger-claude', async (c) => {
   const body = await c.req.json()


### PR DESCRIPTION
Replaces the native browser `title` tooltip on branch buildings with a styled CSS hover popover showing branch name, last commit date, staleness status, and behind/ahead commit counts vs the default branch.

The behind/ahead data is lazy-fetched on first hover via a new backend endpoint.

Closes #179

Generated with [Claude Code](https://claude.ai/code)