### PR TITLE
feat: add custom badges for battlefield map landmarks

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData, SetupStatus, Building, ClawComMessage } from './types'
+import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData, SetupStatus, Building, ClawComMessage, Badge, PlacedBadge } from './types'
 
 export function getServerUrl(): string {
   return localStorage.getItem('serverUrl')?.replace(/\/$/, '') ?? ''
@@ -289,4 +289,42 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ content }),
     }),
+
+  uploadBadge: (file: File, name: string): Promise<Badge> => {
+    const serverUrl = getServerUrl()
+    const base = serverUrl ? `${serverUrl}/api` : '/api'
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('name', name)
+    return fetch(`${base}/badges/upload`, { method: 'POST', body: formData })
+      .then(async (res) => {
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: res.statusText }))
+          throw new Error(err.error || res.statusText)
+        }
+        return res.json()
+      })
+  },
+
+  listBadges: () => request<Badge[]>('/badges'),
+
+  deleteBadge: (id: number) =>
+    request<{ ok: boolean }>(`/badges/${id}`, { method: 'DELETE' }),
+
+  listPlacedBadges: () => request<PlacedBadge[]>('/badges/placed'),
+
+  placeBadge: (params: { badgeId: number; posX: number; posY: number; scale?: number; label?: string; mapId?: number | null }) =>
+    request<PlacedBadge>('/badges/placed', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
+
+  updatePlacedBadge: (id: number, updates: { posX?: number; posY?: number; scale?: number; label?: string }) =>
+    request<PlacedBadge>(`/badges/placed/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(updates),
+    }),
+
+  removePlacedBadge: (id: number) =>
+    request<{ ok: boolean }>(`/badges/placed/${id}`, { method: 'DELETE' }),
 }

--- a/gh-ctrl/client/src/components/BadgeLibraryDialog.tsx
+++ b/gh-ctrl/client/src/components/BadgeLibraryDialog.tsx
@@ -1,0 +1,256 @@
+import { useState, useRef, useCallback } from 'react'
+import { useAppStore } from '../store'
+import type { Badge } from '../types'
+
+interface BadgeLibraryDialogProps {
+  onClose: () => void
+  onSelectForPlacement: (badge: Badge) => void
+  serverUrl: string
+}
+
+export function BadgeLibraryDialog({ onClose, onSelectForPlacement, serverUrl }: BadgeLibraryDialogProps) {
+  const badges = useAppStore((s) => s.badges)
+  const uploadBadge = useAppStore((s) => s.uploadBadge)
+  const deleteBadge = useAppStore((s) => s.deleteBadge)
+  const addToast = useAppStore((s) => s.addToast)
+
+  const [activeTab, setActiveTab] = useState<'library' | 'upload'>('library')
+  const [uploading, setUploading] = useState(false)
+  const [uploadName, setUploadName] = useState('')
+  const [dragOver, setDragOver] = useState(false)
+  const [pendingFile, setPendingFile] = useState<File | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  function getBadgeUrl(badge: Badge) {
+    return `${serverUrl}/uploads/badges/${badge.filename}`
+  }
+
+  const handleFileSelect = useCallback((file: File) => {
+    if (!file.type.startsWith('image/')) {
+      addToast('Only image files are allowed', 'error')
+      return
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      addToast('File exceeds 5MB limit', 'error')
+      return
+    }
+    setPendingFile(file)
+    if (!uploadName) setUploadName(file.name.replace(/\.[^.]+$/, ''))
+  }, [uploadName, addToast])
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault()
+    setDragOver(false)
+    const file = e.dataTransfer.files[0]
+    if (file) handleFileSelect(file)
+  }
+
+  async function handleUpload() {
+    if (!pendingFile) { addToast('Select a file first', 'error'); return }
+    if (!uploadName.trim()) { addToast('Enter a badge name', 'error'); return }
+    setUploading(true)
+    try {
+      await uploadBadge(pendingFile, uploadName.trim())
+      addToast(`Badge "${uploadName.trim()}" uploaded!`, 'success')
+      setPendingFile(null)
+      setUploadName('')
+      setActiveTab('library')
+    } catch { /* toast shown by store */ }
+    finally { setUploading(false) }
+  }
+
+  async function handleDelete(badge: Badge) {
+    if (!confirm(`Delete badge "${badge.name}"? This will also remove all placed instances.`)) return
+    try {
+      await deleteBadge(badge.id)
+      addToast(`Badge "${badge.name}" deleted`, 'info')
+    } catch { /* toast shown by store */ }
+  }
+
+  return (
+    <div
+      className="map-dialog-overlay"
+      onClick={onClose}
+      onWheel={(e) => e.stopPropagation()}
+    >
+      <div
+        className="map-dialog"
+        style={{ minWidth: 420, maxWidth: 520 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="map-dialog-title">&#x25a0; BADGE LIBRARY</div>
+
+        {/* Tabs */}
+        <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+          <button
+            className={`hud-btn${activeTab === 'library' ? ' active' : ''}`}
+            onClick={() => setActiveTab('library')}
+            style={{ flex: 1 }}
+          >
+            LIBRARY ({badges.length})
+          </button>
+          <button
+            className={`hud-btn${activeTab === 'upload' ? ' active' : ''}`}
+            onClick={() => setActiveTab('upload')}
+            style={{ flex: 1 }}
+          >
+            + UPLOAD
+          </button>
+        </div>
+
+        {activeTab === 'library' && (
+          <div>
+            {badges.length === 0 ? (
+              <div className="map-dialog-empty" style={{ padding: '24px 0', textAlign: 'center' }}>
+                No badges uploaded yet. Go to the Upload tab to add one.
+              </div>
+            ) : (
+              <div style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(3, 1fr)',
+                gap: 10,
+                maxHeight: 320,
+                overflowY: 'auto',
+                padding: '4px 2px',
+              }}>
+                {badges.map((badge) => (
+                  <div
+                    key={badge.id}
+                    style={{
+                      background: 'var(--bg-panel)',
+                      border: '1px solid var(--green-neon)33',
+                      borderRadius: 6,
+                      padding: 10,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: 6,
+                      cursor: 'pointer',
+                      transition: 'border-color 0.15s',
+                    }}
+                    onMouseEnter={(e) => (e.currentTarget.style.borderColor = 'var(--green-neon)')}
+                    onMouseLeave={(e) => (e.currentTarget.style.borderColor = 'var(--green-neon)33')}
+                    onClick={() => { onSelectForPlacement(badge); onClose() }}
+                  >
+                    <img
+                      src={getBadgeUrl(badge)}
+                      alt={badge.name}
+                      style={{ width: 48, height: 48, objectFit: 'contain' }}
+                    />
+                    <div style={{
+                      fontSize: 10,
+                      color: 'var(--green-neon)',
+                      textAlign: 'center',
+                      maxWidth: '100%',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}>
+                      {badge.name}
+                    </div>
+                    <button
+                      className="hud-btn"
+                      style={{ fontSize: 9, padding: '1px 6px', color: '#ff6b6b' }}
+                      onClick={(e) => { e.stopPropagation(); handleDelete(badge) }}
+                      title="Delete badge"
+                    >
+                      ✕ DELETE
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            {badges.length > 0 && (
+              <div style={{ fontSize: 10, color: 'var(--text-dim)', marginTop: 10, textAlign: 'center' }}>
+                Click a badge to place it on the battlefield
+              </div>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'upload' && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {/* Drop zone */}
+            <div
+              style={{
+                border: `2px dashed ${dragOver ? 'var(--green-neon)' : 'var(--green-neon)55'}`,
+                borderRadius: 8,
+                padding: '24px 16px',
+                textAlign: 'center',
+                cursor: 'pointer',
+                background: dragOver ? 'var(--green-neon)11' : 'transparent',
+                transition: 'all 0.15s',
+              }}
+              onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
+              onDragLeave={() => setDragOver(false)}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                style={{ display: 'none' }}
+                onChange={(e) => { const f = e.target.files?.[0]; if (f) handleFileSelect(f) }}
+              />
+              {pendingFile ? (
+                <div style={{ color: 'var(--green-neon)', fontSize: 12 }}>
+                  <div>✓ {pendingFile.name}</div>
+                  <div style={{ fontSize: 10, color: 'var(--text-dim)', marginTop: 4 }}>
+                    {(pendingFile.size / 1024).toFixed(1)} KB · {pendingFile.type}
+                  </div>
+                </div>
+              ) : (
+                <div style={{ color: 'var(--text-dim)', fontSize: 11 }}>
+                  <div style={{ fontSize: 24, marginBottom: 8 }}>⬆</div>
+                  Drag & drop an image or click to browse
+                  <div style={{ fontSize: 10, marginTop: 4 }}>PNG, SVG, JPG, WebP · Max 5MB</div>
+                </div>
+              )}
+            </div>
+
+            {/* Name field */}
+            <div>
+              <label style={{ fontSize: 10, color: 'var(--text-dim)', display: 'block', marginBottom: 4 }}>
+                BADGE NAME
+              </label>
+              <input
+                type="text"
+                value={uploadName}
+                onChange={(e) => setUploadName(e.target.value)}
+                placeholder="e.g. Command Post, Danger Zone..."
+                style={{
+                  width: '100%',
+                  background: 'var(--bg-panel)',
+                  border: '1px solid var(--green-neon)55',
+                  color: 'var(--green-neon)',
+                  padding: '6px 8px',
+                  borderRadius: 4,
+                  fontSize: 12,
+                  outline: 'none',
+                  boxSizing: 'border-box',
+                }}
+                onFocus={(e) => (e.target.style.borderColor = 'var(--green-neon)')}
+                onBlur={(e) => (e.target.style.borderColor = 'var(--green-neon)55')}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleUpload() }}
+              />
+            </div>
+
+            <button
+              className="hud-btn"
+              style={{ padding: '6px 12px', fontSize: 12 }}
+              onClick={handleUpload}
+              disabled={uploading || !pendingFile || !uploadName.trim()}
+            >
+              {uploading ? '⟳ UPLOADING...' : '⬆ UPLOAD BADGE'}
+            </button>
+          </div>
+        )}
+
+        <div className="map-dialog-actions" style={{ marginTop: 16 }}>
+          <button className="hud-btn" onClick={onClose}>CLOSE</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/components/BadgeMarker.tsx
+++ b/gh-ctrl/client/src/components/BadgeMarker.tsx
@@ -1,0 +1,197 @@
+import { useState, useRef } from 'react'
+import { useAppStore } from '../store'
+import type { PlacedBadge } from '../types'
+import { api } from '../api'
+
+interface BadgeMarkerProps {
+  placedBadge: PlacedBadge
+  position: { x: number; y: number }
+  isRelocateMode: boolean
+  isBeingRelocated: boolean
+  onStartRelocate: (mouseX: number, mouseY: number) => void
+  addToast: (msg: string, type?: 'success' | 'error' | 'info') => void
+  serverUrl: string
+}
+
+export function BadgeMarker({
+  placedBadge,
+  position,
+  isRelocateMode,
+  isBeingRelocated,
+  onStartRelocate,
+  addToast,
+  serverUrl,
+}: BadgeMarkerProps) {
+  const removePlacedBadge = useAppStore((s) => s.removePlacedBadge)
+  const updatePlacedBadgeScale = useAppStore((s) => s.updatePlacedBadgeScale)
+  const updatePlacedBadgeLabel = useAppStore((s) => s.updatePlacedBadgeLabel)
+
+  const [showActions, setShowActions] = useState(false)
+  const [editingLabel, setEditingLabel] = useState(false)
+  const [labelValue, setLabelValue] = useState(placedBadge.label ?? '')
+  const [scale, setScale] = useState(placedBadge.scale)
+  const labelInputRef = useRef<HTMLInputElement>(null)
+
+  const badge = placedBadge.badge
+  const imgSrc = badge
+    ? `${serverUrl}/uploads/badges/${badge.filename}`
+    : ''
+
+  const imgSize = Math.round(48 * scale)
+
+  function handleMouseDown(e: React.MouseEvent) {
+    if (isRelocateMode) {
+      e.stopPropagation()
+      onStartRelocate(e.clientX, e.clientY)
+    }
+  }
+
+  async function handleRemove() {
+    if (!confirm(`Remove badge "${badge?.name ?? 'badge'}"?`)) return
+    try {
+      await removePlacedBadge(placedBadge.id)
+    } catch { /* toast shown by store */ }
+  }
+
+  async function handleScaleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const newScale = Number(e.target.value)
+    setScale(newScale)
+    await updatePlacedBadgeScale(placedBadge.id, newScale)
+  }
+
+  async function handleLabelSave() {
+    setEditingLabel(false)
+    await updatePlacedBadgeLabel(placedBadge.id, labelValue)
+  }
+
+  async function handleLabelKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') await handleLabelSave()
+    if (e.key === 'Escape') { setEditingLabel(false); setLabelValue(placedBadge.label ?? '') }
+  }
+
+  return (
+    <div
+      className="base-node badge-marker"
+      style={{
+        position: 'absolute',
+        left: position.x,
+        top: position.y,
+        transform: 'translate(-50%, -50%)',
+        cursor: isRelocateMode ? 'grab' : 'pointer',
+        userSelect: 'none',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 3,
+        zIndex: isBeingRelocated ? 100 : 2,
+        opacity: isBeingRelocated ? 0.75 : 1,
+      }}
+      onMouseDown={handleMouseDown}
+      onClick={() => { if (!isRelocateMode) setShowActions((v) => !v) }}
+    >
+      {badge && (
+        <img
+          src={imgSrc}
+          alt={badge.name}
+          style={{
+            width: imgSize,
+            height: imgSize,
+            objectFit: 'contain',
+            imageRendering: 'auto',
+            filter: isBeingRelocated ? 'brightness(1.5) drop-shadow(0 0 6px #fff)' : 'drop-shadow(0 0 4px rgba(0,255,136,0.5))',
+            transition: 'width 0.15s, height 0.15s',
+          }}
+          draggable={false}
+        />
+      )}
+
+      {/* Label */}
+      {editingLabel ? (
+        <input
+          ref={labelInputRef}
+          autoFocus
+          value={labelValue}
+          onChange={(e) => setLabelValue(e.target.value)}
+          onBlur={handleLabelSave}
+          onKeyDown={handleLabelKeyDown}
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            background: 'var(--bg-panel)',
+            border: '1px solid var(--green-neon)',
+            color: 'var(--green-neon)',
+            fontSize: 10,
+            padding: '1px 4px',
+            borderRadius: 2,
+            width: 90,
+            textAlign: 'center',
+            outline: 'none',
+          }}
+        />
+      ) : (
+        <div style={{
+          fontSize: 10,
+          fontWeight: 600,
+          color: 'var(--green-neon)',
+          textAlign: 'center',
+          textShadow: '0 0 6px var(--green-neon)44',
+          maxWidth: 100,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minHeight: 14,
+        }}>
+          {labelValue || badge?.name || ''}
+        </div>
+      )}
+
+      {/* Action bar — shown on click */}
+      {showActions && !isRelocateMode && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 4,
+            padding: '4px 6px',
+            background: 'var(--bg-panel)',
+            border: '1px solid var(--green-neon)44',
+            borderRadius: 4,
+            marginTop: 2,
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+            <span style={{ fontSize: 9, color: 'var(--text-dim)' }}>SIZE</span>
+            <input
+              type="range"
+              min="0.25"
+              max="3"
+              step="0.05"
+              value={scale}
+              onChange={handleScaleChange}
+              style={{ width: 70 }}
+            />
+            <span style={{ fontSize: 9, color: 'var(--green-neon)', minWidth: 28 }}>{Math.round(scale * 100)}%</span>
+          </div>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <button
+              className="hud-btn"
+              style={{ fontSize: 9, padding: '1px 5px', flex: 1 }}
+              onClick={() => { setEditingLabel(true); setShowActions(false) }}
+              title="Edit label"
+            >
+              ✎
+            </button>
+            <button
+              className="hud-btn"
+              style={{ fontSize: 9, padding: '1px 5px', color: '#ff6b6b', flex: 1 }}
+              onClick={handleRemove}
+              title="Remove badge"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
-import type { DashboardEntry, GameMap, MapTile, Building } from '../types'
+import type { DashboardEntry, GameMap, MapTile, Building, Badge } from '../types'
 import { BranchSiloPanel } from './BranchSiloPanel'
 import { api } from '../api'
+import { getServerUrl } from '../api'
 import { getBranchState } from './BranchBuilding'
 import { BaseNode, BaseDetailPanel } from './BaseNode'
 import { ActionModal } from './ActionModal'
@@ -14,6 +15,8 @@ import { useAppStore } from '../store'
 import { ClawComBuilding } from './ClawComBuilding'
 import { BuildOptionsMenu } from './BuildOptionsMenu'
 import type { PlacementParams } from './BuildOptionsMenu'
+import { BadgeMarker } from './BadgeMarker'
+import { BadgeLibraryDialog } from './BadgeLibraryDialog'
 
 interface Position {
   x: number
@@ -338,6 +341,11 @@ export function BattlefieldView() {
   const loadBuildings = useAppStore((s) => s.loadBuildings)
   const storeBuildings = useAppStore((s) => s.buildings)
   const updateBuildingPosition = useAppStore((s) => s.updateBuildingPosition)
+  const loadBadges = useAppStore((s) => s.loadBadges)
+  const loadPlacedBadges = useAppStore((s) => s.loadPlacedBadges)
+  const placedBadges = useAppStore((s) => s.placedBadges)
+  const storePlaceBadge = useAppStore((s) => s.placeBadge)
+  const updatePlacedBadgePosition = useAppStore((s) => s.updatePlacedBadgePosition)
   const onReposChange = () => { loadRepos(); onRefresh() }
   const [offset, setOffset] = useState<Position>(() => ({
     x: window.innerWidth / 2 - ISO_MAP_CENTER_X,
@@ -372,6 +380,11 @@ export function BattlefieldView() {
   const [buildingPositions, setBuildingPositions] = useState<Record<number, { x: number; y: number }>>({})
   const [relocatingBuildingId, setRelocatingBuildingId] = useState<number | null>(null)
   const [relocatingBuildingStart, setRelocatingBuildingStart] = useState<{ mouseX: number; mouseY: number; nodeX: number; nodeY: number } | null>(null)
+  const [showBadgeLibrary, setShowBadgeLibrary] = useState(false)
+  const [placingBadge, setPlacingBadge] = useState<Badge | null>(null)
+  const [badgePositions, setBadgePositions] = useState<Record<number, { x: number; y: number }>>({})
+  const [relocatingBadgeId, setRelocatingBadgeId] = useState<number | null>(null)
+  const [relocatingBadgeStart, setRelocatingBadgeStart] = useState<{ mouseX: number; mouseY: number; nodeX: number; nodeY: number } | null>(null)
 
   useEffect(() => {
     const el = detailPanelRef.current
@@ -412,6 +425,30 @@ export function BattlefieldView() {
   useEffect(() => {
     loadBuildings()
   }, [loadBuildings])
+
+  // Load badges on mount
+  useEffect(() => {
+    loadBadges()
+    loadPlacedBadges()
+  }, [loadBadges, loadPlacedBadges])
+
+  // Sync placed badge positions from store into local state
+  useEffect(() => {
+    setBadgePositions((prev) => {
+      const next = { ...prev }
+      for (const pb of placedBadges) {
+        if (!next[pb.id]) {
+          next[pb.id] = { x: pb.posX, y: pb.posY }
+        }
+      }
+      for (const id of Object.keys(next).map(Number)) {
+        if (!placedBadges.find((pb) => pb.id === id)) {
+          delete next[id]
+        }
+      }
+      return next
+    })
+  }, [placedBadges])
 
   // Sync building positions from store (DB) into local state
   useEffect(() => {
@@ -531,19 +568,32 @@ export function BattlefieldView() {
   const handleMapMouseDown = useCallback((e: React.MouseEvent) => {
     if ((e.target as HTMLElement).closest('.cnc-sidebar')) return
     if (placementMode) return  // handled in handleMapClick
+    if (placingBadge) return  // handled in handleMapClick
     if ((e.target as HTMLElement).closest('.base-node')) return
     if (isRelocateMode) return
     setIsDraggingMap(true)
     setDragStart({ x: e.clientX - offset.x, y: e.clientY - offset.y })
-  }, [offset, isRelocateMode, placementMode])
+  }, [offset, isRelocateMode, placementMode, placingBadge])
 
   const handleMapClick = useCallback(async (e: React.MouseEvent) => {
-    if (!placementMode) return
     if ((e.target as HTMLElement).closest('.cnc-sidebar')) return
     const rect = containerRef.current?.getBoundingClientRect()
     if (!rect) return
     const mapX = (e.clientX - rect.left - offsetRef.current.x) / zoomRef.current
     const mapY = (e.clientY - rect.top - offsetRef.current.y) / zoomRef.current
+
+    if (placingBadge) {
+      try {
+        await storePlaceBadge({ badgeId: placingBadge.id, posX: mapX, posY: mapY })
+        addToast(`Badge "${placingBadge.name}" placed!`, 'success')
+      } catch (err: any) {
+        addToast(`Failed to place badge: ${err.message}`, 'error')
+      }
+      setPlacingBadge(null)
+      return
+    }
+
+    if (!placementMode) return
     try {
       await api.createBuilding({ type: placementMode.type, name: placementMode.name, color: placementMode.color, posX: mapX, posY: mapY })
       await loadBuildings()
@@ -552,7 +602,7 @@ export function BattlefieldView() {
       addToast(`Bau fehlgeschlagen: ${err.message}`, 'error')
     }
     setPlacementMode(null)
-  }, [placementMode, loadBuildings, addToast])
+  }, [placementMode, placingBadge, loadBuildings, addToast, storePlaceBadge])
 
   const handleMapMouseMove = useCallback((e: React.MouseEvent) => {
     if (placementMode) {
@@ -581,8 +631,18 @@ export function BattlefieldView() {
           y: relocatingBuildingStart.nodeY + dy,
         },
       }))
+    } else if (relocatingBadgeId !== null && relocatingBadgeStart !== null) {
+      const dx = (e.clientX - relocatingBadgeStart.mouseX) / zoomRef.current
+      const dy = (e.clientY - relocatingBadgeStart.mouseY) / zoomRef.current
+      setBadgePositions(prev => ({
+        ...prev,
+        [relocatingBadgeId]: {
+          x: relocatingBadgeStart.nodeX + dx,
+          y: relocatingBadgeStart.nodeY + dy,
+        },
+      }))
     }
-  }, [isDraggingMap, dragStart, relocatingId, relocatingStart, relocatingBuildingId, relocatingBuildingStart])
+  }, [isDraggingMap, dragStart, relocatingId, relocatingStart, relocatingBuildingId, relocatingBuildingStart, relocatingBadgeId, relocatingBadgeStart])
 
   const handleWheel = useCallback((e: WheelEvent) => {
     if ((e.target as HTMLElement).closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"]')) return
@@ -611,11 +671,16 @@ export function BattlefieldView() {
   }, [handleWheel])
 
   useEffect(() => {
-    if (!placementMode) return
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setPlacementMode(null) }
+    if (!placementMode && !placingBadge) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setPlacementMode(null)
+        setPlacingBadge(null)
+      }
+    }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [placementMode])
+  }, [placementMode, placingBadge])
 
   const handleZoomIn = useCallback(() => {
     setZoom(prev => {
@@ -690,7 +755,15 @@ export function BattlefieldView() {
       setRelocatingBuildingId(null)
       setRelocatingBuildingStart(null)
     }
-  }, [relocatingId, relocatingBuildingId, buildingPositions, updateBuildingPosition])
+    if (relocatingBadgeId !== null) {
+      const pos = badgePositions[relocatingBadgeId]
+      if (pos) {
+        updatePlacedBadgePosition(relocatingBadgeId, pos.x, pos.y)
+      }
+      setRelocatingBadgeId(null)
+      setRelocatingBadgeStart(null)
+    }
+  }, [relocatingId, relocatingBuildingId, buildingPositions, updateBuildingPosition, relocatingBadgeId, badgePositions, updatePlacedBadgePosition])
 
   const handleStartRelocate = useCallback((id: number, mouseX: number, mouseY: number) => {
     const pos = positions[id]
@@ -705,6 +778,13 @@ export function BattlefieldView() {
     setRelocatingBuildingId(id)
     setRelocatingBuildingStart({ mouseX, mouseY, nodeX: pos.x, nodeY: pos.y })
   }, [buildingPositions])
+
+  const handleStartBadgeRelocate = useCallback((id: number, mouseX: number, mouseY: number) => {
+    const pos = badgePositions[id]
+    if (!pos) return
+    setRelocatingBadgeId(id)
+    setRelocatingBadgeStart({ mouseX, mouseY, nodeX: pos.x, nodeY: pos.y })
+  }, [badgePositions])
 
   // When an active map is selected, filter to only its assigned repos
   const visibleEntries = activeMapRepoIds === null
@@ -736,7 +816,7 @@ export function BattlefieldView() {
       onMouseLeave={handleMapMouseUp}
       onClick={handleMapClick}
       ref={containerRef}
-      style={{ cursor: placementMode ? 'crosshair' : isDraggingMap ? 'grabbing' : (isRelocateMode ? 'crosshair' : 'grab') }}
+      style={{ cursor: (placementMode || placingBadge) ? 'crosshair' : isDraggingMap ? 'grabbing' : (isRelocateMode ? 'crosshair' : 'grab') }}
     >
       {/* Scanlines — fixed to viewport */}
       <div className="battlefield-scanlines" />
@@ -790,6 +870,13 @@ export function BattlefieldView() {
             title="Bau Optionen (ClawCom, etc.)"
           >
             <BuildIcon size={11} /><span className="hud-label"> BUILD</span>
+          </button>
+          <button
+            className={`hud-btn${showBadgeLibrary ? ' active' : ''}`}
+            onClick={() => { play('peep'); setShowBadgeLibrary(true) }}
+            title="Badge Library — place custom markers on the battlefield"
+          >
+            ◈<span className="hud-label"> BADGES</span>
           </button>
           <span className="hud-zoom-sep" />
           <button
@@ -917,6 +1004,23 @@ export function BattlefieldView() {
             />
           )
         })}
+
+        {/* Custom badge markers */}
+        {placedBadges.map((pb) => {
+          const pos = badgePositions[pb.id] ?? { x: pb.posX, y: pb.posY }
+          return (
+            <BadgeMarker
+              key={`badge-${pb.id}`}
+              placedBadge={pb}
+              position={pos}
+              isRelocateMode={isRelocateMode}
+              isBeingRelocated={relocatingBadgeId === pb.id}
+              onStartRelocate={(mouseX, mouseY) => handleStartBadgeRelocate(pb.id, mouseX, mouseY)}
+              addToast={addToast}
+              serverUrl={getServerUrl()}
+            />
+          )
+        })}
       </div>
 
       {/* Minimap */}
@@ -1010,6 +1114,25 @@ export function BattlefieldView() {
             }
           }}
         />
+      )}
+
+      {/* Badge library dialog */}
+      {showBadgeLibrary && (
+        <BadgeLibraryDialog
+          onClose={() => setShowBadgeLibrary(false)}
+          onSelectForPlacement={(badge) => {
+            setPlacingBadge(badge)
+            setShowBadgeLibrary(false)
+          }}
+          serverUrl={getServerUrl()}
+        />
+      )}
+
+      {/* Badge placement banner */}
+      {placingBadge && (
+        <div className="battlefield-placement-banner">
+          ◈ BADGE MODE — Click on the battlefield to place <strong>{placingBadge.name}</strong> &nbsp;·&nbsp; ESC to cancel
+        </div>
       )}
 
       {/* Placement mode: ghost + banner */}

--- a/gh-ctrl/client/src/store.ts
+++ b/gh-ctrl/client/src/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { Repo, DashboardEntry, RepoData, GameMap, Building } from './types'
+import type { Repo, DashboardEntry, RepoData, GameMap, Building, Badge, PlacedBadge } from './types'
 import { api } from './api'
 
 type ToastType = 'success' | 'error' | 'info'
@@ -30,6 +30,8 @@ interface AppStore {
   toasts: Toast[]
   maps: GameMap[]
   buildings: Building[]
+  badges: Badge[]
+  placedBadges: PlacedBadge[]
 
   // Toast
   addToast: (message: string, type?: ToastType) => void
@@ -48,6 +50,15 @@ interface AppStore {
   updateBuildingPosition: (id: number, posX: number, posY: number) => Promise<void>
   updateBuildingColor: (id: number, color: string) => Promise<void>
   deleteBuilding: (id: number) => Promise<void>
+  loadBadges: () => Promise<void>
+  loadPlacedBadges: () => Promise<void>
+  uploadBadge: (file: File, name: string) => Promise<Badge>
+  deleteBadge: (id: number) => Promise<void>
+  placeBadge: (params: { badgeId: number; posX: number; posY: number; scale?: number; label?: string; mapId?: number | null }) => Promise<PlacedBadge>
+  updatePlacedBadgePosition: (id: number, posX: number, posY: number) => Promise<void>
+  updatePlacedBadgeScale: (id: number, scale: number) => Promise<void>
+  updatePlacedBadgeLabel: (id: number, label: string) => Promise<void>
+  removePlacedBadge: (id: number) => Promise<void>
 }
 
 export const useAppStore = create<AppStore>((set, get) => ({
@@ -59,6 +70,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
   toasts: [],
   maps: [],
   buildings: [],
+  badges: [],
+  placedBadges: [],
 
   addToast: (message, type = 'info') => {
     const id = nextToastId++
@@ -199,6 +212,104 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }))
     } catch (err: any) {
       get().addToast(`Failed to delete building: ${err.message}`, 'error')
+      throw err
+    }
+  },
+
+  loadBadges: async () => {
+    try {
+      const data = await api.listBadges()
+      set({ badges: data })
+    } catch (err: any) {
+      get().addToast(`Failed to load badges: ${err.message}`, 'error')
+    }
+  },
+
+  loadPlacedBadges: async () => {
+    try {
+      const data = await api.listPlacedBadges()
+      set({ placedBadges: data })
+    } catch (err: any) {
+      get().addToast(`Failed to load placed badges: ${err.message}`, 'error')
+    }
+  },
+
+  uploadBadge: async (file: File, name: string) => {
+    try {
+      const badge = await api.uploadBadge(file, name)
+      set((state) => ({ badges: [...state.badges, badge] }))
+      return badge
+    } catch (err: any) {
+      get().addToast(`Failed to upload badge: ${err.message}`, 'error')
+      throw err
+    }
+  },
+
+  deleteBadge: async (id: number) => {
+    try {
+      await api.deleteBadge(id)
+      set((state) => ({
+        badges: state.badges.filter((b) => b.id !== id),
+        placedBadges: state.placedBadges.filter((pb) => pb.badgeId !== id),
+      }))
+    } catch (err: any) {
+      get().addToast(`Failed to delete badge: ${err.message}`, 'error')
+      throw err
+    }
+  },
+
+  placeBadge: async (params) => {
+    try {
+      const placed = await api.placeBadge(params)
+      set((state) => ({ placedBadges: [...state.placedBadges, placed] }))
+      return placed
+    } catch (err: any) {
+      get().addToast(`Failed to place badge: ${err.message}`, 'error')
+      throw err
+    }
+  },
+
+  updatePlacedBadgePosition: async (id: number, posX: number, posY: number) => {
+    try {
+      const updated = await api.updatePlacedBadge(id, { posX, posY })
+      set((state) => ({
+        placedBadges: state.placedBadges.map((pb) => pb.id === id ? { ...pb, posX: updated.posX, posY: updated.posY } : pb),
+      }))
+    } catch (err: any) {
+      get().addToast(`Failed to update badge position: ${err.message}`, 'error')
+    }
+  },
+
+  updatePlacedBadgeScale: async (id: number, scale: number) => {
+    try {
+      const updated = await api.updatePlacedBadge(id, { scale })
+      set((state) => ({
+        placedBadges: state.placedBadges.map((pb) => pb.id === id ? { ...pb, scale: updated.scale } : pb),
+      }))
+    } catch (err: any) {
+      get().addToast(`Failed to update badge scale: ${err.message}`, 'error')
+    }
+  },
+
+  updatePlacedBadgeLabel: async (id: number, label: string) => {
+    try {
+      const updated = await api.updatePlacedBadge(id, { label })
+      set((state) => ({
+        placedBadges: state.placedBadges.map((pb) => pb.id === id ? { ...pb, label: updated.label } : pb),
+      }))
+    } catch (err: any) {
+      get().addToast(`Failed to update badge label: ${err.message}`, 'error')
+    }
+  },
+
+  removePlacedBadge: async (id: number) => {
+    try {
+      await api.removePlacedBadge(id)
+      set((state) => ({
+        placedBadges: state.placedBadges.filter((pb) => pb.id !== id),
+      }))
+    } catch (err: any) {
+      get().addToast(`Failed to remove badge: ${err.message}`, 'error')
       throw err
     }
   },

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -245,3 +245,25 @@ export interface GameMap {
   updatedAt: string | number | null
   assignedRepos?: Repo[]
 }
+
+export interface Badge {
+  id: number
+  name: string
+  filename: string
+  originalFilename: string
+  mimeType: string
+  createdAt: string | number | null
+}
+
+export interface PlacedBadge {
+  id: number
+  badgeId: number
+  badge?: Badge
+  label: string
+  posX: number
+  posY: number
+  scale: number
+  mapId: number | null
+  createdAt: string | number | null
+  updatedAt: string | number | null
+}

--- a/gh-ctrl/src/db/index.ts
+++ b/gh-ctrl/src/db/index.ts
@@ -62,4 +62,29 @@ sqlite.exec(`
   )
 `)
 
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS badges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    original_filename TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    created_at INTEGER DEFAULT (unixepoch())
+  )
+`)
+
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS placed_badges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    badge_id INTEGER NOT NULL REFERENCES badges(id) ON DELETE CASCADE,
+    label TEXT DEFAULT '',
+    pos_x REAL NOT NULL DEFAULT 0,
+    pos_y REAL NOT NULL DEFAULT 0,
+    scale REAL NOT NULL DEFAULT 1.0,
+    map_id INTEGER REFERENCES maps(id) ON DELETE SET NULL,
+    created_at INTEGER DEFAULT (unixepoch()),
+    updated_at INTEGER DEFAULT (unixepoch())
+  )
+`)
+
 export const db = drizzle(sqlite, { schema })

--- a/gh-ctrl/src/db/schema.ts
+++ b/gh-ctrl/src/db/schema.ts
@@ -46,3 +46,24 @@ export const clawcomMessages = sqliteTable('clawcom_messages', {
   content:    text('content').notNull(),
   createdAt:  integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
 })
+
+export const badges = sqliteTable('badges', {
+  id:               integer('id').primaryKey({ autoIncrement: true }),
+  name:             text('name').notNull(),
+  filename:         text('filename').notNull(),
+  originalFilename: text('original_filename').notNull(),
+  mimeType:         text('mime_type').notNull(),
+  createdAt:        integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+})
+
+export const placedBadges = sqliteTable('placed_badges', {
+  id:        integer('id').primaryKey({ autoIncrement: true }),
+  badgeId:   integer('badge_id').notNull().references(() => badges.id, { onDelete: 'cascade' }),
+  label:     text('label').default(''),
+  posX:      real('pos_x').notNull().default(0),
+  posY:      real('pos_y').notNull().default(0),
+  scale:     real('scale').notNull().default(1.0),
+  mapId:     integer('map_id').references(() => maps.id, { onDelete: 'set null' }),
+  createdAt: integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+})

--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -7,7 +7,16 @@ import githubRouter from './routes/github'
 import mapsRouter from './routes/maps'
 import setupRouter from './routes/setup'
 import buildingsRouter from './routes/buildings'
+import badgesRouter from './routes/badges'
 import pkg from '../package.json'
+import { existsSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Ensure uploads directory exists on startup
+const uploadsDir = join(process.cwd(), 'uploads', 'badges')
+if (!existsSync(uploadsDir)) {
+  mkdirSync(uploadsDir, { recursive: true })
+}
 
 const app = new Hono()
 
@@ -37,9 +46,13 @@ app.route('/api/github', githubRouter)
 app.route('/api/maps', mapsRouter)
 app.route('/api/setup', setupRouter)
 app.route('/api/buildings', buildingsRouter)
+app.route('/api/badges', badgesRouter)
 
 app.get('/api/health', (c) => c.json({ ok: true }))
 app.get('/api/version', (c) => c.json({ version: pkg.version }))
+
+// Serve uploaded badge images
+app.use('/uploads/*', serveStatic({ root: './' }))
 
 // Serve built React in production
 app.use('*', serveStatic({ root: './client/dist' }))

--- a/gh-ctrl/src/routes/badges.ts
+++ b/gh-ctrl/src/routes/badges.ts
@@ -1,0 +1,120 @@
+import { Hono } from 'hono'
+import { db } from '../db'
+import { badges, placedBadges } from '../db/schema'
+import { eq } from 'drizzle-orm'
+import { existsSync, mkdirSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+const UPLOAD_DIR = join(process.cwd(), 'uploads', 'badges')
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+
+// Ensure upload directory exists
+if (!existsSync(UPLOAD_DIR)) {
+  mkdirSync(UPLOAD_DIR, { recursive: true })
+}
+
+const app = new Hono()
+
+// POST /upload — multipart file upload
+app.post('/upload', async (c) => {
+  const formData = await c.req.formData()
+  const file = formData.get('file') as File | null
+  const name = formData.get('name') as string | null
+
+  if (!file) return c.json({ error: 'No file provided' }, 400)
+  if (!name?.trim()) return c.json({ error: 'Badge name is required' }, 400)
+  if (!file.type.startsWith('image/')) return c.json({ error: 'Only image files are allowed' }, 400)
+  if (file.size > MAX_FILE_SIZE) return c.json({ error: 'File size exceeds 5MB limit' }, 400)
+
+  const ext = file.name.split('.').pop() ?? 'png'
+  const filename = `${randomUUID()}.${ext}`
+  const filepath = join(UPLOAD_DIR, filename)
+
+  const buffer = await file.arrayBuffer()
+  await Bun.write(filepath, buffer)
+
+  const result = await db.insert(badges).values({
+    name: String(name).trim(),
+    filename,
+    originalFilename: file.name,
+    mimeType: file.type,
+  }).returning()
+
+  return c.json(result[0], 201)
+})
+
+// GET / — list all badges
+app.get('/', async (c) => {
+  const all = await db.select().from(badges).orderBy(badges.createdAt)
+  return c.json(all)
+})
+
+// DELETE /:id — delete badge + file from disk
+app.delete('/:id', async (c) => {
+  const id = Number(c.req.param('id'))
+  const result = await db.delete(badges).where(eq(badges.id, id)).returning()
+  if (result.length === 0) return c.json({ error: 'Badge not found' }, 404)
+
+  const filepath = join(UPLOAD_DIR, result[0].filename)
+  try { unlinkSync(filepath) } catch { /* file may already be gone */ }
+
+  return c.json({ ok: true })
+})
+
+// GET /placed — list all placed badge instances
+app.get('/placed', async (c) => {
+  const all = await db.select().from(placedBadges).orderBy(placedBadges.createdAt)
+  // Join badge info
+  const badgeMap = new Map((await db.select().from(badges)).map((b) => [b.id, b]))
+  return c.json(all.map((pb) => ({ ...pb, badge: badgeMap.get(pb.badgeId) })))
+})
+
+// POST /placed — place a badge on the map
+app.post('/placed', async (c) => {
+  const body = await c.req.json()
+  const { badgeId, posX = 0, posY = 0, scale = 1.0, label = '', mapId } = body
+
+  if (!badgeId) return c.json({ error: 'badgeId is required' }, 400)
+
+  // Verify badge exists
+  const badge = await db.select().from(badges).where(eq(badges.id, Number(badgeId)))
+  if (badge.length === 0) return c.json({ error: 'Badge not found' }, 404)
+
+  const result = await db.insert(placedBadges).values({
+    badgeId: Number(badgeId),
+    posX: Number(posX),
+    posY: Number(posY),
+    scale: Number(scale),
+    label: String(label),
+    mapId: mapId != null ? Number(mapId) : null,
+  }).returning()
+
+  return c.json({ ...result[0], badge: badge[0] }, 201)
+})
+
+// PATCH /placed/:id — update position / scale / label
+app.patch('/placed/:id', async (c) => {
+  const id = Number(c.req.param('id'))
+  const body = await c.req.json()
+  const updates: Record<string, any> = { updatedAt: new Date() }
+
+  if (body.posX !== undefined) updates.posX = Number(body.posX)
+  if (body.posY !== undefined) updates.posY = Number(body.posY)
+  if (body.scale !== undefined) updates.scale = Number(body.scale)
+  if (body.label !== undefined) updates.label = String(body.label)
+
+  const result = await db.update(placedBadges).set(updates).where(eq(placedBadges.id, id)).returning()
+  if (result.length === 0) return c.json({ error: 'Placed badge not found' }, 404)
+  return c.json(result[0])
+})
+
+// DELETE /placed/:id — remove a placed badge
+app.delete('/placed/:id', async (c) => {
+  const id = Number(c.req.param('id'))
+  const result = await db.delete(placedBadges).where(eq(placedBadges.id, id)).returning()
+  if (result.length === 0) return c.json({ error: 'Placed badge not found' }, 404)
+  return c.json({ ok: true })
+})
+
+export default app


### PR DESCRIPTION
Adds a custom badge system for marking landmarks and areas on the battlefield map.

Users can upload custom images (PNG, SVG, JPG, WebP) via the new BADGES HUD button, then click on the battlefield to place them. Placed badges are draggable in relocate mode and have per-badge size and label controls.

Closes #221

Generated with [Claude Code](https://claude.ai/code)