### PR TITLE
feat: unify panel/sidebar close behavior with shared primitives

### DIFF
--- a/gh-ctrl/client/src/components/BaseDialog.tsx
+++ b/gh-ctrl/client/src/components/BaseDialog.tsx
@@ -1,0 +1,32 @@
+import { useEffect, type ReactNode } from 'react'
+
+interface BaseDialogProps {
+  onClose: () => void
+  className?: string
+  children: ReactNode
+}
+
+/**
+ * Shared dialog primitive.
+ * Handles: Escape key to close, onClick/onMouseDown/wheel stopPropagation.
+ */
+export function BaseDialog({ onClose, className, children }: BaseDialogProps) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  return (
+    <div
+      className={className}
+      onWheel={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {children}
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import type { DashboardEntry, GameMap, Badge } from '../types'
 import { BranchSiloPanel } from './BranchSiloPanel'
+import { SidePanel } from './SidePanel'
 import { api } from '../api'
 import { getServerUrl } from '../api'
 import { getBranchState } from './BranchBuilding'
@@ -67,7 +68,6 @@ export function BattlefieldView() {
   const [selectedBuildingId, setSelectedBuildingId] = useState<number | null>(null)
   const [constructingBuildingIds, setConstructingBuildingIds] = useState<Set<number>>(new Set())
   const [constructingRepoIds, setConstructingRepoIds] = useState<Set<number>>(new Set())
-  const detailPanelRef = useRef<HTMLDivElement>(null)
   const [showBuildMenu, setShowBuildMenu] = useState(false)
   const [placementMode, setPlacementMode] = useState<PlacementParams | null>(null)
   const [ghostScreenPos, setGhostScreenPos] = useState<Position>({ x: 0, y: 0 })
@@ -76,14 +76,6 @@ export function BattlefieldView() {
   const [placingBadge, setPlacingBadge] = useState<Badge | null>(null)
 
   const autoScanTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  useEffect(() => {
-    const el = detailPanelRef.current
-    if (!el) return
-    const stop = (e: WheelEvent) => e.stopPropagation()
-    el.addEventListener('wheel', stop, { passive: true })
-    return () => el.removeEventListener('wheel', stop)
-  }, [detailEntry])
 
   const { play } = useSound()
 
@@ -363,7 +355,7 @@ export function BattlefieldView() {
         onToggleBadgeLibrary={() => { play('peep'); setShowBadgeLibrary(true) }}
         onShowMapSelector={() => setShowMapSelector(true)}
         onClearMap={handleClearMap}
-        onToggleFeed={() => { play('peep'); setShowFeedPanel(v => !v) }}
+        onToggleFeed={() => { play('peep'); setShowFeedPanel(v => !v); setBranchSiloEntry(null); setDetailEntry(null); setSelectedBuildingId(null) }}
         onToggleTimers={() => { play('peep'); setShowTimers(v => !v) }}
         onZoomIn={handleZoomIn}
         onZoomOut={handleZoomOut}
@@ -541,7 +533,7 @@ export function BattlefieldView() {
       />
 
       {detailEntry && (
-        <div ref={detailPanelRef} className="base-detail-side-panel">
+        <SidePanel className="base-detail-side-panel" onClose={() => setDetailEntry(null)}>
           <div className="base-detail-side-panel-header">
             <div className="base-detail-side-panel-title-row">
               <span className="base-detail-side-panel-icon" style={{ color: detailEntry.repo.color }}>&#x25a0;</span>
@@ -559,7 +551,7 @@ export function BattlefieldView() {
               onModalOpen={(state) => { play('peep'); setModalState(state) }}
             />
           </div>
-        </div>
+        </SidePanel>
       )}
     </div>
   )

--- a/gh-ctrl/client/src/components/BranchSiloPanel.tsx
+++ b/gh-ctrl/client/src/components/BranchSiloPanel.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import type { DashboardEntry, Branch, GHPR } from '../types'
 import { getBranchState } from './BranchBuilding'
 import { api } from '../api'
 import { ExternalLinkIcon } from './Icons'
 import type { ModalState } from './ActionModal'
+import { SidePanel } from './SidePanel'
 
 interface BranchSiloPanelProps {
   entry: DashboardEntry | null
@@ -171,27 +172,10 @@ function BranchRow({
 
 export function BranchSiloPanel({ entry, onClose, addToast, onModalOpen }: BranchSiloPanelProps) {
   const [deletedBranches, setDeletedBranches] = useState<Set<string>>(new Set())
-  const panelRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const el = panelRef.current
-    if (!el) return
-    const stop = (e: WheelEvent) => e.stopPropagation()
-    el.addEventListener('wheel', stop, { passive: true })
-    return () => el.removeEventListener('wheel', stop)
-  }, [])
 
   useEffect(() => {
     setDeletedBranches(new Set())
   }, [entry?.repo.id])
-
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    window.addEventListener('keydown', handleKey)
-    return () => window.removeEventListener('keydown', handleKey)
-  }, [onClose])
 
   const handleDelete = useCallback(async (branchName: string) => {
     if (!entry) return
@@ -219,12 +203,7 @@ export function BranchSiloPanel({ entry, onClose, addToast, onModalOpen }: Branc
   const activeCount = nonDefaultBranches.length - staleCount - veryStaleCount
 
   return (
-    <div
-      ref={panelRef}
-      className="silo-panel"
-      onClick={(e) => e.stopPropagation()}
-      onMouseDown={(e) => e.stopPropagation()}
-    >
+    <SidePanel className="silo-panel" onClose={onClose}>
       {/* C&C-style panel header */}
       <div className="silo-panel-header">
         <div className="silo-panel-header-left">
@@ -277,6 +256,6 @@ export function BranchSiloPanel({ entry, onClose, addToast, onModalOpen }: Branc
           ))
         )}
       </div>
-    </div>
+    </SidePanel>
   )
 }

--- a/gh-ctrl/client/src/components/BuildOptionsMenu.tsx
+++ b/gh-ctrl/client/src/components/BuildOptionsMenu.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { PlusIcon, CloseIcon } from './Icons'
+import { SidePanel } from './SidePanel'
 
 interface BuildingDef {
   type: string
@@ -93,12 +94,12 @@ export function BuildOptionsMenu({ onClose, onStartPlacement }: BuildOptionsMenu
   }
 
   return (
-    <div className="cnc-sidebar" onWheel={(e) => e.stopPropagation()}>
+    <SidePanel className="cnc-sidebar" onClose={onClose}>
 
       {/* Header */}
       <div className="cnc-sidebar-header">
         <span>&#x25a0; BAU OPTIONEN</span>
-        <button className="cnc-close-btn" onClick={onClose} title="Schließen">
+        <button className="cnc-close-btn" onClick={onClose} title="Close [Esc]">
           <CloseIcon size={10} />
         </button>
       </div>
@@ -222,6 +223,6 @@ export function BuildOptionsMenu({ onClose, onStartPlacement }: BuildOptionsMenu
         </button>
       </div>
 
-    </div>
+    </SidePanel>
   )
 }

--- a/gh-ctrl/client/src/components/ClawComSetupDialog.tsx
+++ b/gh-ctrl/client/src/components/ClawComSetupDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { api } from '../api'
 import { useAppStore } from '../store'
 import type { Building, ClawComConfig } from '../types'
+import { BaseDialog } from './BaseDialog'
 
 interface ClawComSetupDialogProps {
   building: Building
@@ -61,10 +62,7 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
   }
 
   return (
-    <div
-      className="map-dialog"
-      onWheel={(e) => e.stopPropagation()}
-    >
+    <BaseDialog className="map-dialog" onClose={onClose}>
         <div className="map-dialog-title">&#x25a0; {building.name.toUpperCase()} — SETUP</div>
 
         <div className="clawcom-setup-body">
@@ -131,6 +129,6 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
             {saving ? '◌ SPEICHERN...' : '✓ KONFIGURIEREN'}
           </button>
         </div>
-    </div>
+    </BaseDialog>
   )
 }

--- a/gh-ctrl/client/src/components/ConstructDialog.tsx
+++ b/gh-ctrl/client/src/components/ConstructDialog.tsx
@@ -3,6 +3,7 @@ import type { DashboardEntry, GHLabel } from '../types'
 import { api } from '../api'
 import { VoiceButton } from './VoiceButton'
 import { CloseIcon } from './Icons'
+import { BaseDialog } from './BaseDialog'
 
 interface Props {
   entry: DashboardEntry
@@ -77,18 +78,8 @@ export function ConstructDialog({ entry, onClose, onSuccess, onError }: Props) {
     }
   }
 
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
-    document.addEventListener('keydown', handleKey)
-    return () => document.removeEventListener('keydown', handleKey)
-  }, [onClose])
-
   return (
-    <div
-      className="construct-dialog"
-      onWheel={(e) => e.stopPropagation()}
-      onMouseDown={(e) => e.stopPropagation()}
-    >
+    <BaseDialog className="construct-dialog" onClose={onClose}>
         {/* Header */}
         <div className="construct-header">
           <div className="construct-title-bar">
@@ -179,6 +170,6 @@ export function ConstructDialog({ entry, onClose, onSuccess, onError }: Props) {
         <div className="construct-footer">
           &#x25a0; BASE: {entry.repo.fullName} &nbsp;·&nbsp; COMMAND CENTER READY
         </div>
-    </div>
+    </BaseDialog>
   )
 }

--- a/gh-ctrl/client/src/components/DeadlineTimers.tsx
+++ b/gh-ctrl/client/src/components/DeadlineTimers.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import type { DeadlineTimer } from '../types'
 import { useAppStore } from '../store'
+import { SidePanel } from './SidePanel'
 
 interface DeadlineTimersProps {
   isOpen: boolean
@@ -231,7 +232,7 @@ export function DeadlineTimers({ isOpen, onClose }: DeadlineTimersProps) {
   }
 
   return (
-    <div className="dt-panel">
+    <SidePanel className="dt-panel" onClose={onClose}>
       <div className="dt-panel-header">
         <div className="dt-panel-title">⏱ MISSION TIMERS</div>
         <div className="dt-panel-header-actions">
@@ -241,7 +242,7 @@ export function DeadlineTimers({ isOpen, onClose }: DeadlineTimersProps) {
           >
             + NEW
           </button>
-          <button className="dt-panel-close" onClick={onClose} title="Close">✕</button>
+          <button className="dt-panel-close" onClick={onClose} title="Close [Esc]">✕</button>
         </div>
       </div>
 
@@ -278,6 +279,6 @@ export function DeadlineTimers({ isOpen, onClose }: DeadlineTimersProps) {
           />
         ))}
       </div>
-    </div>
+    </SidePanel>
   )
 }

--- a/gh-ctrl/client/src/components/FeedPanel.tsx
+++ b/gh-ctrl/client/src/components/FeedPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { DashboardEntry, FeedItem } from '../types'
 import { api } from '../api'
+import { SidePanel } from './SidePanel'
 
 type FeedTab = 'mentions' | 'issues' | 'prs'
 
@@ -123,10 +124,10 @@ export function FeedPanel({ entries, isOpen, onClose }: FeedPanelProps) {
   if (!isOpen) return null
 
   return (
-    <div className="feed-panel" onMouseDown={(e) => e.stopPropagation()}>
+    <SidePanel className="feed-panel" onClose={onClose}>
       <div className="feed-panel-header">
         <span className="feed-panel-title">◈ INTEL FEED</span>
-        <button className="feed-panel-close" onClick={onClose} title="Close feed">✕</button>
+        <button className="feed-panel-close" onClick={onClose} title="Close [Esc]">✕</button>
       </div>
 
       <div className="feed-panel-tabs">
@@ -165,6 +166,6 @@ export function FeedPanel({ entries, isOpen, onClose }: FeedPanelProps) {
           <FeedItemRow key={`${item.repo}-${item.type}-${item.number}`} item={item} />
         ))}
       </div>
-    </div>
+    </SidePanel>
   )
 }

--- a/gh-ctrl/client/src/components/HealthcheckSetupDialog.tsx
+++ b/gh-ctrl/client/src/components/HealthcheckSetupDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { api } from '../api'
 import { useAppStore } from '../store'
 import type { Building, HealthcheckConfig, HealthcheckEndpoint } from '../types'
+import { BaseDialog } from './BaseDialog'
 
 interface HealthcheckSetupDialogProps {
   building: Building
@@ -83,7 +84,7 @@ export function HealthcheckSetupDialog({ building, onClose, onConfigured, onErro
   const activePreset = INTERVAL_PRESETS.find((p) => p.ms === intervalMs)
 
   return (
-    <div className="map-dialog" onWheel={(e) => e.stopPropagation()}>
+    <BaseDialog className="map-dialog" onClose={onClose}>
       <div className="map-dialog-title">&#x25a0; {building.name.toUpperCase()} — HEALTHCHECK SETUP</div>
 
       <div className="clawcom-setup-body">
@@ -191,6 +192,6 @@ export function HealthcheckSetupDialog({ building, onClose, onConfigured, onErro
           {saving ? '◌ SPEICHERN...' : '✓ KONFIGURIEREN'}
         </button>
       </div>
-    </div>
+    </BaseDialog>
   )
 }

--- a/gh-ctrl/client/src/components/SidePanel.tsx
+++ b/gh-ctrl/client/src/components/SidePanel.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+
+interface SidePanelProps {
+  onClose: () => void
+  className?: string
+  children: ReactNode
+}
+
+/**
+ * Shared side panel primitive.
+ * Handles: Escape key to close, onClick/onMouseDown/wheel stopPropagation.
+ */
+export function SidePanel({ onClose, className, children }: SidePanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = panelRef.current
+    if (!el) return
+    const stop = (e: WheelEvent) => e.stopPropagation()
+    el.addEventListener('wheel', stop, { passive: true })
+    return () => el.removeEventListener('wheel', stop)
+  }, [])
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  return (
+    <div
+      ref={panelRef}
+      className={className}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #249

Introduces `SidePanel` and `BaseDialog` shared components providing consistent Escape-to-close and event stopPropagation across all panels and dialogs.

Generated with [Claude Code](https://claude.ai/code)