### PR TITLE
feat: versioning system with auto bump and UI display

### DIFF
--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Routes, Route, NavLink } from 'react-router-dom'
 import { useAppStore } from './store'
 import { Dashboard } from './components/Dashboard'
@@ -6,6 +6,7 @@ import { Settings } from './components/Settings'
 import { BattlefieldView } from './components/BattlefieldView'
 import { MapEditor } from './components/MapEditor'
 import { ToastArea } from './components/Toast'
+import { api } from './api'
 
 export default function App() {
   const repos = useAppStore((s) => s.repos)
@@ -15,10 +16,12 @@ export default function App() {
   const toasts = useAppStore((s) => s.toasts)
   const loadRepos = useAppStore((s) => s.loadRepos)
   const loadDashboard = useAppStore((s) => s.loadDashboard)
+  const [appVersion, setAppVersion] = useState<string | null>(null)
 
   useEffect(() => {
     loadRepos()
     loadDashboard()
+    api.getVersion().then((r) => setAppVersion(r.version)).catch(() => {})
   }, [loadRepos, loadDashboard])
 
   useEffect(() => {
@@ -99,6 +102,10 @@ export default function App() {
             ? `Updated ${lastRefresh.toLocaleTimeString()}`
             : 'Not refreshed yet'}
         </div>
+
+        {appVersion && (
+          <div className="sidebar-version">v{appVersion}</div>
+        )}
       </aside>
 
       <main className="main-content">

--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -199,6 +199,8 @@ export const api = {
     return request<{ repos: { name: string; fullName: string; description: string | null; url: string; isPrivate: boolean }[]; page: number; perPage: number; total: number | null; truncated: boolean; ghAvailable: boolean }>(`/github/user-repos?${qs}`)
   },
 
+  getVersion: () => request<{ version: string }>('/version'),
+
   listMaps: () => request<GameMap[]>('/maps'),
 
   createMap: (params: { name: string; width: number; height: number }) =>

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -146,6 +146,14 @@ a:hover { text-decoration: underline; }
   color: var(--text-3);
 }
 
+.sidebar-version {
+  text-align: center;
+  font-size: 10px;
+  color: var(--text-3);
+  letter-spacing: 0.08em;
+  opacity: 0.7;
+}
+
 .status-dot {
   width: 8px;
   height: 8px;

--- a/gh-ctrl/package.json
+++ b/gh-ctrl/package.json
@@ -1,12 +1,16 @@
 {
   "name": "gh-ctrl",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "concurrently \"bun run dev:server\" \"bun run dev:client\"",
     "dev:server": "bun --watch src/index.ts",
     "dev:client": "cd client && bun run dev",
     "build": "cd client && bun run build",
-    "start": "bun src/index.ts"
+    "start": "bun src/index.ts",
+    "version:patch": "node scripts/bump-version.js patch",
+    "version:minor": "node scripts/bump-version.js minor",
+    "version:major": "node scripts/bump-version.js major"
   },
   "dependencies": {
     "concurrently": "^8.2.0",

--- a/gh-ctrl/scripts/bump-version.js
+++ b/gh-ctrl/scripts/bump-version.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Version bump script following semantic versioning (semver).
+ *
+ * Usage:
+ *   node scripts/bump-version.js [patch|minor|major]
+ *
+ * Defaults to 'patch' if no argument is provided.
+ *
+ * Examples:
+ *   node scripts/bump-version.js         -> 1.0.0 => 1.0.1
+ *   node scripts/bump-version.js patch   -> 1.0.0 => 1.0.1
+ *   node scripts/bump-version.js minor   -> 1.0.0 => 1.1.0
+ *   node scripts/bump-version.js major   -> 1.0.0 => 2.0.0
+ */
+
+import { readFileSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkgPath = resolve(__dirname, '../package.json')
+
+const bumpType = process.argv[2] || 'patch'
+
+if (!['patch', 'minor', 'major'].includes(bumpType)) {
+  console.error(`Invalid bump type: "${bumpType}". Use patch, minor, or major.`)
+  process.exit(1)
+}
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+const [major, minor, patch] = pkg.version.split('.').map(Number)
+
+let nextVersion
+if (bumpType === 'major') nextVersion = `${major + 1}.0.0`
+else if (bumpType === 'minor') nextVersion = `${major}.${minor + 1}.0`
+else nextVersion = `${major}.${minor}.${patch + 1}`
+
+pkg.version = nextVersion
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
+
+console.log(`Bumped version: ${major}.${minor}.${patch} → ${nextVersion}`)

--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -5,6 +5,7 @@ import { serveStatic } from 'hono/bun'
 import reposRouter from './routes/repos'
 import githubRouter from './routes/github'
 import mapsRouter from './routes/maps'
+import pkg from '../package.json'
 
 const app = new Hono()
 
@@ -16,6 +17,7 @@ app.route('/api/github', githubRouter)
 app.route('/api/maps', mapsRouter)
 
 app.get('/api/health', (c) => c.json({ ok: true }))
+app.get('/api/version', (c) => c.json({ version: pkg.version }))
 
 // Serve built React in production
 app.use('*', serveStatic({ root: './client/dist' }))


### PR DESCRIPTION
Implements semantic versioning system as requested in #177.

- Adds version field to package.json (1.0.0)
- New `GET /api/version` endpoint on Hono backend
- Version badge displayed in sidebar footer
- Version bump script (patch/minor/major) in gh-ctrl/scripts/bump-version.js
- npm scripts: version:patch, version:minor, version:major

> Note: The GitHub Actions workflow for auto bump on merge needs to be added manually (see issue comment for YAML).

Generated with [Claude Code](https://claude.ai/code)