### PR TITLE
feat: base indicator for missing claude.yml

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -165,6 +165,7 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
   const hasConflicts = stats.conflicts > 0
   const hasReviews = stats.needsReview > 0
   const hasClaudeActive = (data.activeClaudeIssues?.length ?? 0) > 0
+  const claudeNotSetup = data.hasClaudeYml === false
   const runningWorkflows = data.runningWorkflows ?? []
   const hasRunningActions = runningWorkflows.length > 0
 
@@ -270,6 +271,11 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
               title={`${runningWorkflows.length} running action(s): ${runningWorkflows.map(r => r.workflowName).join(', ')}`}
             >
               ⚙
+            </span>
+          )}
+          {claudeNotSetup && (
+            <span className="base-beacon beacon-no-claude" title="Claude not set up — claude.yml missing from .github/workflows">
+              &#x2298;
             </span>
           )}
         </div>

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1910,6 +1910,13 @@ select.input {
   font-size: 18px;
 }
 
+.beacon-no-claude {
+  color: #888;
+  text-shadow: 0 0 4px #888;
+  font-size: 14px;
+  opacity: 0.7;
+}
+
 /* Building graphic — isometric PNG building */
 .base-building {
   position: relative;

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -107,6 +107,7 @@ export interface RepoData {
   runningWorkflows: WorkflowRun[]
   branches: Branch[]
   defaultBranch: string
+  hasClaudeYml: boolean
   error: string | null
 }
 

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -170,6 +170,11 @@ async function fetchRunningWorkflows(fullName: string): Promise<RunningWorkflows
   return { activeClaudeIssues: Array.from(activeIssues), runningWorkflows }
 }
 
+async function checkClaudeYml(fullName: string): Promise<boolean> {
+  const result = await gh(['api', `repos/${fullName}/contents/.github/workflows/claude.yml`])
+  return result.error === null && result.data !== null
+}
+
 async function fetchRepoBranches(fullName: string): Promise<{ branches: { name: string; committedDate: string }[]; defaultBranch: string }> {
   const [owner, name] = fullName.split('/')
   const graphqlQuery = `{
@@ -236,6 +241,7 @@ async function fetchRepoData(fullName: string) {
       runningWorkflows: [],
       branches: [],
       defaultBranch: 'main',
+      hasClaudeYml: false,
       error: prResult.error || issueResult.error,
     }
   }
@@ -244,11 +250,12 @@ async function fetchRepoData(fullName: string) {
   const issues = issueResult.data || []
 
   // Netlify URLs depend on prs, but workflows and branches are independent
-  const [previewUrls, { activeClaudeIssues, runningWorkflows }, claudeIssueBranches, { branches, defaultBranch }] = await Promise.all([
+  const [previewUrls, { activeClaudeIssues, runningWorkflows }, claudeIssueBranches, { branches, defaultBranch }, hasClaudeYml] = await Promise.all([
     fetchNetlifyUrls(fullName, prs),
     fetchRunningWorkflows(fullName),
     fetchClaudeIssueBranches(fullName),
     fetchRepoBranches(fullName),
+    checkClaudeYml(fullName),
   ])
 
   const enrichedPrs = prs.map((pr: any) => ({
@@ -294,6 +301,7 @@ async function fetchRepoData(fullName: string) {
     runningWorkflows,
     branches,
     defaultBranch,
+    hasClaudeYml,
     error: null,
   }
 }


### PR DESCRIPTION
Add a grey ⊘ beacon on base nodes when `.github/workflows/claude.yml` is not present in the repository.

Closes #254

Generated with [Claude Code](https://claude.ai/code)