### PR TITLE
feat: GitLab API client + gitlab routes (Phase 3)

### DIFF
--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -4,6 +4,7 @@ import { logger } from 'hono/logger'
 import { serveStatic } from 'hono/bun'
 import reposRouter from './routes/repos'
 import githubRouter from './routes/github'
+import gitlabRouter from './routes/gitlab'
 import mapsRouter from './routes/maps'
 import setupRouter from './routes/setup'
 import buildingsRouter from './routes/buildings'
@@ -45,6 +46,7 @@ app.use('*', logger())
 
 app.route('/api/repos', reposRouter)
 app.route('/api/github', githubRouter)
+app.route('/api/gitlab', gitlabRouter)
 app.route('/api/maps', mapsRouter)
 app.route('/api/setup', setupRouter)
 app.route('/api/buildings', buildingsRouter)

--- a/gh-ctrl/src/providers/gitlab.ts
+++ b/gh-ctrl/src/providers/gitlab.ts
@@ -1,0 +1,312 @@
+/**
+ * GitLab REST API v4 client.
+ * Authentication: Personal Access Token via GITLAB_TOKEN env var.
+ * Self-hosted GitLab: pass instanceUrl (e.g. "https://gitlab.example.com").
+ */
+
+import type {
+  NormalizedMR,
+  NormalizedIssue,
+  NormalizedBranch,
+  NormalizedPipeline,
+  NormalizedRepoData,
+  NormalizedRepoMeta,
+  NormalizedRepoStats,
+} from './types'
+
+const CLAUDE_LABELS = ['claude', 'ai', 'ai-fix', 'ai-feature']
+
+/** Encode a project path (namespace/name) for use in GitLab API URLs. */
+export function encodeProjectPath(path: string): string {
+  return encodeURIComponent(path)
+}
+
+/** Low-level GitLab REST API v4 fetch helper. */
+export async function glabApi(
+  path: string,
+  options: { instanceUrl?: string | null; method?: string; body?: unknown } = {}
+): Promise<{ data: any; error: string | null }> {
+  const base = (options.instanceUrl ?? 'https://gitlab.com').replace(/\/$/, '')
+  const token = process.env.GITLAB_TOKEN
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  if (token) headers['PRIVATE-TOKEN'] = token
+
+  try {
+    const res = await fetch(`${base}/api/v4${path}`, {
+      method: options.method ?? 'GET',
+      headers,
+      ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+    })
+
+    if (res.status === 204) return { data: null, error: null }
+
+    const text = await res.text()
+    if (!res.ok) {
+      let msg: string
+      try {
+        const parsed = JSON.parse(text)
+        msg = parsed.message || parsed.error || text
+      } catch {
+        msg = text
+      }
+      return { data: null, error: `GitLab API ${res.status}: ${msg}` }
+    }
+
+    try {
+      return { data: JSON.parse(text), error: null }
+    } catch {
+      return { data: null, error: 'Failed to parse GitLab response' }
+    }
+  } catch (err: any) {
+    return { data: null, error: err?.message ?? 'Network error' }
+  }
+}
+
+function normalizeMRState(gl: any): NormalizedMR['mergeable'] {
+  // GitLab: merge_status can be 'can_be_merged', 'cannot_be_merged', 'unchecked', etc.
+  if (gl.merge_status === 'cannot_be_merged') return 'CONFLICTING'
+  if (gl.merge_status === 'can_be_merged') return 'MERGEABLE'
+  return 'UNKNOWN'
+}
+
+function normalizeReviewState(gl: any): NormalizedMR['reviewState'] {
+  // GitLab approvals are fetched separately; without them we derive from merge_status
+  if (gl.approved) return 'approved'
+  return 'pending'
+}
+
+export function normalizeMR(gl: any): NormalizedMR {
+  const mergeable = normalizeMRState(gl)
+  return {
+    number: gl.iid,
+    title: gl.title,
+    url: gl.web_url,
+    draft: gl.draft ?? gl.work_in_progress ?? false,
+    isDraft: gl.draft ?? gl.work_in_progress ?? false,
+    author: {
+      login: gl.author?.username ?? '',
+      avatarUrl: gl.author?.avatar_url ?? '',
+      url: gl.author?.web_url ?? '',
+    },
+    labels: (gl.labels ?? []).map((name: string) => ({ name, color: '#6366f1' })),
+    reviewState: normalizeReviewState(gl),
+    conflicting: mergeable === 'CONFLICTING',
+    mergeable,
+    headRefName: gl.source_branch ?? '',
+    createdAt: gl.created_at ?? '',
+    updatedAt: gl.updated_at ?? '',
+    previewUrl: null,
+    assignees: (gl.assignees ?? (gl.assignee ? [gl.assignee] : [])).map((u: any) => ({
+      login: u.username ?? '',
+      avatarUrl: u.avatar_url ?? '',
+      url: u.web_url ?? '',
+    })),
+  }
+}
+
+export function normalizeIssue(gl: any): NormalizedIssue {
+  return {
+    number: gl.iid,
+    title: gl.title,
+    url: gl.web_url,
+    state: gl.state,
+    author: {
+      login: gl.author?.username ?? '',
+      avatarUrl: gl.author?.avatar_url ?? '',
+      url: gl.author?.web_url ?? '',
+    },
+    labels: (gl.labels ?? []).map((name: string) => ({ name, color: '#6366f1' })),
+    assignees: (gl.assignees ?? (gl.assignee ? [gl.assignee] : [])).map((u: any) => ({
+      login: u.username ?? '',
+      avatarUrl: u.avatar_url ?? '',
+      url: u.web_url ?? '',
+    })),
+    updatedAt: gl.updated_at ?? '',
+  }
+}
+
+function normalizePipelineStatus(status: string): NormalizedPipeline['status'] {
+  const map: Record<string, NormalizedPipeline['status']> = {
+    running: 'running',
+    pending: 'pending',
+    created: 'pending',
+    waiting_for_resource: 'pending',
+    preparing: 'pending',
+    scheduled: 'pending',
+    success: 'success',
+    failed: 'failed',
+    canceled: 'canceled',
+    canceling: 'canceled',
+    skipped: 'skipped',
+    manual: 'skipped',
+  }
+  return map[status] ?? 'unknown'
+}
+
+export function normalizePipeline(gl: any, projectUrl: string): NormalizedPipeline {
+  return {
+    id: gl.id,
+    name: gl.name ?? `Pipeline #${gl.id}`,
+    status: normalizePipelineStatus(gl.status),
+    ref: gl.ref ?? '',
+    url: gl.web_url ?? `${projectUrl}/-/pipelines/${gl.id}`,
+    createdAt: gl.created_at ?? '',
+    updatedAt: gl.updated_at ?? gl.created_at ?? '',
+  }
+}
+
+/** Fetch the full repo dashboard data for a GitLab project. */
+export async function fetchGitLabRepoData(
+  projectPath: string,
+  instanceUrl?: string | null
+): Promise<NormalizedRepoData> {
+  const encoded = encodeProjectPath(projectPath)
+  const opts = { instanceUrl }
+
+  const empty: NormalizedRepoData = {
+    fullName: projectPath,
+    provider: 'gitlab',
+    prs: [],
+    issues: [],
+    stats: { openPRs: 0, openIssues: 0, conflicts: 0, needsReview: 0, approved: 0, drafts: 0, claudeIssues: 0, runningActions: 0 },
+    conflicts: [],
+    needsReview: [],
+    claudeIssues: [],
+    activeClaudeIssues: [],
+    claudeIssuePRLinks: {},
+    runningWorkflows: [],
+    branches: [],
+    defaultBranch: 'main',
+    hasClaudeYml: false,
+    error: null,
+  }
+
+  // Fetch MRs, issues, and pipelines in parallel
+  const [mrResult, issueResult, pipelineResult, projectResult] = await Promise.all([
+    glabApi(`/projects/${encoded}/merge_requests?state=opened&per_page=30`, opts),
+    glabApi(`/projects/${encoded}/issues?state=opened&per_page=30`, opts),
+    glabApi(`/projects/${encoded}/pipelines?per_page=30`, opts),
+    glabApi(`/projects/${encoded}`, opts),
+  ])
+
+  if (mrResult.error && issueResult.error) {
+    return { ...empty, error: mrResult.error || issueResult.error }
+  }
+
+  const projectUrl = projectResult.data?.web_url ?? `https://gitlab.com/${projectPath}`
+  const defaultBranch: string = projectResult.data?.default_branch ?? 'main'
+
+  const prs: NormalizedMR[] = (mrResult.data ?? []).map(normalizeMR)
+  const issues: NormalizedIssue[] = (issueResult.data ?? []).map(normalizeIssue)
+  const pipelines: NormalizedPipeline[] = (pipelineResult.data ?? []).map((p: any) => normalizePipeline(p, projectUrl))
+
+  // Fetch branches
+  const branchResult = await glabApi(
+    `/projects/${encoded}/repository/branches?per_page=100&order_by=updated_at&sort=desc`,
+    opts
+  )
+  const branches: NormalizedBranch[] = (branchResult.data ?? []).map((b: any) => ({
+    name: b.name,
+    committedDate: b.commit?.committed_date ?? b.commit?.created_at ?? '',
+  }))
+
+  const conflicts = prs.filter((mr) => mr.mergeable === 'CONFLICTING')
+  const needsReview = prs.filter((mr) => mr.reviewState !== 'approved' && !mr.isDraft)
+  const approved = prs.filter((mr) => mr.reviewState === 'approved')
+  const drafts = prs.filter((mr) => mr.isDraft)
+  const claudeIssues = issues.filter((issue) =>
+    issue.labels.some((l) => CLAUDE_LABELS.includes(l.name.toLowerCase()))
+  )
+  const runningPipelines = pipelines.filter(
+    (p) => p.status === 'running' || p.status === 'pending'
+  )
+
+  const stats: NormalizedRepoStats = {
+    openPRs: prs.length,
+    openIssues: issues.length,
+    conflicts: conflicts.length,
+    needsReview: needsReview.length,
+    approved: approved.length,
+    drafts: drafts.length,
+    claudeIssues: claudeIssues.length,
+    runningActions: runningPipelines.length,
+  }
+
+  return {
+    fullName: projectPath,
+    provider: 'gitlab',
+    prs,
+    issues,
+    stats,
+    conflicts,
+    needsReview,
+    claudeIssues,
+    activeClaudeIssues: [],
+    claudeIssuePRLinks: {},
+    runningWorkflows: runningPipelines,
+    branches,
+    defaultBranch,
+    hasClaudeYml: false,
+    error: null,
+  }
+}
+
+/** Fetch repo meta: stars, languages, topics, contributors, commit activity */
+export async function fetchGitLabRepoMeta(
+  projectPath: string,
+  instanceUrl?: string | null
+): Promise<NormalizedRepoMeta> {
+  const encoded = encodeProjectPath(projectPath)
+  const opts = { instanceUrl }
+
+  const [projectResult, languagesResult, membersResult, commitsResult] = await Promise.all([
+    glabApi(`/projects/${encoded}`, opts),
+    glabApi(`/projects/${encoded}/languages`, opts),
+    glabApi(`/projects/${encoded}/members/all?per_page=5`, opts),
+    glabApi(`/projects/${encoded}/repository/commits?per_page=100`, opts),
+  ])
+
+  const project = projectResult.data ?? {}
+
+  // Languages: GitLab returns { "JavaScript": 73.45, "TypeScript": 26.55 }
+  const langData: Record<string, number> = languagesResult.data ?? {}
+  const primaryLanguageName = Object.keys(langData)[0] ?? null
+  const languages = Object.entries(langData).map(([name, pct]) => ({
+    name,
+    color: '#8b8b8b',
+    percentage: Math.round(pct * 10) / 10,
+  }))
+
+  const contributors = (membersResult.data ?? []).slice(0, 5).map((m: any) => ({
+    login: m.username ?? '',
+    avatarUrl: m.avatar_url ?? '',
+    contributions: m.access_level ?? 0,
+  }))
+
+  // Commit activity: bucket commits into 26 weekly bins
+  const commitWeeks: number[] = Array(26).fill(0)
+  const now = Date.now()
+  for (const commit of commitsResult.data ?? []) {
+    const date = new Date(commit.committed_date ?? commit.created_at).getTime()
+    const weeksAgo = Math.floor((now - date) / (7 * 24 * 60 * 60 * 1000))
+    if (weeksAgo >= 0 && weeksAgo < 26) {
+      commitWeeks[25 - weeksAgo]++
+    }
+  }
+
+  return {
+    stars: project.star_count ?? 0,
+    forks: project.forks_count ?? 0,
+    watchers: project.star_count ?? 0,
+    primaryLanguage: primaryLanguageName ? { name: primaryLanguageName, color: '#8b8b8b' } : null,
+    languages,
+    topics: project.tag_list ?? project.topics ?? [],
+    contributors,
+    commitWeeks,
+    createdAt: project.created_at ?? '',
+    pushedAt: project.last_activity_at ?? '',
+  }
+}

--- a/gh-ctrl/src/providers/types.ts
+++ b/gh-ctrl/src/providers/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Provider-agnostic normalized types.
+ * GitHub PRs and GitLab Merge Requests are both represented as NormalizedMR.
+ * GitHub Actions and GitLab CI Pipelines are both represented as NormalizedPipeline.
+ */
+
+export interface NormalizedAuthor {
+  login: string
+  avatarUrl: string
+  url: string
+}
+
+export interface NormalizedLabel {
+  name: string
+  color: string
+}
+
+export interface NormalizedMR {
+  number: number
+  title: string
+  url: string
+  draft: boolean
+  author: NormalizedAuthor
+  labels: NormalizedLabel[]
+  /** 'approved' | 'changes_requested' | 'pending' | null */
+  reviewState: 'approved' | 'changes_requested' | 'pending' | null
+  conflicting: boolean
+  mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+  headRefName: string
+  createdAt: string
+  updatedAt: string
+  /** GitHub Netlify preview URL or GitLab environment URL */
+  previewUrl: string | null
+  isDraft: boolean
+  assignees: NormalizedAuthor[]
+}
+
+export interface NormalizedIssue {
+  number: number
+  title: string
+  url: string
+  state: string
+  author: NormalizedAuthor
+  labels: NormalizedLabel[]
+  assignees: NormalizedAuthor[]
+  updatedAt: string
+}
+
+export interface NormalizedBranch {
+  name: string
+  committedDate: string
+}
+
+export interface NormalizedPipeline {
+  id: number
+  name: string
+  status: 'running' | 'pending' | 'success' | 'failed' | 'canceled' | 'skipped' | 'unknown'
+  ref: string
+  url: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface NormalizedRepoStats {
+  openPRs: number
+  openIssues: number
+  conflicts: number
+  needsReview: number
+  approved: number
+  drafts: number
+  claudeIssues: number
+  runningActions: number
+}
+
+export interface NormalizedRepoData {
+  fullName: string
+  provider: 'github' | 'gitlab'
+  prs: NormalizedMR[]
+  issues: NormalizedIssue[]
+  stats: NormalizedRepoStats
+  conflicts: NormalizedMR[]
+  needsReview: NormalizedMR[]
+  claudeIssues: NormalizedIssue[]
+  activeClaudeIssues: number[]
+  claudeIssuePRLinks: Record<number, unknown>
+  runningWorkflows: NormalizedPipeline[]
+  branches: NormalizedBranch[]
+  defaultBranch: string
+  hasClaudeYml: false
+  error: string | null
+}
+
+export interface NormalizedRepoMeta {
+  stars: number
+  forks: number
+  watchers: number
+  primaryLanguage: { name: string; color: string } | null
+  languages: { name: string; color: string; percentage: number }[]
+  topics: string[]
+  contributors: { login: string; avatarUrl: string; contributions: number }[]
+  commitWeeks: number[]
+  createdAt: string
+  pushedAt: string
+}

--- a/gh-ctrl/src/routes/gitlab.ts
+++ b/gh-ctrl/src/routes/gitlab.ts
@@ -1,0 +1,357 @@
+/**
+ * GitLab API routes — mirrors the structure of github.ts routes.
+ *
+ * Routes are mounted at /api/gitlab.
+ * Project paths (e.g. "group/project") are passed as ":namespace/:project" path params.
+ * For nested groups (e.g. "group/sub/project"), the full path should be passed as a query
+ * param: ?path=group/sub/project, falling back to :namespace/:project.
+ *
+ * Authentication: Set GITLAB_TOKEN env var with a GitLab Personal Access Token.
+ * Self-hosted GitLab: Set GITLAB_INSTANCE_URL env var or pass instanceUrl in request body.
+ */
+
+import { Hono } from 'hono'
+import { db } from '../db'
+import { repos } from '../db/schema'
+import { eq } from 'drizzle-orm'
+import {
+  glabApi,
+  encodeProjectPath,
+  fetchGitLabRepoData,
+  fetchGitLabRepoMeta,
+  normalizeMR,
+  normalizeIssue,
+} from '../providers/gitlab'
+
+const app = new Hono()
+
+/** Resolve project path and instanceUrl from request params + DB. */
+async function resolveProject(
+  c: Parameters<Parameters<typeof app.get>[1]>[0]
+): Promise<{ projectPath: string; instanceUrl: string | null } | null> {
+  const namespace = c.req.param('namespace')
+  const project = c.req.param('project')
+  const queryPath = c.req.query('path')
+  const projectPath = queryPath || `${namespace}/${project}`
+
+  // Look up the repo in DB to get instanceUrl (if any)
+  const row = await db
+    .select()
+    .from(repos)
+    .where(eq(repos.fullName, projectPath))
+    .get()
+
+  const instanceUrl = row?.instanceUrl ?? process.env.GITLAB_INSTANCE_URL ?? null
+
+  return { projectPath, instanceUrl }
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard data
+// ---------------------------------------------------------------------------
+
+// GET /api/gitlab/repo/:namespace/:project — fetch live data for a single repo
+app.get('/repo/:namespace/:project', async (c) => {
+  const resolved = await resolveProject(c)
+  if (!resolved) return c.json({ error: 'Could not resolve project' }, 400)
+
+  const data = await fetchGitLabRepoData(resolved.projectPath, resolved.instanceUrl)
+  return c.json(data)
+})
+
+// ---------------------------------------------------------------------------
+// Meta (stars, languages, topics, contributors)
+// ---------------------------------------------------------------------------
+
+// GET /api/gitlab/meta/:namespace/:project
+app.get('/meta/:namespace/:project', async (c) => {
+  const resolved = await resolveProject(c)
+  if (!resolved) return c.json({ error: 'Could not resolve project' }, 400)
+
+  const meta = await fetchGitLabRepoMeta(resolved.projectPath, resolved.instanceUrl)
+  return c.json(meta)
+})
+
+// ---------------------------------------------------------------------------
+// Labels
+// ---------------------------------------------------------------------------
+
+// GET /api/gitlab/labels/:namespace/:project — list available labels
+app.get('/labels/:namespace/:project', async (c) => {
+  const resolved = await resolveProject(c)
+  if (!resolved) return c.json({ error: 'Could not resolve project' }, 400)
+
+  const encoded = encodeProjectPath(resolved.projectPath)
+  const result = await glabApi(`/projects/${encoded}/labels?per_page=100`, {
+    instanceUrl: resolved.instanceUrl,
+  })
+  if (result.error) return c.json({ error: result.error }, 500)
+
+  const labels = (result.data ?? []).map((l: any) => ({
+    name: l.name,
+    color: l.color,
+    description: l.description ?? '',
+  }))
+  return c.json(labels)
+})
+
+// POST /api/gitlab/label — add a label to an MR or issue
+app.post('/label', async (c) => {
+  const body = await c.req.json()
+  const { fullName, number, type, label, instanceUrl: bodyInstanceUrl } = body
+
+  if (!fullName || !number || !type || !label) {
+    return c.json({ error: 'Missing required fields: fullName, number, type, label' }, 400)
+  }
+
+  const row = await db.select().from(repos).where(eq(repos.fullName, fullName)).get()
+  const instanceUrl = bodyInstanceUrl ?? row?.instanceUrl ?? process.env.GITLAB_INSTANCE_URL ?? null
+
+  const encoded = encodeProjectPath(fullName)
+  const resource = type === 'mr' || type === 'pr' ? 'merge_requests' : 'issues'
+
+  // Fetch current labels first
+  const currentResult = await glabApi(`/projects/${encoded}/${resource}/${number}`, { instanceUrl })
+  if (currentResult.error) return c.json({ error: currentResult.error }, 500)
+
+  const currentLabels: string[] = currentResult.data?.labels ?? []
+  if (!currentLabels.includes(label)) currentLabels.push(label)
+
+  const updateResult = await glabApi(`/projects/${encoded}/${resource}/${number}`, {
+    instanceUrl,
+    method: 'PUT',
+    body: { labels: currentLabels.join(',') },
+  })
+  if (updateResult.error) return c.json({ error: updateResult.error }, 500)
+
+  return c.json({ ok: true })
+})
+
+// DELETE /api/gitlab/label — remove a label from an MR or issue
+app.delete('/label', async (c) => {
+  const body = await c.req.json()
+  const { fullName, number, type, label, instanceUrl: bodyInstanceUrl } = body
+
+  if (!fullName || !number || !type || !label) {
+    return c.json({ error: 'Missing required fields: fullName, number, type, label' }, 400)
+  }
+
+  const row = await db.select().from(repos).where(eq(repos.fullName, fullName)).get()
+  const instanceUrl = bodyInstanceUrl ?? row?.instanceUrl ?? process.env.GITLAB_INSTANCE_URL ?? null
+
+  const encoded = encodeProjectPath(fullName)
+  const resource = type === 'mr' || type === 'pr' ? 'merge_requests' : 'issues'
+
+  // Fetch current labels first
+  const currentResult = await glabApi(`/projects/${encoded}/${resource}/${number}`, { instanceUrl })
+  if (currentResult.error) return c.json({ error: currentResult.error }, 500)
+
+  const currentLabels: string[] = (currentResult.data?.labels ?? []).filter((l: string) => l !== label)
+
+  const updateResult = await glabApi(`/projects/${encoded}/${resource}/${number}`, {
+    instanceUrl,
+    method: 'PUT',
+    body: { labels: currentLabels.join(',') },
+  })
+  if (updateResult.error) return c.json({ error: updateResult.error }, 500)
+
+  return c.json({ ok: true })
+})
+
+// ---------------------------------------------------------------------------
+// Branches
+// ---------------------------------------------------------------------------
+
+// GET /api/gitlab/branches/:namespace/:project — list branches sorted by commit date desc
+app.get('/branches/:namespace/:project', async (c) => {
+  const resolved = await resolveProject(c)
+  if (!resolved) return c.json({ error: 'Could not resolve project' }, 400)
+
+  const encoded = encodeProjectPath(resolved.projectPath)
+  const [branchResult, projectResult] = await Promise.all([
+    glabApi(
+      `/projects/${encoded}/repository/branches?per_page=100&order_by=updated_at&sort=desc`,
+      { instanceUrl: resolved.instanceUrl }
+    ),
+    glabApi(`/projects/${encoded}`, { instanceUrl: resolved.instanceUrl }),
+  ])
+
+  if (branchResult.error) return c.json({ error: branchResult.error }, 500)
+
+  const defaultBranch: string = projectResult.data?.default_branch ?? 'main'
+  const branches = (branchResult.data ?? []).map((b: any) => ({
+    name: b.name,
+    committedDate: b.commit?.committed_date ?? b.commit?.created_at ?? '',
+  }))
+
+  return c.json({ branches, defaultBranch })
+})
+
+// GET /api/gitlab/branch-compare/:namespace/:project/:branch — ahead/behind vs default branch
+app.get('/branch-compare/:namespace/:project/:branch', async (c) => {
+  const resolved = await resolveProject(c)
+  if (!resolved) return c.json({ error: 'Could not resolve project' }, 400)
+
+  const branch = decodeURIComponent(c.req.param('branch'))
+  const base = c.req.query('base') || 'main'
+  const encoded = encodeProjectPath(resolved.projectPath)
+
+  const result = await glabApi(
+    `/projects/${encoded}/repository/compare?from=${encodeURIComponent(base)}&to=${encodeURIComponent(branch)}`,
+    { instanceUrl: resolved.instanceUrl }
+  )
+  if (result.error) return c.json({ error: result.error }, 500)
+
+  return c.json({
+    ahead: result.data?.commits?.length ?? 0,
+    behind: 0, // GitLab compare does not return behind count directly
+  })
+})
+
+// DELETE /api/gitlab/branch/:namespace/:project/:branch — delete a branch
+app.delete('/branch/:namespace/:project/:branch', async (c) => {
+  const resolved = await resolveProject(c)
+  if (!resolved) return c.json({ error: 'Could not resolve project' }, 400)
+
+  const branch = decodeURIComponent(c.req.param('branch'))
+  const encoded = encodeProjectPath(resolved.projectPath)
+
+  const result = await glabApi(
+    `/projects/${encoded}/repository/branches/${encodeURIComponent(branch)}`,
+    { instanceUrl: resolved.instanceUrl, method: 'DELETE' }
+  )
+  if (result.error) return c.json({ error: result.error }, 500)
+  return c.json({ ok: true })
+})
+
+// ---------------------------------------------------------------------------
+// Issues
+// ---------------------------------------------------------------------------
+
+// POST /api/gitlab/create-issue — create a new issue
+app.post('/create-issue', async (c) => {
+  const body = await c.req.json()
+  const { fullName, title, description, labels, instanceUrl: bodyInstanceUrl } = body
+
+  if (!fullName || !title) {
+    return c.json({ error: 'Missing required fields: fullName, title' }, 400)
+  }
+
+  const row = await db.select().from(repos).where(eq(repos.fullName, fullName)).get()
+  const instanceUrl = bodyInstanceUrl ?? row?.instanceUrl ?? process.env.GITLAB_INSTANCE_URL ?? null
+
+  const encoded = encodeProjectPath(fullName)
+  const result = await glabApi(`/projects/${encoded}/issues`, {
+    instanceUrl,
+    method: 'POST',
+    body: {
+      title,
+      description: description ?? '',
+      labels: Array.isArray(labels) ? labels.join(',') : (labels ?? ''),
+    },
+  })
+
+  if (result.error) return c.json({ error: result.error }, 500)
+  return c.json(normalizeIssue(result.data), 201)
+})
+
+// ---------------------------------------------------------------------------
+// Merge Requests
+// ---------------------------------------------------------------------------
+
+// POST /api/gitlab/create-mr — create a new merge request
+app.post('/create-mr', async (c) => {
+  const body = await c.req.json()
+  const {
+    fullName,
+    title,
+    sourceBranch,
+    targetBranch,
+    description,
+    labels,
+    draft,
+    instanceUrl: bodyInstanceUrl,
+  } = body
+
+  if (!fullName || !title || !sourceBranch || !targetBranch) {
+    return c.json(
+      { error: 'Missing required fields: fullName, title, sourceBranch, targetBranch' },
+      400
+    )
+  }
+
+  const row = await db.select().from(repos).where(eq(repos.fullName, fullName)).get()
+  const instanceUrl = bodyInstanceUrl ?? row?.instanceUrl ?? process.env.GITLAB_INSTANCE_URL ?? null
+
+  const encoded = encodeProjectPath(fullName)
+  const result = await glabApi(`/projects/${encoded}/merge_requests`, {
+    instanceUrl,
+    method: 'POST',
+    body: {
+      title: draft ? `Draft: ${title}` : title,
+      source_branch: sourceBranch,
+      target_branch: targetBranch,
+      description: description ?? '',
+      labels: Array.isArray(labels) ? labels.join(',') : (labels ?? ''),
+    },
+  })
+
+  if (result.error) return c.json({ error: result.error }, 500)
+  return c.json(normalizeMR(result.data), 201)
+})
+
+// ---------------------------------------------------------------------------
+// Comments
+// ---------------------------------------------------------------------------
+
+// POST /api/gitlab/comment — post a comment on an MR or issue
+app.post('/comment', async (c) => {
+  const body = await c.req.json()
+  const { fullName, number, type, comment, instanceUrl: bodyInstanceUrl } = body
+
+  if (!fullName || !number || !type || !comment) {
+    return c.json({ error: 'Missing required fields: fullName, number, type, comment' }, 400)
+  }
+
+  const row = await db.select().from(repos).where(eq(repos.fullName, fullName)).get()
+  const instanceUrl = bodyInstanceUrl ?? row?.instanceUrl ?? process.env.GITLAB_INSTANCE_URL ?? null
+
+  const encoded = encodeProjectPath(fullName)
+  const resource = type === 'mr' || type === 'pr' ? 'merge_requests' : 'issues'
+
+  const result = await glabApi(`/projects/${encoded}/${resource}/${number}/notes`, {
+    instanceUrl,
+    method: 'POST',
+    body: { body: comment },
+  })
+
+  if (result.error) return c.json({ error: result.error }, 500)
+  return c.json({ ok: true })
+})
+
+// ---------------------------------------------------------------------------
+// Setup validation — validate that a GitLab repo path is accessible
+// Used by the repos route when adding a GitLab repo
+// ---------------------------------------------------------------------------
+
+// GET /api/gitlab/validate?path=namespace/project — validate a GitLab project exists
+app.get('/validate', async (c) => {
+  const projectPath = c.req.query('path')
+  const instanceUrl = c.req.query('instanceUrl') || process.env.GITLAB_INSTANCE_URL || null
+
+  if (!projectPath) return c.json({ error: 'path query param is required' }, 400)
+
+  const encoded = encodeProjectPath(projectPath)
+  const result = await glabApi(`/projects/${encoded}`, { instanceUrl })
+
+  if (result.error) return c.json({ error: result.error }, 404)
+
+  return c.json({
+    valid: true,
+    nameWithNamespace: result.data?.path_with_namespace ?? projectPath,
+    description: result.data?.description ?? '',
+    defaultBranch: result.data?.default_branch ?? 'main',
+  })
+})
+
+export default app


### PR DESCRIPTION
Adds GitLab REST API v4 client and Hono routes mirroring the existing GitHub routes.

- `src/providers/types.ts`: provider-agnostic normalized types
- `src/providers/gitlab.ts`: `glabApi()` helper + `fetchGitLabRepoData()` / `fetchGitLabRepoMeta()`
- `src/routes/gitlab.ts`: full set of /api/gitlab routes (repo, meta, labels, branches, MRs, issues, comments)
- `src/index.ts`: register gitlabRouter at /api/gitlab

Closes #265 (Phase 3)

Generated with [Claude Code](https://claude.ai/code)