### PR TITLE
feat: New Base creation moved into Build dialog as clawCom-style option

### DIFF
--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -7,8 +7,7 @@ import { BaseNode, BaseDetailPanel } from './BaseNode'
 import { ActionModal } from './ActionModal'
 import type { ModalState } from './ActionModal'
 import { ConstructDialog } from './ConstructDialog'
-import { CreateBaseDialog } from './CreateBaseDialog'
-import { CloseIcon, RelocateIcon, ScanIcon, BuildIcon, MapIcon, FeedIcon, PlusIcon } from './Icons'
+import { CloseIcon, RelocateIcon, ScanIcon, BuildIcon, MapIcon, FeedIcon } from './Icons'
 import { FeedPanel } from './FeedPanel'
 import { useSound } from '../hooks/useSound'
 import { useAppStore } from '../store'
@@ -356,7 +355,6 @@ export function BattlefieldView() {
   const [relocatingStart, setRelocatingStart] = useState<{ mouseX: number; mouseY: number; nodeX: number; nodeY: number } | null>(null)
   const [constructTarget, setConstructTarget] = useState<DashboardEntry | null>(null)
   const [isRelocateMode, setIsRelocateMode] = useState(false)
-  const [showCreateBase, setShowCreateBase] = useState(false)
   const [modalState, setModalState] = useState<ModalState>(null)
   const [activeMap, setActiveMap] = useState<GameMap | null>(null)
   const [allMaps, setAllMaps] = useState<GameMap[]>([])
@@ -787,13 +785,6 @@ export function BattlefieldView() {
             <span className="hud-label"> {isRelocateMode ? 'CANCEL' : 'RELOCATE'}</span>
           </button>
           <button
-            className="hud-btn hud-btn-new-base"
-            onClick={() => { play('peep'); setShowCreateBase(true) }}
-            title="Create new base"
-          >
-            <PlusIcon size={10} /><span className="hud-label"> NEW BASE</span>
-          </button>
-          <button
             className="hud-btn"
             onClick={() => { play('hydraulic'); setShowBuildMenu(true) }}
             title="Bau Optionen (ClawCom, etc.)"
@@ -983,19 +974,6 @@ export function BattlefieldView() {
         />
       )}
 
-      {/* Create new base dialog */}
-      {showCreateBase && (
-        <CreateBaseDialog
-          onClose={() => setShowCreateBase(false)}
-          onSuccess={(msg) => {
-            addToast(msg, 'success')
-            setShowCreateBase(false)
-            onReposChange()
-          }}
-          onError={(msg) => addToast(msg, 'error')}
-        />
-      )}
-
       {/* Map selector dialog */}
       {showMapSelector && (
         <LoadBattlefieldMapDialog
@@ -1010,10 +988,26 @@ export function BattlefieldView() {
       {showBuildMenu && (
         <BuildOptionsMenu
           onClose={() => setShowBuildMenu(false)}
-          onStartPlacement={(params) => {
-            setShowBuildMenu(false)
-            setPlacementMode(params)
-            setGhostScreenPos({ x: window.innerWidth / 2, y: window.innerHeight / 2 })
+          onStartPlacement={async (params) => {
+            if (params.type === 'new-base') {
+              setShowBuildMenu(false)
+              try {
+                await api.createRepo({
+                  name: params.name,
+                  description: params.repoDescription,
+                  visibility: params.repoVisibility ?? 'private',
+                })
+                addToast(`Base "${params.name}" established!`, 'success')
+                loadRepos()
+                onRefresh()
+              } catch (err) {
+                addToast(err instanceof Error ? err.message : 'Failed to create repository', 'error')
+              }
+            } else {
+              setShowBuildMenu(false)
+              setPlacementMode(params)
+              setGhostScreenPos({ x: window.innerWidth / 2, y: window.innerHeight / 2 })
+            }
           }}
         />
       )}

--- a/gh-ctrl/client/src/components/BuildOptionsMenu.tsx
+++ b/gh-ctrl/client/src/components/BuildOptionsMenu.tsx
@@ -18,6 +18,14 @@ const AVAILABLE_BUILDINGS: BuildingDef[] = [
     buildImage: '/buildings/build_clawcom.png',
     defaultColor: '#00ff88',
   },
+  {
+    type: 'new-base',
+    name: 'New Base',
+    description:
+      'Etabliere ein neues GitHub-Repository direkt vom Schlachtfeld. Konfiguriere Namen, Beschreibung und Sichtbarkeit — das neue Hauptquartier erscheint sofort in deiner Kommandozentrale.',
+    buildImage: '/buildings/build_clawcom.png',
+    defaultColor: '#00ff88',
+  },
 ]
 
 export interface PlacementParams {
@@ -25,6 +33,8 @@ export interface PlacementParams {
   name: string
   color: string
   buildImage: string
+  repoDescription?: string
+  repoVisibility?: 'public' | 'private'
 }
 
 interface BuildOptionsMenuProps {
@@ -32,24 +42,38 @@ interface BuildOptionsMenuProps {
   onStartPlacement: (params: PlacementParams) => void
 }
 
+const REPO_NAME_RE = /^[a-zA-Z0-9._-]+$/
+
 export function BuildOptionsMenu({ onClose, onStartPlacement }: BuildOptionsMenuProps) {
   const [selected, setSelected] = useState<BuildingDef | null>(null)
   const [buildName, setBuildName] = useState('')
   const [color, setColor] = useState('#00ff88')
+  const [repoDescription, setRepoDescription] = useState('')
+  const [repoVisibility, setRepoVisibility] = useState<'public' | 'private'>('private')
 
   function selectBuilding(b: BuildingDef) {
     setSelected(b)
-    setBuildName(b.name)
+    setBuildName(b.type === 'new-base' ? '' : b.name)
     setColor(b.defaultColor)
+    setRepoDescription('')
+    setRepoVisibility('private')
   }
 
+  const isNewBase = selected?.type === 'new-base'
+  const repoNameValid = !isNewBase || REPO_NAME_RE.test(buildName.trim())
+  const canSubmit = !!selected && (!isNewBase || (buildName.trim().length > 0 && repoNameValid))
+
   function handlePlatzieren() {
-    if (!selected) return
+    if (!selected || !canSubmit) return
     onStartPlacement({
       type: selected.type,
       name: buildName.trim() || selected.name,
       color,
       buildImage: selected.buildImage,
+      ...(isNewBase && {
+        repoDescription: repoDescription.trim() || undefined,
+        repoVisibility,
+      }),
     })
   }
 
@@ -71,26 +95,72 @@ export function BuildOptionsMenu({ onClose, onStartPlacement }: BuildOptionsMenu
             <img className="cnc-preview-img" src={selected.buildImage} alt={selected.name} />
             <div className="cnc-preview-name">{selected.name}</div>
             <div className="cnc-preview-desc">{selected.description}</div>
-            <div className="cnc-field">
-              <label>BEZEICHNUNG</label>
-              <input
-                className="hud-input cnc-input"
-                value={buildName}
-                onChange={(e) => setBuildName(e.target.value)}
-                placeholder={selected.name}
-              />
-            </div>
-            <div className="cnc-field">
-              <label>FARBE</label>
-              <div className="cnc-color-row">
-                <input
-                  type="color"
-                  value={color}
-                  onChange={(e) => setColor(e.target.value)}
-                />
-                <span>{color.toUpperCase()}</span>
-              </div>
-            </div>
+            {isNewBase ? (
+              <>
+                <div className="cnc-field">
+                  <label>BASE DESIGNATION</label>
+                  <input
+                    className="hud-input cnc-input"
+                    value={buildName}
+                    onChange={(e) => setBuildName(e.target.value)}
+                    placeholder="my-new-repo"
+                    style={buildName.trim() && !repoNameValid ? { borderColor: '#ff4444' } : undefined}
+                  />
+                  {buildName.trim() && !repoNameValid && (
+                    <div style={{ color: '#ff4444', fontSize: 10, marginTop: 2 }}>
+                      Only letters, numbers, hyphens, dots and underscores
+                    </div>
+                  )}
+                </div>
+                <div className="cnc-field">
+                  <label>INTEL BRIEF</label>
+                  <input
+                    className="hud-input cnc-input"
+                    value={repoDescription}
+                    onChange={(e) => setRepoDescription(e.target.value)}
+                    placeholder="Optional description"
+                  />
+                </div>
+                <div className="cnc-field">
+                  <label>CLEARANCE LEVEL</label>
+                  <div className="cnc-color-row">
+                    <button
+                      className={`hud-btn${repoVisibility === 'private' ? ' active' : ''}`}
+                      style={{ fontSize: 10 }}
+                      onClick={() => setRepoVisibility('private')}
+                    >PRIVATE</button>
+                    <button
+                      className={`hud-btn${repoVisibility === 'public' ? ' active' : ''}`}
+                      style={{ fontSize: 10 }}
+                      onClick={() => setRepoVisibility('public')}
+                    >PUBLIC</button>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="cnc-field">
+                  <label>BEZEICHNUNG</label>
+                  <input
+                    className="hud-input cnc-input"
+                    value={buildName}
+                    onChange={(e) => setBuildName(e.target.value)}
+                    placeholder={selected.name}
+                  />
+                </div>
+                <div className="cnc-field">
+                  <label>FARBE</label>
+                  <div className="cnc-color-row">
+                    <input
+                      type="color"
+                      value={color}
+                      onChange={(e) => setColor(e.target.value)}
+                    />
+                    <span>{color.toUpperCase()}</span>
+                  </div>
+                </div>
+              </>
+            )}
           </>
         ) : (
           <div className="cnc-preview-empty">
@@ -127,10 +197,10 @@ export function BuildOptionsMenu({ onClose, onStartPlacement }: BuildOptionsMenu
         <button
           className="hud-btn hud-btn-new-base"
           onClick={handlePlatzieren}
-          disabled={!selected}
-          title={!selected ? 'Kein Gebäude ausgewählt' : 'Auf Karte platzieren'}
+          disabled={!canSubmit}
+          title={!selected ? 'Kein Gebäude ausgewählt' : isNewBase ? 'Repository erstellen' : 'Auf Karte platzieren'}
         >
-          <PlusIcon size={9} /> PLATZIEREN
+          <PlusIcon size={9} /> {isNewBase ? 'ERSTELLEN' : 'PLATZIEREN'}
         </button>
       </div>
 


### PR DESCRIPTION
Moves the "New Base" repository creation flow into the BUILD options menu alongside ClawCom.

Closes #232

Generated with [Claude Code](https://claude.ai/code)