### PR TITLE
Unify battlefield dialogs & panels

### DIFF
--- a/gh-ctrl/client/src/components/ClawComChatDialog.tsx
+++ b/gh-ctrl/client/src/components/ClawComChatDialog.tsx
@@ -39,7 +39,6 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
     setSending(true)
     try {
       await api.sendBuildingMessage(building.id, content)
-      // Reload all messages to get any reply
       const updated = await api.getBuildingMessages(building.id)
       setMessages(updated)
     } catch (err: any) {
@@ -75,26 +74,24 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
   return (
     <div
       className="map-dialog"
-      style={{ display: 'flex', flexDirection: 'column' }}
       onWheel={(e) => e.stopPropagation()}
     >
         {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+        <div className="clawcom-chat-header">
           <div>
-            <div className="map-dialog-title" style={{ marginBottom: 2 }}>
+            <div className="map-dialog-title">
               &#x25a0; CLAWCOM — {building.name.toUpperCase()}
             </div>
-            <div style={{ fontSize: 11, color: 'var(--text-dim)' }}>
-              <span style={{ color: 'var(--green-neon)' }}>●</span>&nbsp;
+            <div className="clawcom-chat-status">
+              <span className="clawcom-chat-online-dot">●</span>&nbsp;
               {config.clawType?.toUpperCase() ?? 'CLAW'} @ {config.host}
             </div>
           </div>
-          <div style={{ display: 'flex', gap: 6 }}>
+          <div>
             <button
               className="hud-btn"
               onClick={handleDisconnect}
               title="Verbindung trennen und neu konfigurieren"
-              style={{ fontSize: 10 }}
             >
               ⚙ RESET
             </button>
@@ -102,53 +99,26 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
         </div>
 
         {/* Messages */}
-        <div style={{
-          flex: 1,
-          overflowY: 'auto',
-          background: 'var(--bg-darker)',
-          border: '1px solid var(--border)',
-          borderRadius: 4,
-          padding: 12,
-          minHeight: 200,
-          maxHeight: 380,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 8,
-          marginBottom: 12,
-        }}>
+        <div className="clawcom-chat-messages">
           {loading && (
-            <div style={{ color: 'var(--text-dim)', fontSize: 12, textAlign: 'center' }}>
+            <div className="clawcom-chat-status" style={{ textAlign: 'center' }}>
               ◌ Lade Nachrichten...
             </div>
           )}
           {!loading && messages.length === 0 && (
-            <div style={{ color: 'var(--text-dim)', fontSize: 12, textAlign: 'center', marginTop: 'auto', marginBottom: 'auto' }}>
+            <div className="clawcom-chat-status" style={{ textAlign: 'center', margin: 'auto' }}>
               Keine Nachrichten. Sende deinen ersten Befehl an den Claw.
             </div>
           )}
           {messages.map((msg) => (
             <div
               key={msg.id}
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: msg.direction === 'out' ? 'flex-end' : 'flex-start',
-              }}
+              className={`clawcom-chat-msg clawcom-chat-msg--${msg.direction === 'out' ? 'out' : 'in'}`}
             >
-              <div style={{
-                maxWidth: '80%',
-                padding: '6px 10px',
-                borderRadius: 4,
-                fontSize: 12,
-                lineHeight: 1.5,
-                background: msg.direction === 'out' ? 'rgba(0,255,136,0.12)' : 'rgba(255,255,255,0.06)',
-                border: `1px solid ${msg.direction === 'out' ? 'rgba(0,255,136,0.3)' : 'var(--border)'}`,
-                color: msg.direction === 'out' ? 'var(--green-neon)' : 'var(--text)',
-                wordBreak: 'break-word',
-              }}>
+              <div className={`clawcom-chat-bubble clawcom-chat-bubble--${msg.direction === 'out' ? 'out' : 'in'}`}>
                 {msg.content}
               </div>
-              <div style={{ fontSize: 10, color: 'var(--text-dim)', marginTop: 2 }}>
+              <div className="clawcom-chat-msg-meta">
                 {msg.direction === 'out' ? 'Du' : config.clawType ?? 'Claw'} · {formatTime(msg.createdAt)}
               </div>
             </div>
@@ -157,14 +127,13 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
         </div>
 
         {/* Input */}
-        <div style={{ display: 'flex', gap: 8 }}>
+        <div className="clawcom-chat-input-row">
           <input
             className="hud-input"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Befehl eingeben... (Enter zum Senden)"
-            style={{ flex: 1 }}
             disabled={sending}
             autoFocus
           />
@@ -173,11 +142,11 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
             onClick={handleSend}
             disabled={sending || !input.trim()}
           >
-            {sending ? '◌' : '&#x27a4; SENDEN'}
+            {sending ? '◌' : '➤ SENDEN'}
           </button>
         </div>
 
-        <div className="map-dialog-actions" style={{ marginTop: 12 }}>
+        <div className="map-dialog-actions">
           <button className="hud-btn" onClick={onClose}>SCHLIESSEN</button>
         </div>
     </div>

--- a/gh-ctrl/client/src/components/ClawComSetupDialog.tsx
+++ b/gh-ctrl/client/src/components/ClawComSetupDialog.tsx
@@ -67,29 +67,26 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
     >
         <div className="map-dialog-title">&#x25a0; {building.name.toUpperCase()} — SETUP</div>
 
-        <div style={{ display: 'flex', gap: 20, marginBottom: 20, alignItems: 'flex-start' }}>
+        <div className="clawcom-setup-body">
           <img
             src="/buildings/clawcom.png"
             alt="ClawCom"
-            style={{ width: 96, height: 96, objectFit: 'contain', flexShrink: 0 }}
+            className="clawcom-setup-preview-img"
           />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 12, color: 'var(--text-dim)', marginBottom: 16, lineHeight: 1.5 }}>
+          <div className="clawcom-setup-form">
+            <div className="clawcom-setup-desc">
               Konfiguriere die Verbindung zu einem Openclaw oder Nanoclaw. Nach der Einrichtung
               kannst du Befehle über das integrierte Chatfenster senden und empfangen.
             </div>
 
-            <div style={{ marginBottom: 14 }}>
-              <label style={{ display: 'block', fontSize: 11, color: 'var(--text-dim)', marginBottom: 6 }}>
-                CLAW TYP
-              </label>
-              <div style={{ display: 'flex', gap: 8 }}>
+            <div className="clawcom-setup-group">
+              <label className="clawcom-setup-group-label">Claw Typ</label>
+              <div className="clawcom-setup-row">
                 {(['openclaw', 'nanoclaw'] as const).map((t) => (
                   <button
                     key={t}
                     className={`hud-btn${clawType === t ? ' active' : ''}`}
                     onClick={() => setClawType(t)}
-                    style={{ flex: 1 }}
                   >
                     {t === 'openclaw' ? '⚙ OPENCLAW' : '⬡ NANOCLAW'}
                   </button>
@@ -97,17 +94,14 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
               </div>
             </div>
 
-            <div style={{ marginBottom: 14 }}>
-              <label style={{ display: 'block', fontSize: 11, color: 'var(--text-dim)', marginBottom: 4 }}>
-                HOST URL
-              </label>
-              <div style={{ display: 'flex', gap: 8 }}>
+            <div className="clawcom-setup-group">
+              <label className="clawcom-setup-group-label">Host URL</label>
+              <div className="clawcom-setup-row">
                 <input
                   className="hud-input"
                   value={host}
                   onChange={(e) => setHost(e.target.value)}
                   placeholder="http://192.168.1.100:8080"
-                  style={{ flex: 1 }}
                 />
                 <button
                   className="hud-btn"
@@ -119,11 +113,7 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
                 </button>
               </div>
               {testResult && (
-                <div style={{
-                  marginTop: 6,
-                  fontSize: 11,
-                  color: testResult.startsWith('✓') ? 'var(--green-neon)' : '#ff6b6b',
-                }}>
+                <div className={`clawcom-test-result ${testResult.startsWith('✓') ? 'clawcom-test-result--ok' : 'clawcom-test-result--err'}`}>
                   {testResult}
                 </div>
               )}
@@ -138,7 +128,7 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
             onClick={handleSave}
             disabled={saving}
           >
-            {saving ? '◌ SPEICHERN...' : '&#x2713; KONFIGURIEREN'}
+            {saving ? '◌ SPEICHERN...' : '✓ KONFIGURIEREN'}
           </button>
         </div>
     </div>

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -2797,11 +2797,11 @@ select.input {
 
 .cnc-sidebar {
   position: fixed;
-  top: 0;
+  top: 56px;
   right: 0;
-  bottom: 0;
+  height: calc(100vh - 56px);
   width: 220px;
-  z-index: 50;
+  z-index: 200;
   display: flex;
   flex-direction: column;
   background: linear-gradient(180deg, #081410 0%, #040c08 100%);
@@ -3062,6 +3062,15 @@ select.input {
     width: 52px;
     height: 52px;
   }
+}
+
+/* ---- Construct Overlay (backdrop for centered construct dialogs) ---- */
+.construct-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  z-index: 99;
 }
 
 /* ---- Construction Dialog ---- */
@@ -3651,7 +3660,7 @@ select.input {
   position: fixed;
   top: 56px;
   right: 0;
-  width: 420px;
+  width: 460px;
   max-width: 100vw;
   height: calc(100vh - 56px);
   overflow-y: auto;
@@ -4349,18 +4358,19 @@ select.input {
 /* ── FeedPanel ──────────────────────────────────────────────────────────────── */
 
 .feed-panel {
-  position: absolute;
+  position: fixed;
   top: 56px;
   right: 0;
   width: 340px;
   height: calc(100vh - 56px);
-  background: rgba(5, 8, 9, 0.97);
-  border-left: 1px solid rgba(57, 255, 20, 0.3);
+  background: rgba(4, 7, 8, 0.98);
+  border-left: 2px solid rgba(57, 255, 20, 0.4);
   display: flex;
   flex-direction: column;
   z-index: 20;
   font-family: var(--font-mono);
-  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.6);
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.8);
+  animation: silo-panel-in 0.18s ease-out;
 }
 
 .feed-panel-header {
@@ -4664,6 +4674,154 @@ select.input {
 .branch-silo-active.branch-silo-selected .branch-silo-tower  { outline-color: #00d4ff; }
 .branch-silo-stale.branch-silo-selected .branch-silo-tower   { outline-color: var(--crt-amber); }
 .branch-silo-very-stale.branch-silo-selected .branch-silo-tower { outline-color: var(--crt-red); }
+
+/* ── ClawCom Setup Dialog ── */
+
+.clawcom-setup-body {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 20px;
+  align-items: flex-start;
+}
+
+.clawcom-setup-preview-img {
+  width: 96px;
+  height: 96px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.clawcom-setup-form {
+  flex: 1;
+}
+
+.clawcom-setup-desc {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+.clawcom-setup-group {
+  margin-bottom: 14px;
+}
+
+.clawcom-setup-group-label {
+  display: block;
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-bottom: 6px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.clawcom-setup-row {
+  display: flex;
+  gap: 8px;
+}
+
+.clawcom-setup-row .hud-btn,
+.clawcom-setup-row .hud-input {
+  flex: 1;
+}
+
+.clawcom-test-result {
+  margin-top: 6px;
+  font-size: 11px;
+}
+
+.clawcom-test-result--ok {
+  color: var(--green-neon, var(--crt-green));
+}
+
+.clawcom-test-result--err {
+  color: #ff6b6b;
+}
+
+/* ── ClawCom Chat Dialog ── */
+
+.clawcom-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.clawcom-chat-status {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+
+.clawcom-chat-online-dot {
+  color: var(--green-neon, var(--crt-green));
+}
+
+.clawcom-chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--bg-darker, rgba(4, 7, 8, 0.95));
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 12px;
+  min-height: 200px;
+  max-height: 380px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(57, 255, 20, 0.2) transparent;
+}
+
+.clawcom-chat-msg {
+  display: flex;
+  flex-direction: column;
+}
+
+.clawcom-chat-msg--out {
+  align-items: flex-end;
+}
+
+.clawcom-chat-msg--in {
+  align-items: flex-start;
+}
+
+.clawcom-chat-bubble {
+  max-width: 80%;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.clawcom-chat-bubble--out {
+  background: rgba(0, 255, 136, 0.12);
+  border: 1px solid rgba(0, 255, 136, 0.3);
+  color: var(--green-neon, var(--crt-green));
+}
+
+.clawcom-chat-bubble--in {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.clawcom-chat-msg-meta {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+
+.clawcom-chat-input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.clawcom-chat-input-row .hud-input {
+  flex: 1;
+}
 
 /* ── Branch Silo Panel (C&C-style right-side command panel) ── */
 


### PR DESCRIPTION
Fixes #226 — Unify Dialogs battlefield

## Changes

- Add `.construct-overlay` CSS definition (was missing, causing no backdrop in CreateBaseDialog)
- Fix `cnc-sidebar` (BuildOptionsMenu): now starts at `top: 56px` like all other panels instead of covering the header bar
- Unify `.map-dialog` width to 460px (matches `.construct-dialog`)
- Fix `.feed-panel`: `position: fixed`, consistent 2px border, shadow, and slide-in animation
- Replace inline styles in `ClawComSetupDialog` and `ClawComChatDialog` with proper CSS classes

Generated with [Claude Code](https://claude.ai/code)