### PR TITLE
feat: add provider field to repos schema

### DIFF
--- a/gh-ctrl/src/db/index.ts
+++ b/gh-ctrl/src/db/index.ts
@@ -16,6 +16,10 @@ sqlite.exec(`
   )
 `)
 
+// Migrations: add provider and instance_url to repos (no-op if columns already exist)
+try { sqlite.exec(`ALTER TABLE repos ADD COLUMN provider TEXT NOT NULL DEFAULT 'github'`) } catch {}
+try { sqlite.exec(`ALTER TABLE repos ADD COLUMN instance_url TEXT`) } catch {}
+
 sqlite.exec(`
   CREATE TABLE IF NOT EXISTS maps (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/gh-ctrl/src/db/schema.ts
+++ b/gh-ctrl/src/db/schema.ts
@@ -7,6 +7,8 @@ export const repos = sqliteTable('repos', {
   fullName:    text('full_name').notNull().unique(),
   description: text('description'),
   color:       text('color').default('#00ff88'),
+  provider:    text('provider').notNull().default('github'), // 'github' | 'gitlab'
+  instanceUrl: text('instance_url'),                        // null = cloud, set for self-hosted GitLab
   createdAt:   integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
 })
 


### PR DESCRIPTION
Adds `provider` and `instance_url` columns to the repos table to support GitLab repositories alongside GitHub.

Closes #265 (Phase 1)

Generated with [Claude Code](https://claude.ai/code)