### PR TITLE
feat: assign repositories to maps

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -226,6 +226,15 @@ export const api = {
   deleteMap: (id: number) =>
     request<{ ok: boolean }>(`/maps/${id}`, { method: 'DELETE' }),
 
+  getMapRepos: (mapId: number) =>
+    request<Repo[]>(`/maps/${mapId}/repos`),
+
+  assignRepoToMap: (mapId: number, repoId: number) =>
+    request<{ ok: boolean }>(`/maps/${mapId}/repos/${repoId}`, { method: 'POST' }),
+
+  unassignRepoFromMap: (mapId: number, repoId: number) =>
+    request<{ ok: boolean }>(`/maps/${mapId}/repos/${repoId}`, { method: 'DELETE' }),
+
   getFeed: () => request<FeedData>('/github/feed'),
 
   getSetupStatus: () => request<SetupStatus>('/setup/status'),

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -355,6 +355,7 @@ export function BattlefieldView() {
   const [activeMap, setActiveMap] = useState<GameMap | null>(null)
   const [allMaps, setAllMaps] = useState<GameMap[]>([])
   const [showMapSelector, setShowMapSelector] = useState(false)
+  const [activeMapRepoIds, setActiveMapRepoIds] = useState<Set<number> | null>(null)
   const [showFeedPanel, setShowFeedPanel] = useState(false)
   const [branchSiloEntry, setBranchSiloEntry] = useState<DashboardEntry | null>(null)
   const [detailEntry, setDetailEntry] = useState<DashboardEntry | null>(null)
@@ -402,6 +403,17 @@ export function BattlefieldView() {
       api.getMap(savedId).then(setActiveMap).catch(() => saveActiveMapId(null))
     }
   }, [])
+
+  // Load assigned repos whenever activeMap changes
+  useEffect(() => {
+    if (!activeMap) {
+      setActiveMapRepoIds(null)
+      return
+    }
+    api.getMapRepos(activeMap.id)
+      .then((repos) => setActiveMapRepoIds(new Set(repos.map((r) => r.id))))
+      .catch(() => setActiveMapRepoIds(null))
+  }, [activeMap])
 
   // Load all maps when selector opens
   useEffect(() => {
@@ -603,13 +615,18 @@ export function BattlefieldView() {
     setRelocatingStart({ mouseX, mouseY, nodeX: pos.x, nodeY: pos.y })
   }, [positions])
 
-  const totalConflicts = entries.reduce((sum, e) => sum + e.data.stats.conflicts, 0)
-  const totalRunningActions = entries.reduce((sum, e) => sum + (e.data.stats.runningActions ?? 0), 0)
+  // When an active map is selected, filter to only its assigned repos
+  const visibleEntries = activeMapRepoIds === null
+    ? entries
+    : entries.filter((e) => activeMapRepoIds.has(e.repo.id))
+
+  const totalConflicts = visibleEntries.reduce((sum, e) => sum + e.data.stats.conflicts, 0)
+  const totalRunningActions = visibleEntries.reduce((sum, e) => sum + (e.data.stats.runningActions ?? 0), 0)
   const loadedFullNames = new Set(entries.map((e) => e.repo.fullName))
   const pendingRepos = loading ? repos.filter((r) => !loadedFullNames.has(r.fullName)) : []
 
-  // Stale branch counts across all repos
-  const staleBranchStats = entries.reduce((acc, e) => {
+  // Stale branch counts across visible repos
+  const staleBranchStats = visibleEntries.reduce((acc, e) => {
     const defaultBranch = e.data.defaultBranch ?? 'main'
     const nonDefault = (e.data.branches ?? []).filter(b => b.name !== defaultBranch)
     const stale = nonDefault.filter(b => getBranchState(b.committedDate) === 'stale' || getBranchState(b.committedDate) === 'very-stale')
@@ -636,7 +653,7 @@ export function BattlefieldView() {
       <div className="battlefield-hud">
         <div className="hud-brand">&#x25a0; C&amp;C GITAGENTS — TACTICAL COMMAND</div>
         <div className="hud-controls">
-          <span className="hud-stat">BASES: <strong>{entries.length}</strong></span>
+          <span className="hud-stat">BASES: <strong>{visibleEntries.length}</strong>{activeMapRepoIds !== null && entries.length !== visibleEntries.length && <span style={{ opacity: 0.6, fontSize: 10 }}> /{entries.length}</span>}</span>
           {totalConflicts > 0 && (
             <span className="hud-stat hud-alert blink">&#x26a0; CONFLICTS: <strong>{totalConflicts}</strong></span>
           )}
@@ -738,7 +755,7 @@ export function BattlefieldView() {
           </div>
         ))}
 
-        {entries.map((entry) => {
+        {visibleEntries.map((entry) => {
           const pos = positions[entry.repo.id] ?? { x: 0, y: 0 }
           return (
             <BaseNode
@@ -777,8 +794,8 @@ export function BattlefieldView() {
       </div>
 
       {/* Minimap */}
-      {(entries.length > 0 || pendingRepos.length > 0) && (
-        <Minimap entries={entries} positions={positions} offset={offset} zoom={zoom} onJump={setOffset} />
+      {(visibleEntries.length > 0 || pendingRepos.length > 0) && (
+        <Minimap entries={visibleEntries} positions={positions} offset={offset} zoom={zoom} onJump={setOffset} />
       )}
 
       {/* Empty state */}
@@ -786,6 +803,14 @@ export function BattlefieldView() {
         <div className="battlefield-empty">
           <div className="battlefield-empty-title">&#x25a0; NO BASES DETECTED</div>
           <div className="battlefield-empty-sub">Add repositories in the Repositories panel to deploy bases.</div>
+        </div>
+      )}
+
+      {/* Active map with no assigned repos */}
+      {activeMap && activeMapRepoIds !== null && activeMapRepoIds.size === 0 && !loading && entries.length > 0 && (
+        <div className="battlefield-empty">
+          <div className="battlefield-empty-title">&#x25a6; NO BASES ON THIS MAP</div>
+          <div className="battlefield-empty-sub">Assign repositories to &quot;{activeMap.name}&quot; in the Repositories panel.</div>
         </div>
       )}
 
@@ -848,7 +873,7 @@ export function BattlefieldView() {
 
       {/* Intel Feed Panel */}
       <FeedPanel
-        entries={entries}
+        entries={visibleEntries}
         isOpen={showFeedPanel}
         onClose={() => setShowFeedPanel(false)}
       />

--- a/gh-ctrl/client/src/components/Settings.tsx
+++ b/gh-ctrl/client/src/components/Settings.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import type { Repo } from '../types'
 import { api } from '../api'
 import { useAppStore } from '../store'
+import type { GameMap } from '../types'
 
 const COLORS = ['#39d353', '#58a6ff', '#f0883e', '#f85149', '#bc8cff', '#ffa657', '#ff7b72', '#79c0ff']
 
@@ -22,8 +23,17 @@ export function Settings() {
   const loadDashboard = useAppStore((s) => s.loadDashboard)
   const handleRefreshIntervalChange = useAppStore((s) => s.handleRefreshIntervalChange)
   const updateRepoColor = useAppStore((s) => s.updateRepoColor)
+  const storeMaps = useAppStore((s) => s.maps)
+  const loadMaps = useAppStore((s) => s.loadMaps)
+  const assignRepoToMap = useAppStore((s) => s.assignRepoToMap)
+  const unassignRepoFromMap = useAppStore((s) => s.unassignRepoFromMap)
   const [openColorPicker, setOpenColorPicker] = useState<number | null>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
+
+  // Map assignment state: repoId → Set of assigned mapIds
+  const [repoMapIds, setRepoMapIds] = useState<Record<number, Set<number>>>({})
+  const [openMapPicker, setOpenMapPicker] = useState<number | null>(null)
+  const mapPickerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (openColorPicker === null) return
@@ -35,6 +45,63 @@ export function Settings() {
     document.addEventListener('mousedown', handleClick)
     return () => document.removeEventListener('mousedown', handleClick)
   }, [openColorPicker])
+
+  useEffect(() => {
+    if (openMapPicker === null) return
+    const handleClick = (e: MouseEvent) => {
+      if (mapPickerRef.current && !mapPickerRef.current.contains(e.target as Node)) {
+        setOpenMapPicker(null)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [openMapPicker])
+
+  // Load maps and their repo assignments
+  useEffect(() => {
+    loadMaps()
+  }, [])
+
+  useEffect(() => {
+    if (storeMaps.length === 0 || repos.length === 0) return
+    // Load all map-repo assignments and build repoId → Set<mapId>
+    Promise.all(storeMaps.map((m) => api.getMapRepos(m.id).then((r) => ({ mapId: m.id, repos: r }))))
+      .then((results) => {
+        const mapping: Record<number, Set<number>> = {}
+        for (const { mapId, repos: assignedRepos } of results) {
+          for (const repo of assignedRepos) {
+            if (!mapping[repo.id]) mapping[repo.id] = new Set()
+            mapping[repo.id].add(mapId)
+          }
+        }
+        setRepoMapIds(mapping)
+      })
+      .catch(() => {})
+  }, [storeMaps, repos])
+
+  const handleToggleRepoMap = async (repo: Repo, mapId: number) => {
+    const current = repoMapIds[repo.id] ?? new Set<number>()
+    const isAssigned = current.has(mapId)
+    try {
+      if (isAssigned) {
+        await unassignRepoFromMap(mapId, repo.id)
+        setRepoMapIds((prev) => {
+          const next = new Set(prev[repo.id] ?? [])
+          next.delete(mapId)
+          return { ...prev, [repo.id]: next }
+        })
+      } else {
+        await assignRepoToMap(mapId, repo.id)
+        setRepoMapIds((prev) => {
+          const next = new Set(prev[repo.id] ?? [])
+          next.add(mapId)
+          return { ...prev, [repo.id]: next }
+        })
+      }
+    } catch {
+      // toast already shown by store action
+    }
+  }
 
   const [fullName, setFullName] = useState('')
   const [selectedColor, setSelectedColor] = useState(COLORS[0])
@@ -371,6 +438,77 @@ export function Settings() {
                     )}
                   </div>
                   <span>{repo.fullName}</span>
+                </div>
+                <div className="repo-map-assignment" style={{ display: 'flex', alignItems: 'center', gap: '4px', flexWrap: 'wrap' }}>
+                  {storeMaps.length > 0 && (repoMapIds[repo.id]?.size ?? 0) === 0 && (
+                    <span className="repo-map-badge repo-map-badge-none">no map</span>
+                  )}
+                  {storeMaps
+                    .filter((m) => repoMapIds[repo.id]?.has(m.id))
+                    .map((m) => (
+                      <span
+                        key={m.id}
+                        className="repo-map-badge repo-map-badge-assigned"
+                        title={`Remove from "${m.name}"`}
+                        onClick={() => handleToggleRepoMap(repo, m.id)}
+                        style={{ cursor: 'pointer' }}
+                      >
+                        &#x25a6; {m.name} ✕
+                      </span>
+                    ))}
+                  {storeMaps.length > 0 && (
+                    <div style={{ position: 'relative' }}>
+                      <button
+                        className="btn btn-ghost btn-sm"
+                        style={{ fontSize: '11px', padding: '2px 6px' }}
+                        title="Assign to map"
+                        onClick={() => setOpenMapPicker(openMapPicker === repo.id ? null : repo.id)}
+                        type="button"
+                      >
+                        + map
+                      </button>
+                      {openMapPicker === repo.id && (
+                        <div ref={mapPickerRef} style={{
+                          position: 'absolute',
+                          top: '100%',
+                          right: 0,
+                          zIndex: 100,
+                          background: 'var(--surface)',
+                          border: '1px solid var(--border)',
+                          borderRadius: '6px',
+                          padding: '4px',
+                          boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+                          minWidth: '150px',
+                        }}>
+                          {storeMaps.map((m) => {
+                            const assigned = repoMapIds[repo.id]?.has(m.id) ?? false
+                            return (
+                              <div
+                                key={m.id}
+                                onClick={() => handleToggleRepoMap(repo, m.id)}
+                                style={{
+                                  padding: '6px 8px',
+                                  cursor: 'pointer',
+                                  borderRadius: '4px',
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  gap: '6px',
+                                  fontSize: '12px',
+                                  color: assigned ? 'var(--green-neon)' : 'var(--text)',
+                                  background: assigned ? 'rgba(0,255,136,0.08)' : 'transparent',
+                                }}
+                                onMouseEnter={(e) => (e.currentTarget.style.background = assigned ? 'rgba(0,255,136,0.15)' : 'var(--surface-hover, rgba(255,255,255,0.05))')}
+                                onMouseLeave={(e) => (e.currentTarget.style.background = assigned ? 'rgba(0,255,136,0.08)' : 'transparent')}
+                              >
+                                <span>{assigned ? '✓' : '○'}</span>
+                                <span>&#x25a6; {m.name}</span>
+                              </div>
+                            )
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </div>
                 <button
                   className="btn btn-danger btn-sm"

--- a/gh-ctrl/client/src/store.ts
+++ b/gh-ctrl/client/src/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { Repo, DashboardEntry, RepoData } from './types'
+import type { Repo, DashboardEntry, RepoData, GameMap } from './types'
 import { api } from './api'
 
 type ToastType = 'success' | 'error' | 'info'
@@ -28,6 +28,7 @@ interface AppStore {
   lastRefresh: Date | null
   refreshInterval: number
   toasts: Toast[]
+  maps: GameMap[]
 
   // Toast
   addToast: (message: string, type?: ToastType) => void
@@ -39,6 +40,9 @@ interface AppStore {
   loadSingleRepo: (owner: string, name: string) => Promise<void>
   handleRefreshIntervalChange: (ms: number) => void
   updateRepoColor: (id: number, color: string) => Promise<void>
+  loadMaps: () => Promise<void>
+  assignRepoToMap: (mapId: number, repoId: number) => Promise<void>
+  unassignRepoFromMap: (mapId: number, repoId: number) => Promise<void>
 }
 
 export const useAppStore = create<AppStore>((set, get) => ({
@@ -48,6 +52,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   lastRefresh: null,
   refreshInterval: getStoredRefreshInterval(),
   toasts: [],
+  maps: [],
 
   addToast: (message, type = 'info') => {
     const id = nextToastId++
@@ -119,6 +124,33 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }))
     } catch (err: any) {
       get().addToast(`Failed to update color: ${err.message}`, 'error')
+    }
+  },
+
+  loadMaps: async () => {
+    try {
+      const data = await api.listMaps()
+      set({ maps: data })
+    } catch (err: any) {
+      get().addToast(`Failed to load maps: ${err.message}`, 'error')
+    }
+  },
+
+  assignRepoToMap: async (mapId: number, repoId: number) => {
+    try {
+      await api.assignRepoToMap(mapId, repoId)
+    } catch (err: any) {
+      get().addToast(`Failed to assign repo to map: ${err.message}`, 'error')
+      throw err
+    }
+  },
+
+  unassignRepoFromMap: async (mapId: number, repoId: number) => {
+    try {
+      await api.unassignRepoFromMap(mapId, repoId)
+    } catch (err: any) {
+      get().addToast(`Failed to unassign repo from map: ${err.message}`, 'error')
+      throw err
     }
   },
 }))

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -587,10 +587,38 @@ a:hover { text-decoration: underline; }
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 8px;
   padding: 12px 16px;
   background: var(--bg-2);
   border: 1px solid var(--border);
   border-radius: 8px;
+}
+
+.repo-map-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-family: var(--font-mono, monospace);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.repo-map-badge-none {
+  color: var(--text-muted, #666);
+  background: transparent;
+}
+
+.repo-map-badge-assigned {
+  color: var(--green-neon, #00ff88);
+  background: rgba(0, 255, 136, 0.08);
+  border-color: rgba(0, 255, 136, 0.3);
+}
+
+.repo-map-badge-assigned:hover {
+  background: rgba(0, 255, 136, 0.15);
 }
 
 .repo-list-item-info {

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -217,4 +217,5 @@ export interface GameMap {
   tiles: string // JSON-encoded Record<string, MapTile> keyed by "col,row"
   createdAt: string | number | null
   updatedAt: string | number | null
+  assignedRepos?: Repo[]
 }

--- a/gh-ctrl/src/db/index.ts
+++ b/gh-ctrl/src/db/index.ts
@@ -28,4 +28,14 @@ sqlite.exec(`
   )
 `)
 
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS map_repos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    map_id INTEGER NOT NULL REFERENCES maps(id) ON DELETE CASCADE,
+    repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    created_at INTEGER DEFAULT (unixepoch()),
+    UNIQUE(map_id, repo_id)
+  )
+`)
+
 export const db = drizzle(sqlite, { schema })

--- a/gh-ctrl/src/db/schema.ts
+++ b/gh-ctrl/src/db/schema.ts
@@ -19,3 +19,10 @@ export const maps = sqliteTable('maps', {
   createdAt: integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
   updatedAt: integer('updated_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
 })
+
+export const mapRepos = sqliteTable('map_repos', {
+  id:        integer('id').primaryKey({ autoIncrement: true }),
+  mapId:     integer('map_id').notNull().references(() => maps.id),
+  repoId:    integer('repo_id').notNull().references(() => repos.id),
+  createdAt: integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+})

--- a/gh-ctrl/src/routes/maps.ts
+++ b/gh-ctrl/src/routes/maps.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { db } from '../db'
-import { maps } from '../db/schema'
-import { eq } from 'drizzle-orm'
+import { maps, mapRepos, repos } from '../db/schema'
+import { eq, and } from 'drizzle-orm'
 
 const app = new Hono()
 
@@ -67,6 +67,39 @@ app.delete('/:id', async (c) => {
   const id = Number(c.req.param('id'))
   const result = await db.delete(maps).where(eq(maps.id, id)).returning()
   if (result.length === 0) return c.json({ error: 'Map not found' }, 404)
+  return c.json({ ok: true })
+})
+
+// GET /:id/repos — list repos assigned to this map
+app.get('/:id/repos', async (c) => {
+  const id = Number(c.req.param('id'))
+  const map = await db.select().from(maps).where(eq(maps.id, id))
+  if (map.length === 0) return c.json({ error: 'Map not found' }, 404)
+  const result = await db
+    .select({ repo: repos })
+    .from(mapRepos)
+    .innerJoin(repos, eq(mapRepos.repoId, repos.id))
+    .where(eq(mapRepos.mapId, id))
+  return c.json(result.map((r) => r.repo))
+})
+
+// POST /:id/repos/:repoId — assign a repo to a map
+app.post('/:id/repos/:repoId', async (c) => {
+  const mapId = Number(c.req.param('id'))
+  const repoId = Number(c.req.param('repoId'))
+  const map = await db.select().from(maps).where(eq(maps.id, mapId))
+  if (map.length === 0) return c.json({ error: 'Map not found' }, 404)
+  const repo = await db.select().from(repos).where(eq(repos.id, repoId))
+  if (repo.length === 0) return c.json({ error: 'Repo not found' }, 404)
+  await db.insert(mapRepos).values({ mapId, repoId }).onConflictDoNothing()
+  return c.json({ ok: true })
+})
+
+// DELETE /:id/repos/:repoId — unassign a repo from a map
+app.delete('/:id/repos/:repoId', async (c) => {
+  const mapId = Number(c.req.param('id'))
+  const repoId = Number(c.req.param('repoId'))
+  await db.delete(mapRepos).where(and(eq(mapRepos.mapId, mapId), eq(mapRepos.repoId, repoId)))
   return c.json({ ok: true })
 })
 


### PR DESCRIPTION
Implements many-to-many repository-to-map assignment.

- New `map_repos` junction table with UNIQUE constraint
- Three new API endpoints (GET/POST/DELETE) for map repo assignments
- Map assignment UI in Settings page per repo
- BattlefieldView filters visible bases by active map's assigned repos

Closes #211

Generated with [Claude Code](https://claude.ai/code)