### PR TITLE
feat: show offline_base.gif for unreachable repositories

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -104,6 +104,18 @@ function IsoBaseBuilding({ color }: { color: string }) {
   )
 }
 
+function OfflineBaseBuilding() {
+  return (
+    <img
+      src="/buildings/offline_base.gif"
+      width="120"
+      height="120"
+      style={{ display: 'block', imageRendering: 'pixelated' }}
+      draggable={false}
+    />
+  )
+}
+
 function IsoPRBuilding() {
   return (
     <img
@@ -162,6 +174,7 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
     }
   }, [onRefreshRepo, repo.owner, repo.name])
 
+  const isOffline = !!data.error
   const hasConflicts = stats.conflicts > 0
   const hasReviews = stats.needsReview > 0
   const hasClaudeActive = (data.activeClaudeIssues?.length ?? 0) > 0
@@ -174,7 +187,9 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
     ? []
     : data.prs.filter((pr) => pr.headRefName?.startsWith('claude/'))
 
-  const statusClass = hasConflicts
+  const statusClass = isOffline
+    ? 'base-offline'
+    : hasConflicts
     ? 'base-conflict'
     : hasReviews
     ? 'base-review'
@@ -238,6 +253,11 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
       >
         {/* Status beacons */}
         <div className="base-beacons">
+          {isOffline && (
+            <span className="base-beacon beacon-offline" title={`Base unreachable: ${data.error}`}>
+              &#x2296;
+            </span>
+          )}
           {hasConflicts && (
             <span className="base-beacon beacon-conflict blink" title={`${stats.conflicts} conflict(s) — BASE UNDER ATTACK`}>
               &#x26a0;
@@ -283,9 +303,12 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
           )}
         </div>
 
-        {/* Building graphic — isometric PNG with repo-color overlay */}
+        {/* Building graphic — isometric PNG with repo-color overlay, or offline gif */}
         <div className="base-building">
-          <IsoBaseBuilding color={repo.color || '#00ff88'} />
+          {isOffline
+            ? <OfflineBaseBuilding />
+            : <IsoBaseBuilding color={repo.color || '#00ff88'} />
+          }
         </div>
 
         {/* Floating HUD toolbar — appears on hover */}

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1842,6 +1842,14 @@ select.input {
   50%       { filter: drop-shadow(0 4px 20px rgba(248, 81, 73, 1.0)); }
 }
 
+.base-node.base-offline .base-building :is(img, canvas) {
+  filter: drop-shadow(0 4px 8px rgba(120, 120, 120, 0.4)) grayscale(0.5) opacity(0.75);
+}
+
+.beacon-offline {
+  color: #888;
+}
+
 .base-node.relocate-mode .base-building {
   outline: 2px dashed var(--base-color, var(--crt-green));
   outline-offset: 2px;


### PR DESCRIPTION
When a repository cannot be reached (e.g. GitLab behind VPN, network error), the base building now shows offline_base.gif instead of the normal colorized base, and a grey beacon is displayed indicating the base is offline.

Closes #279

Generated with [Claude Code](https://claude.ai/code)