### PR TITLE
feat: add docker compose setup with prod and dev profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Required — all GitHub API calls will fail without this
+GH_TOKEN=your_github_token_here

--- a/README.md
+++ b/README.md
@@ -107,6 +107,48 @@ bun run build   # builds the React client
 bun run start   # serves everything on port 3001
 ```
 
+## Docker
+
+The easiest way to run Vibe and Conquer without installing Bun or the GitHub CLI locally.
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) with Compose v2
+- A GitHub [personal access token](https://github.com/settings/tokens) with `repo` and `read:org` scopes
+
+### Setup
+
+```bash
+cp .env.example .env
+# Edit .env and set your token:
+# GH_TOKEN=ghp_...
+```
+
+### Production
+
+Builds the frontend into the image and serves everything from a single port.
+
+```bash
+docker compose --profile prod up --build
+```
+
+App available at `http://localhost:3001`. The SQLite database is stored in a named Docker volume (`gh-ctrl-data`) and persists across restarts.
+
+### Development
+
+Mounts the source from your host for live reload — Vite HMR on port 5173, Bun `--watch` on port 3001.
+
+```bash
+docker compose --profile dev up --build
+```
+
+| URL | Purpose |
+|-----|---------|
+| `http://localhost:5173` | Frontend (Vite, with HMR) |
+| `http://localhost:3001` | Backend API |
+
+`--build` is only needed when the Dockerfile changes (e.g. after a dependency update). Normal dev sessions can omit it.
+
 ## Project Structure
 
 ```

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,31 @@
+services:
+  app:
+    profiles: [prod]
+    build:
+      context: ./gh-ctrl
+      target: runtime
+    ports:
+      - "3001:3001"
+    environment:
+      - GH_TOKEN=${GH_TOKEN}
+    volumes:
+      - gh-ctrl-data:/app/data
+
+  app-dev:
+    profiles: [dev]
+    build:
+      context: ./gh-ctrl
+      target: dev
+    ports:
+      - "3001:3001"
+      - "5173:5173"
+    environment:
+      - GH_TOKEN=${GH_TOKEN}
+    volumes:
+      - ./gh-ctrl:/app
+      - /app/node_modules
+      - /app/client/node_modules
+      - gh-ctrl-data:/app/data
+
+volumes:
+  gh-ctrl-data:

--- a/gh-ctrl/.env.example
+++ b/gh-ctrl/.env.example
@@ -1,0 +1,2 @@
+# Required — all GitHub API calls will fail without this
+GH_TOKEN=your_github_token_here

--- a/gh-ctrl/.gitignore
+++ b/gh-ctrl/.gitignore
@@ -9,3 +9,4 @@ bun.lockb
 
 # macOS
 .DS_Store
+.env

--- a/gh-ctrl/Dockerfile
+++ b/gh-ctrl/Dockerfile
@@ -1,0 +1,80 @@
+# ── Stage 1: builder ─────────────────────────────────────────────────────────
+FROM oven/bun AS builder
+
+WORKDIR /app
+
+# Install backend deps
+COPY package.json bun.lock ./
+RUN bun install
+
+# Install frontend deps
+COPY client/package.json client/bun.lock ./client/
+RUN cd client && bun install
+
+# Copy source and build frontend
+COPY . .
+RUN cd client && bunx vite build
+
+# ── Stage 2: runtime (production) ────────────────────────────────────────────
+FROM oven/bun AS runtime
+
+# Install gh CLI
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Pre-create data dir with correct ownership
+RUN mkdir -p /app/data
+
+# Copy only what production needs
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/client/dist ./client/dist
+
+EXPOSE 3001
+
+CMD ["bun", "src/index.ts"]
+
+# ── Stage 3: dev ──────────────────────────────────────────────────────────────
+FROM oven/bun AS dev
+
+# Install gh CLI (same as runtime)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Pre-create data dir with correct ownership
+RUN mkdir -p /app/data
+
+# Install deps into the image so the anonymous node_modules volumes are
+# populated from the image on first start, preventing host node_modules
+# (wrong OS/arch) from being used when the source bind mount overlays /app.
+COPY package.json bun.lock ./
+RUN bun install
+COPY client/package.json client/bun.lock ./client/
+RUN cd client && bun install
+
+EXPOSE 3001 5173
+
+CMD ["bun", "run", "dev"]

--- a/gh-ctrl/client/vite.config.ts
+++ b/gh-ctrl/client/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: true,
     proxy: {
       '/api': {
         target: 'http://localhost:3001',

--- a/gh-ctrl/src/db/index.ts
+++ b/gh-ctrl/src/db/index.ts
@@ -2,7 +2,7 @@ import { drizzle } from 'drizzle-orm/bun-sqlite'
 import { Database } from 'bun:sqlite'
 import * as schema from './schema'
 
-const sqlite = new Database('./github-dashboard.db')
+const sqlite = new Database('./data/github-dashboard.db')
 sqlite.exec('PRAGMA journal_mode = WAL;')
 sqlite.exec(`
   CREATE TABLE IF NOT EXISTS repos (


### PR DESCRIPTION
Introduces comprehensive Docker support for the `gh-ctrl` (Vibe and Conquer) project, enabling both production and development workflows using Docker Compose. It adds a multi-stage `Dockerfile`, a `compose.yml` with separate profiles for production and development, persistent database storage via a Docker volume, and improved developer experience with live reload in development mode. Minimal source code changes ensure compatibility with containerized environments.