### PR TITLE
feat: double-click on base zooms to that base

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -131,6 +131,7 @@ interface Props {
   onRefreshRepo: (owner: string, name: string) => Promise<void>
   onToast: (message: string, type: 'success' | 'error' | 'info') => void
   onModalOpen: (state: ModalState) => void
+  onZoomToBase: () => void
 }
 
 const PR_BUILDING_OFFSET_X = 148
@@ -146,7 +147,7 @@ const BRANCH_BUILDING_ROW_HEIGHT = 68
 const BRANCH_BUILDING_COLS = 4
 const MAX_BRANCH_BUILDINGS = 12
 
-export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, onConstruct, onStartRelocate, onRefreshRepo, onToast, onModalOpen }: Props) {
+export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, onConstruct, onStartRelocate, onRefreshRepo, onToast, onModalOpen, onZoomToBase }: Props) {
   const { repo, data } = entry
   const { stats } = data
   const [showDetail, setShowDetail] = useState(false)
@@ -193,6 +194,12 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
     setShowDetail(v => !v)
   }, [isRelocateMode])
 
+  const handleDoubleClick = useCallback((e: React.MouseEvent) => {
+    if (isRelocateMode) return
+    e.stopPropagation()
+    onZoomToBase()
+  }, [isRelocateMode, onZoomToBase])
+
   const visiblePRs = data.prs.slice(0, MAX_PR_BUILDINGS)
 
   // Branch buildings: exclude default branch, sort stale first, cap at MAX_BRANCH_BUILDINGS
@@ -234,6 +241,7 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
         } as React.CSSProperties}
         onMouseDown={handleMouseDown}
         onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
       >
         {/* Status beacons */}
         <div className="base-beacons">

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -562,6 +562,15 @@ export function BattlefieldView() {
     }
   }, [positions])
 
+  const handleZoomToBase = useCallback((pos: Position) => {
+    const targetZoom = Math.max(1.5, ZOOM_MAX * 0.5)
+    setZoom(targetZoom)
+    setOffset({
+      x: window.innerWidth / 2 - pos.x * targetZoom,
+      y: window.innerHeight / 2 - pos.y * targetZoom,
+    })
+  }, [])
+
   const handleMapMouseUp = useCallback(() => {
     setIsDraggingMap(false)
     if (relocatingId !== null) {
@@ -730,6 +739,7 @@ export function BattlefieldView() {
               onRefreshRepo={onRefreshRepo}
               addToast={addToast}
               onModalOpen={(state) => { play('peep'); setModalState(state) }}
+              onZoomToBase={() => handleZoomToBase(pos)}
             />
           )
         })}


### PR DESCRIPTION
Implements #201: double-clicking a base in the Battlefield view now zooms in and centers the camera on that base.

Generated with [Claude Code](https://claude.ai/code)