### PR TITLE
feat: add initial setup screen

### DIFF
--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Routes, Route, NavLink } from 'react-router-dom'
 import { useAppStore } from './store'
 import { Dashboard } from './components/Dashboard'
@@ -6,7 +6,9 @@ import { Settings } from './components/Settings'
 import { BattlefieldView } from './components/BattlefieldView'
 import { MapEditor } from './components/MapEditor'
 import { ToastArea } from './components/Toast'
+import { SetupScreen } from './components/SetupScreen'
 import { api } from './api'
+import type { SetupStatus } from './types'
 
 export default function App() {
   const repos = useAppStore((s) => s.repos)
@@ -17,12 +19,29 @@ export default function App() {
   const loadRepos = useAppStore((s) => s.loadRepos)
   const loadDashboard = useAppStore((s) => s.loadDashboard)
   const [appVersion, setAppVersion] = useState<string | null>(null)
+  const [setupStatus, setSetupStatus] = useState<SetupStatus | null>(null)
+  const [setupChecked, setSetupChecked] = useState(false)
+
+  const checkSetup = useCallback(() => {
+    api.getSetupStatus().then((s) => {
+      setSetupStatus(s)
+      setSetupChecked(true)
+    }).catch(() => {
+      // If setup endpoint fails, proceed to main app
+      setSetupChecked(true)
+    })
+  }, [])
 
   useEffect(() => {
+    checkSetup()
+  }, [checkSetup])
+
+  useEffect(() => {
+    if (!setupStatus?.ready) return
     loadRepos()
     loadDashboard()
     api.getVersion().then((r) => setAppVersion(r.version)).catch(() => {})
-  }, [loadRepos, loadDashboard])
+  }, [setupStatus?.ready, loadRepos, loadDashboard])
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -39,6 +58,18 @@ export default function App() {
     }),
     { prs: 0, issues: 0, conflicts: 0 }
   )
+
+  if (!setupChecked) {
+    return (
+      <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg)', color: 'var(--text-2)', fontSize: '0.9rem' }}>
+        Checking setup…
+      </div>
+    )
+  }
+
+  if (setupStatus && !setupStatus.ready) {
+    return <SetupScreen status={setupStatus} onRecheck={checkSetup} />
+  }
 
   return (
     <div className="app-layout">

--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData } from './types'
+import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData, SetupStatus } from './types'
 
 const BASE = '/api'
 
@@ -224,4 +224,6 @@ export const api = {
     request<{ ok: boolean }>(`/maps/${id}`, { method: 'DELETE' }),
 
   getFeed: () => request<FeedData>('/github/feed'),
+
+  getSetupStatus: () => request<SetupStatus>('/setup/status'),
 }

--- a/gh-ctrl/client/src/components/SetupScreen.tsx
+++ b/gh-ctrl/client/src/components/SetupScreen.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react'
+import type { SetupStatus } from '../types'
+
+interface Props {
+  status: SetupStatus
+  onRecheck: () => void
+}
+
+export function SetupScreen({ status, onRecheck }: Props) {
+  const [copied, setCopied] = useState<string | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      onRecheck()
+    }, 3000)
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [onRecheck])
+
+  function copyFix(id: string, text: string) {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(id)
+      setTimeout(() => setCopied(null), 2000)
+    })
+  }
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: 'var(--bg)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '2rem',
+    }}>
+      <div style={{
+        background: 'var(--surface)',
+        border: '1px solid var(--border)',
+        borderRadius: '8px',
+        padding: '2.5rem',
+        maxWidth: '560px',
+        width: '100%',
+      }}>
+        <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+          <img
+            src="/logo-transparent.png"
+            alt="Vibe and Conquer"
+            style={{ height: '56px', marginBottom: '1rem' }}
+          />
+          <h1 style={{ fontSize: '1.4rem', fontWeight: 700, margin: '0 0 0.4rem', color: 'var(--text)' }}>
+            Getting Started
+          </h1>
+          <p style={{ color: 'var(--text-2)', margin: 0, fontSize: '0.9rem' }}>
+            Complete the checks below before using the dashboard.
+          </p>
+          <span style={{
+            display: 'inline-block',
+            marginTop: '0.75rem',
+            padding: '0.2rem 0.6rem',
+            borderRadius: '4px',
+            fontSize: '0.75rem',
+            fontWeight: 600,
+            background: status.mode === 'docker' ? 'rgba(0,120,255,0.15)' : 'rgba(0,255,136,0.12)',
+            color: status.mode === 'docker' ? 'var(--blue)' : 'var(--green)',
+            border: `1px solid ${status.mode === 'docker' ? 'var(--blue)' : 'var(--green)'}`,
+          }}>
+            {status.mode === 'docker' ? '🐳 Docker' : '💻 Local'}
+          </span>
+        </div>
+
+        <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 1.5rem' }}>
+          {status.checks.map((check) => (
+            <li key={check.id} style={{
+              borderBottom: '1px solid var(--border)',
+              padding: '1rem 0',
+            }}>
+              <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.75rem' }}>
+                <span style={{
+                  fontSize: '1rem',
+                  lineHeight: 1,
+                  marginTop: '2px',
+                  color: check.ok ? 'var(--green)' : 'var(--red)',
+                  flexShrink: 0,
+                }}>
+                  {check.ok ? '✓' : '✗'}
+                </span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontWeight: 600, color: 'var(--text)', fontSize: '0.9rem' }}>
+                    {check.label}
+                  </div>
+                  {check.detail && (
+                    <div style={{ color: 'var(--text-2)', fontSize: '0.8rem', marginTop: '0.2rem', wordBreak: 'break-all' }}>
+                      {check.detail}
+                    </div>
+                  )}
+                  {!check.ok && check.fix && (
+                    <div style={{
+                      marginTop: '0.5rem',
+                      background: 'var(--bg)',
+                      border: '1px solid var(--border)',
+                      borderRadius: '4px',
+                      padding: '0.5rem 0.75rem',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '0.5rem',
+                    }}>
+                      <code style={{ flex: 1, fontSize: '0.78rem', color: 'var(--text)', wordBreak: 'break-all' }}>
+                        {check.fix}
+                      </code>
+                      <button
+                        onClick={() => copyFix(check.id, check.fix!)}
+                        style={{
+                          flexShrink: 0,
+                          background: 'none',
+                          border: '1px solid var(--border)',
+                          borderRadius: '3px',
+                          color: 'var(--text-2)',
+                          cursor: 'pointer',
+                          fontSize: '0.72rem',
+                          padding: '0.2rem 0.45rem',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {copied === check.id ? 'Copied!' : 'Copy'}
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <div style={{ textAlign: 'center' }}>
+          <button
+            onClick={onRecheck}
+            style={{
+              background: 'var(--green)',
+              color: '#000',
+              border: 'none',
+              borderRadius: '4px',
+              padding: '0.5rem 1.25rem',
+              fontWeight: 700,
+              fontSize: '0.875rem',
+              cursor: 'pointer',
+            }}
+          >
+            Check Again
+          </button>
+          <p style={{ color: 'var(--text-2)', fontSize: '0.78rem', marginTop: '0.75rem', marginBottom: 0 }}>
+            Checking automatically every 3 seconds…
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -190,6 +190,20 @@ export interface FeedData {
   mentions: FeedItem[]
 }
 
+export interface SetupCheck {
+  id: string
+  label: string
+  ok: boolean
+  detail?: string | null
+  fix?: string | null
+}
+
+export interface SetupStatus {
+  ready: boolean
+  mode: 'docker' | 'local'
+  checks: SetupCheck[]
+}
+
 export interface MapTile {
   type: string
   color: string

--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -5,6 +5,7 @@ import { serveStatic } from 'hono/bun'
 import reposRouter from './routes/repos'
 import githubRouter from './routes/github'
 import mapsRouter from './routes/maps'
+import setupRouter from './routes/setup'
 import pkg from '../package.json'
 
 const app = new Hono()
@@ -15,6 +16,7 @@ app.use('*', logger())
 app.route('/api/repos', reposRouter)
 app.route('/api/github', githubRouter)
 app.route('/api/maps', mapsRouter)
+app.route('/api/setup', setupRouter)
 
 app.get('/api/health', (c) => c.json({ ok: true }))
 app.get('/api/version', (c) => c.json({ version: pkg.version }))

--- a/gh-ctrl/src/routes/setup.ts
+++ b/gh-ctrl/src/routes/setup.ts
@@ -1,0 +1,77 @@
+import { Hono } from 'hono'
+import { db } from '../db'
+import { repos } from '../db/schema'
+import fs from 'fs'
+
+const app = new Hono()
+
+function isDocker(): boolean {
+  return !!process.env.GH_TOKEN || fs.existsSync('/.dockerenv')
+}
+
+app.get('/status', async (c) => {
+  const mode = isDocker() ? 'docker' : 'local'
+
+  // Check 1: gh installed
+  const ghVersionResult = Bun.spawnSync(['gh', '--version'])
+  const ghInstalled = ghVersionResult.exitCode === 0
+  const ghVersionOutput = ghInstalled ? ghVersionResult.stdout.toString().split('\n')[0].trim() : null
+
+  // Check 2: gh auth
+  const ghAuthResult = Bun.spawnSync(['gh', 'auth', 'status'])
+  const ghAuthed = ghAuthResult.exitCode === 0
+  const ghAuthDetail = ghAuthed
+    ? ghAuthResult.stderr.toString().trim() || ghAuthResult.stdout.toString().trim()
+    : ghAuthResult.stderr.toString().trim() || 'Not authenticated'
+
+  let ghAuthFix: string | null = null
+  if (!ghAuthed) {
+    ghAuthFix = mode === 'docker'
+      ? 'Add GH_TOKEN=<your_token> to your .env file and restart the container'
+      : 'Run: gh auth login'
+  }
+
+  // Check 3: db accessible
+  let dbOk = false
+  let dbDetail: string | null = null
+  try {
+    await db.select().from(repos).limit(1)
+    dbOk = true
+  } catch (err) {
+    dbDetail = err instanceof Error ? err.message : 'Unknown error'
+  }
+
+  const checks = [
+    {
+      id: 'gh_installed',
+      label: 'GitHub CLI installed',
+      ok: ghInstalled,
+      detail: ghInstalled ? ghVersionOutput : 'gh CLI not found',
+      fix: ghInstalled
+        ? null
+        : mode === 'docker'
+        ? 'gh CLI should be pre-installed in the Docker image. Rebuild the image.'
+        : 'Install gh CLI: https://cli.github.com/manual/installation',
+    },
+    {
+      id: 'gh_auth',
+      label: 'GitHub authenticated',
+      ok: ghAuthed,
+      detail: ghAuthDetail || null,
+      fix: ghAuthFix,
+    },
+    {
+      id: 'db',
+      label: 'Database accessible',
+      ok: dbOk,
+      detail: dbOk ? null : dbDetail,
+      fix: dbOk ? null : 'Ensure the data/ directory exists and is writable',
+    },
+  ]
+
+  const ready = checks.every((ch) => ch.ok)
+
+  return c.json({ ready, mode, checks })
+})
+
+export default app


### PR DESCRIPTION
Adds a setup/health-check screen that runs before the main app loads. Checks gh CLI installation, GitHub authentication, and database access. Supports both Docker and local deployment modes. Auto-polls every 3s and transitions to the main app once all checks pass.

Closes #189

Generated with [Claude Code](https://claude.ai/code)