### PR TITLE
feat: Keycloak AuthProvider (opt-in OIDC)

### DIFF
--- a/gh-ctrl/.env.example
+++ b/gh-ctrl/.env.example
@@ -1,2 +1,11 @@
 # Required — all GitHub API calls will fail without this
 GH_TOKEN=your_github_token_here
+
+# Optional — Keycloak authentication (leave unset to run without auth)
+# All three backend vars must be set together to enable JWT validation
+KEYCLOAK_URL=https://keycloak.example.com
+KEYCLOAK_REALM=myrealm
+KEYCLOAK_CLIENT_ID=vibe-and-conquer
+
+# CORS — comma-separated list of additional allowed origins
+# ALLOWED_ORIGINS=https://your-domain.com

--- a/gh-ctrl/client/.env.example
+++ b/gh-ctrl/client/.env.example
@@ -1,0 +1,5 @@
+# Optional — Keycloak authentication for the frontend (leave unset to run without auth)
+# All three vars must be set together to enable OIDC login
+VITE_KEYCLOAK_URL=https://keycloak.example.com
+VITE_KEYCLOAK_REALM=myrealm
+VITE_KEYCLOAK_CLIENT_ID=vibe-and-conquer

--- a/gh-ctrl/client/package.json
+++ b/gh-ctrl/client/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "keycloak-js": "^26.1.4",
     "lucide-react": "^0.475.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -7,7 +7,8 @@ import { MapEditor } from './components/MapEditor'
 import { ToastArea } from './components/Toast'
 import { SetupScreen } from './components/SetupScreen'
 import { ConnectionSetup } from './components/ConnectionSetup'
-import { api, getServerUrl } from './api'
+import { api, getServerUrl, setAuthTokenProvider } from './api'
+import { useAuth } from './auth/useAuth'
 import type { SetupStatus } from './types'
 
 export default function App() {
@@ -23,6 +24,12 @@ export default function App() {
   const [setupChecked, setSetupChecked] = useState(false)
   const [connectionChecked, setConnectionChecked] = useState(false)
   const [serverReachable, setServerReachable] = useState(false)
+  const auth = useAuth()
+
+  // Register Keycloak token provider so api.ts can attach Bearer tokens
+  useEffect(() => {
+    setAuthTokenProvider(() => auth.token)
+  }, [auth.token])
 
   const checkConnection = useCallback(async () => {
     try {
@@ -165,6 +172,17 @@ export default function App() {
 
         {appVersion && (
           <div className="sidebar-version">v{appVersion}</div>
+        )}
+
+        {auth.enabled && auth.user && (
+          <div className="sidebar-user">
+            <span className="sidebar-user-name">
+              {auth.user.name ?? auth.user.username ?? auth.user.email ?? 'User'}
+            </span>
+            <button className="sidebar-logout-btn" onClick={auth.logout} title="Logout">
+              ⏻
+            </button>
+          </div>
         )}
       </aside>
 

--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -18,9 +18,18 @@ function getBase(): string {
   return serverUrl ? `${serverUrl}/api` : '/api'
 }
 
+// Auth token provider — set by KeycloakProvider when Keycloak is enabled
+let _getToken: (() => string | undefined) | null = null
+
+export function setAuthTokenProvider(fn: () => string | undefined) {
+  _getToken = fn
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const token = _getToken?.()
+  const authHeader: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {}
   const res = await fetch(`${getBase()}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader },
     ...options,
   })
   if (!res.ok) {
@@ -291,7 +300,9 @@ export const api = {
     const formData = new FormData()
     formData.append('file', file)
     formData.append('name', name)
-    return fetch(`${base}/badges/upload`, { method: 'POST', body: formData })
+    const token = _getToken?.()
+    const uploadHeaders: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {}
+    return fetch(`${base}/badges/upload`, { method: 'POST', body: formData, headers: uploadHeaders })
       .then(async (res) => {
         if (!res.ok) {
           const err = await res.json().catch(() => ({ error: res.statusText }))

--- a/gh-ctrl/client/src/auth/KeycloakProvider.tsx
+++ b/gh-ctrl/client/src/auth/KeycloakProvider.tsx
@@ -1,0 +1,109 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+import Keycloak from 'keycloak-js'
+
+const KEYCLOAK_URL = import.meta.env.VITE_KEYCLOAK_URL as string | undefined
+const KEYCLOAK_REALM = import.meta.env.VITE_KEYCLOAK_REALM as string | undefined
+const KEYCLOAK_CLIENT_ID = import.meta.env.VITE_KEYCLOAK_CLIENT_ID as string | undefined
+
+export const keycloakEnabled =
+  Boolean(KEYCLOAK_URL) && Boolean(KEYCLOAK_REALM) && Boolean(KEYCLOAK_CLIENT_ID)
+
+interface AuthContextValue {
+  keycloak: Keycloak | null
+  initialized: boolean
+  token: string | undefined
+  user: {
+    username?: string
+    email?: string
+    name?: string
+  } | null
+  isAuthenticated: boolean
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  keycloak: null,
+  initialized: true,
+  token: undefined,
+  user: null,
+  isAuthenticated: true,
+  logout: () => {},
+})
+
+let keycloakInstance: Keycloak | null = null
+
+function getKeycloakInstance(): Keycloak {
+  if (!keycloakInstance) {
+    keycloakInstance = new Keycloak({
+      url: KEYCLOAK_URL!,
+      realm: KEYCLOAK_REALM!,
+      clientId: KEYCLOAK_CLIENT_ID!,
+    })
+  }
+  return keycloakInstance
+}
+
+export function KeycloakProvider({ children }: { children: ReactNode }) {
+  const [initialized, setInitialized] = useState(false)
+  const [token, setToken] = useState<string | undefined>(undefined)
+  const [user, setUser] = useState<AuthContextValue['user']>(null)
+  const [keycloak] = useState<Keycloak>(() => getKeycloakInstance())
+
+  useEffect(() => {
+    keycloak
+      .init({
+        onLoad: 'login-required',
+        checkLoginIframe: false,
+        pkceMethod: 'S256',
+      })
+      .then((authenticated) => {
+        if (authenticated) {
+          setToken(keycloak.token)
+          setUser({
+            username: keycloak.tokenParsed?.preferred_username,
+            email: keycloak.tokenParsed?.email,
+            name: keycloak.tokenParsed?.name,
+          })
+        }
+        setInitialized(true)
+      })
+      .catch((err) => {
+        console.error('[keycloak] init error', err)
+        setInitialized(true)
+      })
+
+    keycloak.onTokenExpired = () => {
+      keycloak
+        .updateToken(60)
+        .then(() => {
+          setToken(keycloak.token)
+        })
+        .catch(() => {
+          keycloak.login()
+        })
+    }
+  }, [keycloak])
+
+  const logout = () => {
+    keycloak.logout()
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        keycloak,
+        initialized,
+        token,
+        user,
+        isAuthenticated: keycloak.authenticated ?? false,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuthContext() {
+  return useContext(AuthContext)
+}

--- a/gh-ctrl/client/src/auth/useAuth.ts
+++ b/gh-ctrl/client/src/auth/useAuth.ts
@@ -1,0 +1,13 @@
+import { useAuthContext, keycloakEnabled } from './KeycloakProvider'
+
+export function useAuth() {
+  const ctx = useAuthContext()
+
+  return {
+    token: keycloakEnabled ? ctx.token : undefined,
+    user: ctx.user,
+    isAuthenticated: keycloakEnabled ? ctx.isAuthenticated : true,
+    logout: ctx.logout,
+    enabled: keycloakEnabled,
+  }
+}

--- a/gh-ctrl/client/src/main.tsx
+++ b/gh-ctrl/client/src/main.tsx
@@ -3,11 +3,16 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import './styles.css'
+import { KeycloakProvider, keycloakEnabled } from './auth/KeycloakProvider'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const tree = (
   <React.StrictMode>
     <BrowserRouter>
       <App />
     </BrowserRouter>
   </React.StrictMode>
+)
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  keycloakEnabled ? <KeycloakProvider>{tree}</KeycloakProvider> : tree
 )

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -154,6 +154,41 @@ a:hover { text-decoration: underline; }
   opacity: 0.7;
 }
 
+.sidebar-user {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 11px;
+  color: var(--text-2);
+  border-top: 1px solid var(--border);
+}
+
+.sidebar-user-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.sidebar-logout-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-3);
+  font-size: 14px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.sidebar-logout-btn:hover {
+  color: var(--red);
+  background: rgba(255, 80, 80, 0.1);
+}
+
 .status-dot {
   width: 8px;
   height: 8px;

--- a/gh-ctrl/package.json
+++ b/gh-ctrl/package.json
@@ -17,6 +17,7 @@
     "drizzle-orm": "^0.31.0",
     "hono": "^4.4.0",
     "imapflow": "^1.2.18",
+    "jose": "^5.9.6",
     "lucide-react": "^0.577.0",
     "nodemailer": "^8.0.4",
     "react-router-dom": "^7.13.1",

--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -15,6 +15,7 @@ import { existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { initHealthcheckService } from './healthcheck-service'
 import { initMailboxService } from './mailbox-service'
+import { authMiddleware } from './middleware/auth'
 
 // Ensure uploads directory exists on startup
 const uploadsDir = join(process.cwd(), 'uploads', 'badges')
@@ -44,6 +45,7 @@ app.use(
   })
 )
 app.use('*', logger())
+app.use('/api/*', authMiddleware)
 
 app.route('/api/repos', reposRouter)
 app.route('/api/github', githubRouter)

--- a/gh-ctrl/src/middleware/auth.ts
+++ b/gh-ctrl/src/middleware/auth.ts
@@ -1,0 +1,44 @@
+import type { MiddlewareHandler } from 'hono'
+import { createRemoteJWKSet, jwtVerify } from 'jose'
+
+const KEYCLOAK_URL = process.env.KEYCLOAK_URL
+const KEYCLOAK_REALM = process.env.KEYCLOAK_REALM
+const KEYCLOAK_CLIENT_ID = process.env.KEYCLOAK_CLIENT_ID
+
+let jwks: ReturnType<typeof createRemoteJWKSet> | null = null
+
+function getJwks() {
+  if (!jwks && KEYCLOAK_URL && KEYCLOAK_REALM) {
+    const jwksUrl = new URL(
+      `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs`
+    )
+    jwks = createRemoteJWKSet(jwksUrl)
+  }
+  return jwks
+}
+
+export const authMiddleware: MiddlewareHandler = async (c, next) => {
+  // If Keycloak is not configured, skip auth entirely (opt-in)
+  if (!KEYCLOAK_URL || !KEYCLOAK_REALM || !KEYCLOAK_CLIENT_ID) {
+    return next()
+  }
+
+  const authorization = c.req.header('Authorization')
+  if (!authorization || !authorization.startsWith('Bearer ')) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+
+  const token = authorization.slice(7)
+
+  try {
+    const keySet = getJwks()!
+    const { payload } = await jwtVerify(token, keySet, {
+      issuer: `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`,
+      audience: KEYCLOAK_CLIENT_ID,
+    })
+    c.set('user' as never, payload)
+    return next()
+  } catch {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+}


### PR DESCRIPTION
Implements opt-in Keycloak OIDC authentication as described in #283.

**Backend**: JWT middleware using `jose` validates Bearer tokens against Keycloak JWKS. No-op when `KEYCLOAK_URL`/REALM/CLIENT_ID are not set.

**Frontend**: `keycloak-js` provider with PKCE, login-required flow, automatic token refresh, and logout button in sidebar. No-op when `VITE_KEYCLOAK_*` vars are not set.

Closes #283

Generated with [Claude Code](https://claude.ai/code)