### PR TITLE
feat: GitLab support in frontend types + add-repo dialog (Phase 5)

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -33,10 +33,10 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 export const api = {
   listRepos: () => request<Repo[]>('/repos'),
 
-  addRepo: (fullName: string, color?: string) =>
+  addRepo: (fullName: string, color?: string, provider?: 'github' | 'gitlab', instanceUrl?: string) =>
     request<Repo>('/repos', {
       method: 'POST',
-      body: JSON.stringify({ fullName, color }),
+      body: JSON.stringify({ fullName, color, provider, instanceUrl }),
     }),
 
   updateRepo: (id: number, updates: { color?: string; description?: string }) =>
@@ -353,4 +353,83 @@ export const api = {
 
   deleteTimer: (id: number) =>
     request<{ ok: boolean }>(`/timers/${id}`, { method: 'DELETE' }),
+
+  // ── GitLab API methods ──────────────────────────────────────────────────────
+
+  getGitLabRepoData: (ns: string, project: string) =>
+    request<RepoData>(`/gitlab/repo/${ns}/${project}`),
+
+  getGitLabLabels: (ns: string, project: string) =>
+    request<GHLabel[]>(`/gitlab/labels/${ns}/${project}`),
+
+  getGitLabBranches: (ns: string, project: string) =>
+    request<BranchesData>(`/gitlab/branches/${ns}/${project}`),
+
+  getGitLabBranchCompare: (ns: string, project: string, branch: string, base: string) =>
+    request<{ ahead: number; behind: number }>(`/gitlab/branch-compare/${ns}/${project}/${encodeURIComponent(branch)}?base=${encodeURIComponent(base)}`),
+
+  deleteGitLabBranch: (ns: string, project: string, branch: string) =>
+    request<{ ok: boolean }>(`/gitlab/branch/${ns}/${project}/${encodeURIComponent(branch)}`, { method: 'DELETE' }),
+
+  getGitLabRepoMeta: (ns: string, project: string) =>
+    request<RepoMeta>(`/gitlab/meta/${ns}/${project}`),
+
+  postGitLabComment: (params: {
+    fullName: string
+    number: number
+    type: 'mr' | 'issue'
+    comment: string
+  }) =>
+    request<{ ok: boolean }>('/gitlab/comment', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
+
+  addGitLabLabel: (params: {
+    fullName: string
+    number: number
+    type: 'mr' | 'issue'
+    label: string
+  }) =>
+    request<{ ok: boolean }>('/gitlab/label', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
+
+  removeGitLabLabel: (params: {
+    fullName: string
+    number: number
+    type: 'mr' | 'issue'
+    label: string
+  }) =>
+    request<{ ok: boolean }>('/gitlab/label', {
+      method: 'DELETE',
+      body: JSON.stringify(params),
+    }),
+
+  createGitLabIssue: (params: {
+    fullName: string
+    title: string
+    issueBody?: string
+    labels?: string[]
+  }) =>
+    request<{ ok: boolean; url: string }>('/gitlab/create-issue', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
+
+  createGitLabMR: (params: {
+    fullName: string
+    sourceBranch: string
+    targetBranch: string
+    title: string
+    description?: string
+  }) =>
+    request<{ ok: boolean; url: string }>('/gitlab/create-mr', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
+
+  validateGitLabProject: (ns: string, project: string) =>
+    request<{ ok: boolean; projectId: number; name: string }>(`/gitlab/validate/${ns}/${project}`),
 }

--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import type { DashboardEntry, GHPR, GHIssue, Branch, WorkflowRun, RepoMeta } from '../types'
-import { getPROrigin } from '../types'
+import { getPROrigin, getRepoUrl, getMRLabel } from '../types'
 import type { ModalState } from './ActionModal'
 import { CloseIcon, LinkIcon, LabelIcon, CommentIcon, RefreshIcon, ExternalLinkIcon, AssigneeIcon, CopyIcon } from './Icons'
 import { api } from '../api'
@@ -256,13 +256,16 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
           {claudeDonePRs.length > 0 && (
             <a
               className="beacon-claude-done"
-              href={`https://github.com/${repo.fullName}/pulls?q=is%3Aopen+head%3Aclaude%2F`}
+              href={repo.provider === 'gitlab'
+                ? getRepoUrl(repo, '/-/merge_requests?state=opened&search=claude')
+                : getRepoUrl(repo, '/pulls?q=is%3Aopen+head%3Aclaude%2F')
+              }
               target="_blank"
               rel="noopener noreferrer"
-              title={`Claude created ${claudeDonePRs.length} PR(s) — click to review`}
+              title={`Claude created ${claudeDonePRs.length} ${getMRLabel(repo)} — click to review`}
               onClick={(e) => e.stopPropagation()}
             >
-              &#x2605; PR READY
+              &#x2605; {getMRLabel(repo)} READY
             </a>
           )}
           {hasRunningActions && !hasClaudeActive && (
@@ -289,7 +292,7 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
         <div className="base-hud">
           <div className="base-name">{repo.name}</div>
           <div className="base-stats-mini">
-            <span className="bsm green" title="Open PRs">▲{stats.openPRs}</span>
+            <span className="bsm green" title={`Open ${getMRLabel(repo)}`}>▲{stats.openPRs}</span>
             <span className="bsm blue" title="Open Issues">◆{stats.openIssues}</span>
             {stats.conflicts > 0 && <span className="bsm red" title="Conflicts"><CloseIcon size={10} />{stats.conflicts}</span>}
             {stats.needsReview > 0 && <span className="bsm amber" title="Needs Review">◎{stats.needsReview}</span>}
@@ -387,7 +390,7 @@ export function BaseDetailPanel({ entry, onClose, onModalOpen }: {
     >
       <div className="bdp-header">
         <a
-          href={`https://github.com/${repo.fullName}`}
+          href={getRepoUrl(repo)}
           target="_blank"
           rel="noopener noreferrer"
           className="bdp-title"
@@ -411,7 +414,7 @@ export function BaseDetailPanel({ entry, onClose, onModalOpen }: {
       </div>
 
       <div className="bdp-stats">
-        <span className="bdp-stat green">{data.stats.openPRs} PRs</span>
+        <span className="bdp-stat green">{data.stats.openPRs} {getMRLabel(repo)}</span>
         <span className="bdp-stat blue">{data.stats.openIssues} Issues</span>
         <span className="bdp-stat red">{data.stats.conflicts} Conflicts</span>
         <span className="bdp-stat amber">{data.stats.needsReview} Reviews</span>
@@ -486,7 +489,7 @@ export function BaseDetailPanel({ entry, onClose, onModalOpen }: {
 
       {(data.runningWorkflows?.length ?? 0) > 0 && (
         <div className="bdp-section">
-          <div className="bdp-section-title actions">&#x2699; RUNNING ACTIONS ({data.runningWorkflows.length})</div>
+          <div className="bdp-section-title actions">&#x2699; {repo.provider === 'gitlab' ? 'CI PIPELINES' : 'RUNNING ACTIONS'} ({data.runningWorkflows.length})</div>
           {data.runningWorkflows.map((run: WorkflowRun) => (
             <div key={run.databaseId} className="bdp-item bdp-action-run">
               <div className="bdp-item-left">
@@ -496,11 +499,14 @@ export function BaseDetailPanel({ entry, onClose, onModalOpen }: {
               </div>
               <div className="bdp-item-right">
                 <a
-                  href={`https://github.com/${repo.fullName}/actions/runs/${run.databaseId}`}
+                  href={repo.provider === 'gitlab'
+                    ? getRepoUrl(repo, `/-/pipelines/${run.databaseId}`)
+                    : getRepoUrl(repo, `/actions/runs/${run.databaseId}`)
+                  }
                   target="_blank"
                   rel="noopener noreferrer"
                   className="bdp-icon-btn"
-                  title="View action run"
+                  title={repo.provider === 'gitlab' ? 'View pipeline' : 'View action run'}
                   onClick={(e) => e.stopPropagation()}
                 >
                   <ExternalLinkIcon size={11} />
@@ -514,7 +520,7 @@ export function BaseDetailPanel({ entry, onClose, onModalOpen }: {
       {remainingPRs.length > 0 && (
         <div className="bdp-section">
           <button className="bdp-toggle" onClick={() => setShowAllPRs((v) => !v)}>
-            <span>{showAllPRs ? '▾' : '▸'}</span> All PRs ({remainingPRs.length})
+            <span>{showAllPRs ? '▾' : '▸'}</span> All {getMRLabel(repo)} ({remainingPRs.length})
           </button>
           {showAllPRs && remainingPRs.map((pr: GHPR) => (
             <BdpItemRow

--- a/gh-ctrl/client/src/components/Icons.tsx
+++ b/gh-ctrl/client/src/components/Icons.tsx
@@ -187,3 +187,21 @@ export function CopyIcon({ size = 12, className, title }: IconProps) {
     </svg>
   )
 }
+
+export function GitHubIcon({ size = 16, className, title }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden={!title} role={title ? 'img' : undefined}>
+      {title && <title>{title}</title>}
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  )
+}
+
+export function GitLabIcon({ size = 16, className, title }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden={!title} role={title ? 'img' : undefined}>
+      {title && <title>{title}</title>}
+      <path d="M8 15.2l-3.1-9.5H1.1L8 15.2zM8 15.2l3.1-9.5h3.8L8 15.2zM1.1 5.7L0 9.1l.5 1.5L8 15.2 1.1 5.7zM14.9 5.7L16 9.1l-.5 1.5L8 15.2l6.9-9.5zM4.9 5.7h6.2L8 1 4.9 5.7zM8 1L6.2 5.7h3.6L8 1z" />
+    </svg>
+  )
+}

--- a/gh-ctrl/client/src/components/Settings.tsx
+++ b/gh-ctrl/client/src/components/Settings.tsx
@@ -3,6 +3,7 @@ import type { Repo } from '../types'
 import { api, getServerUrl, setServerUrl } from '../api'
 import { useAppStore } from '../store'
 import type { GameMap } from '../types'
+import { GitHubIcon, GitLabIcon } from './Icons'
 
 const COLORS = ['#39d353', '#58a6ff', '#f0883e', '#f85149', '#bc8cff', '#ffa657', '#ff7b72', '#79c0ff']
 
@@ -132,6 +133,8 @@ export function Settings() {
   const [selectedColor, setSelectedColor] = useState(COLORS[0])
   const [adding, setAdding] = useState(false)
   const [formError, setFormError] = useState('')
+  const [provider, setProvider] = useState<'github' | 'gitlab'>('github')
+  const [instanceUrl, setInstanceUrl] = useState('')
 
   // Browse tab state
   const [activeTab, setActiveTab] = useState<'manual' | 'browse'>('browse')
@@ -230,13 +233,13 @@ export function Settings() {
     setFormError('')
 
     if (!fullName.trim()) {
-      setFormError('Enter owner/repo or a GitHub URL')
+      setFormError(`Enter owner/repo or a ${provider === 'gitlab' ? 'GitLab' : 'GitHub'} URL`)
       return
     }
 
     setAdding(true)
     try {
-      await api.addRepo(fullName.trim(), selectedColor)
+      await api.addRepo(fullName.trim(), selectedColor, provider, instanceUrl.trim() || undefined)
       addToast(`Added ${fullName}`, 'success')
       setFullName('')
       handleReposChange()
@@ -336,11 +339,42 @@ export function Settings() {
 
         {activeTab === 'manual' && (
           <form className="add-repo-form" onSubmit={handleAdd}>
+            <div className="form-row" style={{ marginBottom: '0.5rem' }}>
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <button
+                  type="button"
+                  className={`btn${provider === 'github' ? ' btn-primary' : ' btn-ghost'}`}
+                  style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '0.82rem' }}
+                  onClick={() => setProvider('github')}
+                >
+                  <GitHubIcon size={13} /> GitHub
+                </button>
+                <button
+                  type="button"
+                  className={`btn${provider === 'gitlab' ? ' btn-primary' : ' btn-ghost'}`}
+                  style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '0.82rem' }}
+                  onClick={() => setProvider('gitlab')}
+                >
+                  <GitLabIcon size={13} /> GitLab
+                </button>
+              </div>
+            </div>
+            {provider === 'gitlab' && (
+              <div className="form-row" style={{ marginBottom: '0.5rem' }}>
+                <input
+                  className="input"
+                  type="url"
+                  placeholder="Instance URL (leave blank for gitlab.com)"
+                  value={instanceUrl}
+                  onChange={(e) => setInstanceUrl(e.target.value)}
+                />
+              </div>
+            )}
             <div className="form-row">
               <input
                 className="input"
                 type="text"
-                placeholder="owner/repo or GitHub URL"
+                placeholder={provider === 'gitlab' ? 'group/project or GitLab URL' : 'owner/repo or GitHub URL'}
                 value={fullName}
                 onChange={(e) => setFullName(e.target.value)}
               />
@@ -365,6 +399,9 @@ export function Settings() {
 
         {activeTab === 'browse' && (
           <div className="browse-repos">
+            <p style={{ color: 'var(--text-2)', fontSize: '0.82rem', margin: '0 0 0.75rem' }}>
+              Browse uses the GitHub CLI (<code>gh</code>). To add a GitLab repo use the <strong>Manual</strong> tab.
+            </p>
             {!ghAvailable ? (
               <div className="browse-fallback">
                 <p className="form-error">GitHub CLI (gh) not available. Use manual input instead.</p>
@@ -497,6 +534,15 @@ export function Settings() {
                     )}
                   </div>
                   <span>{repo.fullName}</span>
+                  {repo.provider === 'gitlab' ? (
+                    <span style={{ color: '#fc6d26', display: 'flex', alignItems: 'center' }}>
+                      <GitLabIcon size={13} title="GitLab" />
+                    </span>
+                  ) : (
+                    <span style={{ color: 'var(--text-2)', display: 'flex', alignItems: 'center' }}>
+                      <GitHubIcon size={13} title="GitHub" />
+                    </span>
+                  )}
                 </div>
                 <div className="repo-map-assignment" style={{ display: 'flex', alignItems: 'center', gap: '4px', flexWrap: 'wrap' }}>
                   {storeMaps.length > 0 && (repoMapIds[repo.id]?.size ?? 0) === 0 && (

--- a/gh-ctrl/client/src/store.ts
+++ b/gh-ctrl/client/src/store.ts
@@ -2,21 +2,30 @@ import { create } from 'zustand'
 import type { Repo, DashboardEntry, RepoData, GameMap, Building, Badge, PlacedBadge, DeadlineTimer, BattlefieldUser } from './types'
 import { api } from './api'
 
+function avatarUrlForLogin(login: string, provider: 'github' | 'gitlab', instanceUrl?: string | null): string {
+  if (provider === 'gitlab') {
+    const base = instanceUrl ?? 'https://gitlab.com'
+    return `${base}/${login}.png?size=40`
+  }
+  return `https://github.com/${login}.png?size=40`
+}
+
 export function selectBattlefieldUsers(entries: DashboardEntry[]): BattlefieldUser[] {
   const seen = new Map<string, { login: string; avatarUrl: string; lastRepoId?: number; lastDate: string }>()
   for (const entry of entries) {
+    const { provider, instanceUrl } = entry.repo
     for (const pr of entry.data.prs) {
       const login = pr.author.login
       const existing = seen.get(login)
       if (!existing || pr.updatedAt > existing.lastDate) {
-        seen.set(login, { login, avatarUrl: `https://github.com/${login}.png?size=40`, lastRepoId: entry.repo.id, lastDate: pr.updatedAt })
+        seen.set(login, { login, avatarUrl: avatarUrlForLogin(login, provider, instanceUrl), lastRepoId: entry.repo.id, lastDate: pr.updatedAt })
       }
     }
     for (const issue of entry.data.issues) {
       const login = issue.author.login
       const existing = seen.get(login)
       if (!existing || issue.updatedAt > existing.lastDate) {
-        seen.set(login, { login, avatarUrl: `https://github.com/${login}.png?size=40`, lastRepoId: entry.repo.id, lastDate: issue.updatedAt })
+        seen.set(login, { login, avatarUrl: avatarUrlForLogin(login, provider, instanceUrl), lastRepoId: entry.repo.id, lastDate: issue.updatedAt })
       }
     }
   }

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -5,7 +5,20 @@ export interface Repo {
   fullName: string
   description: string | null
   color: string
+  provider: 'github' | 'gitlab'
+  instanceUrl?: string | null
   createdAt: string | number | null
+}
+
+export function getRepoUrl(repo: Repo, path?: string): string {
+  const base = repo.provider === 'gitlab'
+    ? (repo.instanceUrl ?? 'https://gitlab.com')
+    : 'https://github.com'
+  return `${base}/${repo.fullName}${path ?? ''}`
+}
+
+export function getMRLabel(repo: Repo): string {
+  return repo.provider === 'gitlab' ? 'MRs' : 'PRs'
 }
 
 export type AuthorAssociation = 'OWNER' | 'MEMBER' | 'COLLABORATOR' | 'CONTRIBUTOR' | 'FIRST_TIME_CONTRIBUTOR' | 'FIRST_TIMER' | 'NONE'

--- a/gh-ctrl/src/routes/repos.ts
+++ b/gh-ctrl/src/routes/repos.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { db } from '../db'
 import { repos } from '../db/schema'
 import { eq } from 'drizzle-orm'
+import { glabApi, encodeProjectPath } from '../providers/gitlab'
 
 const app = new Hono()
 
@@ -14,33 +15,65 @@ app.get('/', async (c) => {
 // POST /api/repos — add a repo
 app.post('/', async (c) => {
   const body = await c.req.json()
-  const { fullName, color, description } = body
+  const { fullName, color, description, provider = 'github', instanceUrl } = body
 
   if (!fullName) {
-    return c.json({ error: 'fullName must be in "owner/repo" format or a GitHub URL' }, 400)
-  }
-
-  // Validate repo exists via gh CLI and get canonical nameWithOwner
-  // This also normalizes URLs (e.g. https://github.com/owner/repo) to owner/repo format
-  const check = Bun.spawnSync(['gh', 'repo', 'view', fullName, '--json', 'nameWithOwner'])
-  if (check.exitCode !== 0) {
-    const stderr = check.stderr.toString()
-    const isAuthError = /not logged in|auth login|authentication|401|403|credentials|token/i.test(stderr)
-    if (isAuthError) {
-      return c.json({ error: 'Not authenticated with GitHub CLI. Please run "gh auth login" to authenticate.' }, 401)
-    }
-    return c.json({ error: 'Repository not found on GitHub' }, 404)
+    return c.json({ error: 'fullName must be in "owner/repo" format or a GitHub/GitLab URL' }, 400)
   }
 
   let canonicalFullName: string
-  try {
-    const ghData = JSON.parse(check.stdout.toString())
-    canonicalFullName = ghData.nameWithOwner
-  } catch {
-    return c.json({ error: 'Failed to parse GitHub API response' }, 500)
-  }
+  let owner: string
+  let name: string
 
-  const [owner, name] = canonicalFullName.split('/')
+  if (provider === 'gitlab') {
+    // Normalize GitLab URLs to namespace/project format
+    let normalized = fullName.trim()
+    const gitlabBase = (instanceUrl ?? 'https://gitlab.com').replace(/\/$/, '')
+    if (normalized.startsWith(gitlabBase + '/')) {
+      normalized = normalized.slice(gitlabBase.length + 1)
+    } else if (normalized.startsWith('https://gitlab.com/')) {
+      normalized = normalized.slice('https://gitlab.com/'.length)
+    }
+    // Remove trailing .git
+    normalized = normalized.replace(/\.git$/, '')
+
+    // Validate project exists via GitLab API
+    const { data, error } = await glabApi(
+      `/projects/${encodeProjectPath(normalized)}`,
+      { instanceUrl }
+    )
+    if (error || !data) {
+      return c.json({ error: error ?? 'GitLab project not found' }, 404)
+    }
+
+    canonicalFullName = data.path_with_namespace ?? normalized
+    const parts = canonicalFullName.split('/')
+    name = parts.pop()!
+    owner = parts.join('/')
+  } else {
+    // Validate repo exists via gh CLI and get canonical nameWithOwner
+    // This also normalizes URLs (e.g. https://github.com/owner/repo) to owner/repo format
+    const check = Bun.spawnSync(['gh', 'repo', 'view', fullName, '--json', 'nameWithOwner'])
+    if (check.exitCode !== 0) {
+      const stderr = check.stderr.toString()
+      const isAuthError = /not logged in|auth login|authentication|401|403|credentials|token/i.test(stderr)
+      if (isAuthError) {
+        return c.json({ error: 'Not authenticated with GitHub CLI. Please run "gh auth login" to authenticate.' }, 401)
+      }
+      return c.json({ error: 'Repository not found on GitHub' }, 404)
+    }
+
+    try {
+      const ghData = JSON.parse(check.stdout.toString())
+      canonicalFullName = ghData.nameWithOwner
+    } catch {
+      return c.json({ error: 'Failed to parse GitHub API response' }, 500)
+    }
+
+    const parts = canonicalFullName.split('/')
+    owner = parts[0]
+    name = parts[1]
+  }
 
   try {
     const result = await db.insert(repos).values({
@@ -49,6 +82,8 @@ app.post('/', async (c) => {
       fullName: canonicalFullName,
       description: description || null,
       color: color || '#00ff88',
+      provider,
+      instanceUrl: instanceUrl || null,
     }).returning()
 
     return c.json(result[0], 201)


### PR DESCRIPTION
Adds GitLab provider support to the frontend and the repos backend route.

- `Repo` type gets `provider` + `instanceUrl` fields
- `getRepoUrl()` / `getMRLabel()` helpers for provider-aware rendering
- API client GitLab methods + provider param in addRepo
- Settings: GitHub/GitLab toggle in manual add form + instance URL field
- Repo cards: provider icon badge; "MRs" / "CI Pipelines" labels for GitLab
- Backend repos route: GitLab project validation + provider stored in DB

Closes #265 (Phase 5)

Generated with [Claude Code](https://claude.ai/code)