### PR TITLE
feat: default maps shipped with the application

### DIFF
--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -16,6 +16,7 @@ import { join } from 'node:path'
 import { initHealthcheckService } from './healthcheck-service'
 import { initMailboxService } from './mailbox-service'
 import { authMiddleware } from './middleware/auth'
+import { seedDefaultMaps } from './seed'
 
 // Ensure uploads directory exists on startup
 const uploadsDir = join(process.cwd(), 'uploads', 'badges')
@@ -66,7 +67,8 @@ app.use('/uploads/*', serveStatic({ root: './' }))
 app.use('*', serveStatic({ root: './client/dist' }))
 app.get('*', serveStatic({ path: './client/dist/index.html' }))
 
-// Initialize background services
+// Seed default data and initialize background services
+seedDefaultMaps().catch((err) => console.error('[seed] error:', err))
 initHealthcheckService().catch((err) => console.error('[healthcheck-service] init error:', err))
 initMailboxService().catch((err) => console.error('[mailbox-service] init error:', err))
 

--- a/gh-ctrl/src/seed.ts
+++ b/gh-ctrl/src/seed.ts
@@ -1,0 +1,85 @@
+import { db } from './db'
+import { maps } from './db/schema'
+
+interface MapTile {
+  type: string
+  color: string
+}
+
+function generateFuturaX(): Record<string, MapTile> {
+  const W = 30
+  const H = 30
+  const tiles: Record<string, MapTile> = {}
+
+  const getTile = (col: number, row: number): MapTile => {
+    // Rock border
+    if (col === 0 || col === W - 1 || row === 0 || row === H - 1) {
+      return { type: 'rock', color: '#5a5a6a' }
+    }
+
+    // X diagonals (the "X" in Futura_X)
+    const d1 = Math.abs(col - row)
+    const d2 = Math.abs(col - (H - 1 - row))
+    if (d1 <= 1 || d2 <= 1) {
+      return { type: 'lava', color: '#9a2a0a' }
+    }
+
+    // Top-left quadrant: col > row AND row+col < W-1
+    if (col > row && row + col < W - 1) {
+      if (row <= 5) return { type: 'snow', color: '#aababa' }
+      return { type: 'mountain', color: '#7a7a8a' }
+    }
+
+    // Top-right quadrant: col > row AND row+col > W-1
+    if (col > row && row + col > W - 1) {
+      if (col >= W - 6) return { type: 'sand', color: '#9a8a4a' }
+      return { type: 'ground', color: '#4a6b2a' }
+    }
+
+    // Bottom-left quadrant: row > col AND row+col < W-1
+    if (row > col && row + col < W - 1) {
+      return { type: 'water', color: '#1a4a7a' }
+    }
+
+    // Bottom-right quadrant: row > col AND row+col > W-1
+    if (row > col && row + col > W - 1) {
+      if (row >= H - 6) return { type: 'grass', color: '#5a9a2a' }
+      return { type: 'forest', color: '#1a5a1a' }
+    }
+
+    return { type: 'ground', color: '#4a6b2a' }
+  }
+
+  for (let row = 0; row < H; row++) {
+    for (let col = 0; col < W; col++) {
+      tiles[`${col},${row}`] = getTile(col, row)
+    }
+  }
+
+  return tiles
+}
+
+const DEFAULT_MAPS = [
+  {
+    name: 'Futura_X',
+    width: 30,
+    height: 30,
+    tiles: () => generateFuturaX(),
+  },
+]
+
+export async function seedDefaultMaps(): Promise<void> {
+  const existing = await db.select().from(maps)
+  if (existing.length > 0) return
+
+  console.log('[seed] No maps found — seeding default maps...')
+  for (const map of DEFAULT_MAPS) {
+    await db.insert(maps).values({
+      name: map.name,
+      width: map.width,
+      height: map.height,
+      tiles: JSON.stringify(map.tiles()),
+    })
+    console.log(`[seed] Inserted default map: ${map.name}`)
+  }
+}


### PR DESCRIPTION
Adds a default map seeding mechanism that runs on server startup. When no maps exist in the database, built-in default maps are automatically inserted. Includes Futura_X as the first default map (30×30 isometric with an X-themed terrain layout).

Closes #213

Generated with [Claude Code](https://claude.ai/code)