### PR TITLE
chore: add star history to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,7 @@ vibe-and-conquer/
 - **claude.yml** — Interactive Claude assistant (responds to `@claude` mentions in issues and PRs)
 - **claude-code-review.yml** — Automated PR code review on open/sync
 - **claude-conflict-resolver.yml** — Automatic merge conflict detection and resolution
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=svengraziani/vibe-and-conquer&type=date&legend=top-left)](https://www.star-history.com/#svengraziani/vibe-and-conquer&type=date&legend=top-left)


### PR DESCRIPTION
Adds a Star History section to the README with the star history chart badge.

Closes #190

Generated with [Claude Code](https://claude.ai/code)