### PR TITLE
fix: resolve release-please config errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,3 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [1.0.0] - 2026-03-25
-
-### Added
-- Initial release of Vibe and Conquer (`gh-ctrl`) GitHub Command Center dashboard
-- Battlefield visualization for GitHub activity across multiple repositories
-- Multi-repository aggregation with unified interface
-- GitLab support integration
-- PR management with gamified battlefield view
-- SQLite database with Drizzle ORM for persistent state
-- Hono backend server with REST API
-- React 18 + Vite frontend
-- Zustand state management
-- GitHub CLI (`gh`) integration for fetching live data
-- Automated PR code review via Claude workflow
-- Merge conflict resolution via Claude workflow
-- Manual version bump scripts (`version:patch`, `version:minor`, `version:major`)
-
-[1.0.0]: https://github.com/svengraziani/vibe-and-conquer/releases/tag/v1.0.0
+This changelog is managed by [release-please](https://github.com/googleapis/release-please) in [`gh-ctrl/CHANGELOG.md`](gh-ctrl/CHANGELOG.md).

--- a/gh-ctrl/CHANGELOG.md
+++ b/gh-ctrl/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-03-25
+
+### Added
+- Initial release of Vibe and Conquer (`gh-ctrl`) GitHub Command Center dashboard
+- Battlefield visualization for GitHub activity across multiple repositories
+- Multi-repository aggregation with unified interface
+- GitLab support integration
+- PR management with gamified battlefield view
+- SQLite database with Drizzle ORM for persistent state
+- Hono backend server with REST API
+- React 18 + Vite frontend
+- Zustand state management
+- GitHub CLI (`gh`) integration for fetching live data
+- Automated PR code review via Claude workflow
+- Merge conflict resolution via Claude workflow
+- Manual version bump scripts (`version:patch`, `version:minor`, `version:major`)
+
+[1.0.0]: https://github.com/svengraziani/vibe-and-conquer/releases/tag/v1.0.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,10 +3,8 @@
   "packages": {
     "gh-ctrl": {
       "release-type": "node",
-      "changelog-path": "../CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": false,
-      "tag-separator": ""
+      "include-component-in-tag": false
     }
   },
   "pull-request-title-pattern": "chore: release ${version}",


### PR DESCRIPTION
- Remove `changelog-path: "../CHANGELOG.md"` which caused path traversal
  errors in release-please v4 (paths outside package dir are not supported)
- Remove unnecessary `tag-separator: ""`
- Move CHANGELOG.md to gh-ctrl/ where release-please expects it (matching
  the `gh-ctrl` package path in the config)
- Update root CHANGELOG.md to point to the package-level changelog

https://claude.ai/code/session_018eJz8GiJX672Jq2G5u4LwN