### PR TITLE
feat: Add Netlify deployment preview building to PR buildings

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -856,6 +856,26 @@ function PRBuilding({ pr, position, repo, onModalOpen }: {
         <div className="pr-bld-title">{shortTitle}</div>
         {openedDate && <div className="pr-bld-date">{openedDate}</div>}
       </div>
+      {pr.previewUrl && (
+        <a
+          className="pr-bld-netlify"
+          href={pr.previewUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          title={`Open Netlify preview for #${pr.number}`}
+        >
+          <div className="pr-bld-netlify-body">
+            <div className="pr-bld-netlify-antenna" />
+            <div className="pr-bld-netlify-roof" />
+            <div className="pr-bld-netlify-wall">
+              <div className="pr-bld-netlify-window" />
+              <div className="pr-bld-netlify-door" />
+            </div>
+          </div>
+          <div className="pr-bld-netlify-label">▲ LIVE</div>
+        </a>
+      )}
     </div>
   )
 }

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1973,6 +1973,85 @@ select.input {
   margin-top: 1px;
 }
 
+/* ---- Netlify deployment preview building ---- */
+.pr-bld-netlify {
+  position: absolute;
+  left: 94px;
+  top: 8px;
+  width: 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.12s;
+  z-index: 3;
+}
+
+.pr-bld-netlify:hover {
+  transform: translateY(-3px);
+}
+
+.pr-bld-netlify-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  filter: drop-shadow(0 2px 5px rgba(0, 199, 183, 0.55));
+}
+
+.pr-bld-netlify-antenna {
+  width: 2px;
+  height: 8px;
+  background: #00C7B7;
+  margin-bottom: -1px;
+}
+
+.pr-bld-netlify-roof {
+  width: 0;
+  height: 0;
+  border-left: 11px solid transparent;
+  border-right: 11px solid transparent;
+  border-bottom: 9px solid #00C7B7;
+}
+
+.pr-bld-netlify-wall {
+  width: 22px;
+  height: 26px;
+  background: #00C7B7;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 0 0;
+}
+
+.pr-bld-netlify-window {
+  width: 8px;
+  height: 6px;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.pr-bld-netlify-door {
+  width: 7px;
+  height: 9px;
+  background: rgba(0, 0, 0, 0.4);
+  align-self: center;
+}
+
+.pr-bld-netlify-label {
+  font-size: 6px;
+  font-family: var(--font-mono);
+  color: #00C7B7;
+  letter-spacing: 0.4px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.pr-bld-netlify:hover .pr-bld-netlify-body {
+  filter: drop-shadow(0 3px 8px rgba(0, 199, 183, 0.9));
+}
+
 /* ---- Base Detail Panel ---- */
 .base-detail-panel {
   position: absolute;


### PR DESCRIPTION
Closes #175

When a PR has a Netlify deployment preview URL, a small teal pixel-art building appears next to the kaserne PR building on the battlefield. Clicking it opens the preview in a new tab.

Generated with [Claude Code](https://claude.ai/code)