### PR TITLE
feat: add keyboard shortcuts to battlefield

### DIFF
--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -21,9 +21,11 @@ import { BattlefieldHUD } from './battlefield/BattlefieldHUD'
 import { BattlefieldMapLayer } from './battlefield/BattlefieldMapLayer'
 import { BattlefieldMinimap } from './battlefield/BattlefieldMinimap'
 import { LoadBattlefieldMapDialog } from './battlefield/LoadBattlefieldMapDialog'
+import { BattlefieldShortcutsOverlay } from './battlefield/BattlefieldShortcutsOverlay'
 import { useBattlefieldCamera } from '../hooks/useBattlefieldCamera'
 import { useBattlefieldPositions } from '../hooks/useBattlefieldPositions'
 import { useBattlefieldDraggables } from '../hooks/useBattlefieldDraggables'
+import { useBattlefieldKeyboardShortcuts } from '../hooks/useBattlefieldKeyboardShortcuts'
 import type { Position } from './battlefield/battlefieldConstants'
 import { savePositions, loadActiveMapId, saveActiveMapId } from './battlefield/battlefieldStorage'
 
@@ -74,10 +76,37 @@ export function BattlefieldView() {
   const [showBadgeLibrary, setShowBadgeLibrary] = useState(false)
   const [showTimers, setShowTimers] = useState(false)
   const [placingBadge, setPlacingBadge] = useState<Badge | null>(null)
+  const [showShortcuts, setShowShortcuts] = useState(false)
 
   const autoScanTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { play } = useSound()
+
+  const handlePan = useCallback((dx: number, dy: number) => {
+    setOffset(prev => ({ x: prev.x + dx, y: prev.y + dy }))
+  }, [setOffset])
+
+  const handleToggleShortcuts = useCallback(() => {
+    play('peep')
+    setShowShortcuts(v => !v)
+  }, [play])
+
+  const keyboardShortcuts = useBattlefieldKeyboardShortcuts({
+    entries,
+    buildings: storeBuildings,
+    positions,
+    buildingPositions,
+    onZoomIn: handleZoomIn,
+    onZoomOut: handleZoomOut,
+    onZoomReset: () => handleZoomReset(positions),
+    onZoomToBase: handleZoomToBase,
+    onScan: () => { play('peep'); onRefresh() },
+    onToggleFeed: () => { play('peep'); setShowFeedPanel(v => !v); setBranchSiloEntry(null); setDetailEntry(null); setSelectedBuildingId(null) },
+    onToggleTimers: () => { play('peep'); setShowTimers(v => !v) },
+    onPan: handlePan,
+    onToggleShortcutsOverlay: handleToggleShortcuts,
+    enabled: !placementMode && !placingBadge,
+  })
 
   const prevLoadingRef = useRef(loading)
   useEffect(() => {
@@ -360,6 +389,8 @@ export function BattlefieldView() {
         onZoomIn={handleZoomIn}
         onZoomOut={handleZoomOut}
         onZoomReset={() => handleZoomReset(positions)}
+        onToggleShortcuts={handleToggleShortcuts}
+        showShortcuts={showShortcuts}
       />
 
       <BattlefieldMapLayer
@@ -524,6 +555,19 @@ export function BattlefieldView() {
         isOpen={showTimers}
         onClose={() => setShowTimers(false)}
       />
+
+      {showShortcuts && (
+        <BattlefieldShortcutsOverlay
+          entries={visibleEntries}
+          buildings={storeBuildings}
+          shortcuts={keyboardShortcuts.shortcuts}
+          assigningFor={keyboardShortcuts.assigningFor}
+          onClose={() => setShowShortcuts(false)}
+          onStartAssigning={keyboardShortcuts.startAssigning}
+          onClearShortcut={keyboardShortcuts.clearShortcut}
+          onCancelAssigning={keyboardShortcuts.cancelAssigning}
+        />
+      )}
 
       <BranchSiloPanel
         entry={branchSiloEntry}

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
@@ -27,6 +27,8 @@ interface BattlefieldHUDProps {
   onZoomIn: () => void
   onZoomOut: () => void
   onZoomReset: () => void
+  onToggleShortcuts: () => void
+  showShortcuts: boolean
 }
 
 export function BattlefieldHUD({
@@ -54,6 +56,8 @@ export function BattlefieldHUD({
   onZoomIn,
   onZoomOut,
   onZoomReset,
+  onToggleShortcuts,
+  showShortcuts,
 }: BattlefieldHUDProps) {
   return (
     <div className="battlefield-hud">
@@ -145,9 +149,17 @@ export function BattlefieldHUD({
           ⏱<span className="hud-label"> TIMERS</span>
         </button>
         <span className="hud-zoom-sep" />
-        <button className="hud-btn hud-zoom-btn" onClick={onZoomOut} disabled={zoom <= ZOOM_MIN} title="Zoom out">−</button>
-        <span className="hud-zoom-level" title="Click to reset zoom" onClick={onZoomReset}>{Math.round(zoom * 100)}%</span>
-        <button className="hud-btn hud-zoom-btn" onClick={onZoomIn} disabled={zoom >= ZOOM_MAX} title="Zoom in">+</button>
+        <button className="hud-btn hud-zoom-btn" onClick={onZoomOut} disabled={zoom <= ZOOM_MIN} title="Zoom out [−]">−</button>
+        <span className="hud-zoom-level" title="Click to reset zoom [0]" onClick={onZoomReset}>{Math.round(zoom * 100)}%</span>
+        <button className="hud-btn hud-zoom-btn" onClick={onZoomIn} disabled={zoom >= ZOOM_MAX} title="Zoom in [+]">+</button>
+        <span className="hud-zoom-sep" />
+        <button
+          className={`hud-btn${showShortcuts ? ' active' : ''}`}
+          onClick={onToggleShortcuts}
+          title="Keyboard Shortcuts [?]"
+        >
+          ⌨<span className="hud-label"> KEYS</span>
+        </button>
       </div>
     </div>
   )

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldShortcutsOverlay.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldShortcutsOverlay.tsx
@@ -1,0 +1,192 @@
+import type { DashboardEntry, Building } from '../../types'
+import type { ShortcutConfig } from '../../hooks/useBattlefieldKeyboardShortcuts'
+
+interface BattlefieldShortcutsOverlayProps {
+  entries: DashboardEntry[]
+  buildings: Building[]
+  shortcuts: ShortcutConfig
+  assigningFor: { type: 'base' | 'building'; id: number } | null
+  onClose: () => void
+  onStartAssigning: (type: 'base' | 'building', id: number) => void
+  onClearShortcut: (type: 'base' | 'building', id: number) => void
+  onCancelAssigning: () => void
+}
+
+const BUILT_IN_SHORTCUTS = [
+  { key: '+  /  =', description: 'Zoom in' },
+  { key: '-', description: 'Zoom out' },
+  { key: '0', description: 'Reset view' },
+  { key: '↑ ↓ ← →', description: 'Pan camera' },
+  { key: 'R', description: 'Scan / Refresh' },
+  { key: 'F', description: 'Toggle Intel Feed' },
+  { key: 'T', description: 'Toggle Timers' },
+  { key: '?', description: 'Toggle this overlay' },
+]
+
+function KeyBadge({ keyStr }: { keyStr: string }) {
+  return (
+    <span className="shortcut-key-badge">{keyStr}</span>
+  )
+}
+
+export function BattlefieldShortcutsOverlay({
+  entries,
+  buildings,
+  shortcuts,
+  assigningFor,
+  onClose,
+  onStartAssigning,
+  onClearShortcut,
+  onCancelAssigning,
+}: BattlefieldShortcutsOverlayProps) {
+  return (
+    <div className="shortcuts-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose() }}>
+      <div className="shortcuts-panel">
+        <div className="shortcuts-panel-header">
+          <span className="shortcuts-panel-title">⌨ KEYBOARD SHORTCUTS</span>
+          <button className="shortcuts-panel-close" onClick={onClose} title="Close">✕</button>
+        </div>
+
+        {assigningFor && (
+          <div className="shortcuts-assigning-banner">
+            Press any key to assign — <kbd>Esc</kbd> to cancel
+          </div>
+        )}
+
+        <div className="shortcuts-panel-body">
+          {/* Built-in shortcuts */}
+          <div className="shortcuts-section">
+            <div className="shortcuts-section-title">NAVIGATION</div>
+            <table className="shortcuts-table">
+              <tbody>
+                {BUILT_IN_SHORTCUTS.map(({ key, description }) => (
+                  <tr key={key} className="shortcuts-row">
+                    <td className="shortcuts-key-cell">
+                      <KeyBadge keyStr={key} />
+                    </td>
+                    <td className="shortcuts-desc-cell">{description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Base shortcuts */}
+          {entries.length > 0 && (
+            <div className="shortcuts-section">
+              <div className="shortcuts-section-title">BASES</div>
+              <table className="shortcuts-table">
+                <tbody>
+                  {entries.map((entry) => {
+                    const assignedKey = shortcuts.bases[entry.repo.id]
+                    const isAssigning = assigningFor?.type === 'base' && assigningFor.id === entry.repo.id
+                    return (
+                      <tr key={entry.repo.id} className={`shortcuts-row${isAssigning ? ' shortcuts-row-assigning' : ''}`}>
+                        <td className="shortcuts-key-cell">
+                          {assignedKey
+                            ? <KeyBadge keyStr={assignedKey.toUpperCase()} />
+                            : <span className="shortcuts-unassigned">—</span>
+                          }
+                        </td>
+                        <td className="shortcuts-desc-cell">
+                          <span className="shortcuts-base-color" style={{ color: entry.repo.color }}>■</span>
+                          {' '}{entry.repo.name}
+                        </td>
+                        <td className="shortcuts-action-cell">
+                          {isAssigning ? (
+                            <button className="shortcuts-btn shortcuts-btn-cancel" onClick={onCancelAssigning}>
+                              Cancel
+                            </button>
+                          ) : (
+                            <>
+                              <button
+                                className="shortcuts-btn"
+                                onClick={() => onStartAssigning('base', entry.repo.id)}
+                                title="Assign shortcut key"
+                              >
+                                {assignedKey ? 'Change' : 'Assign'}
+                              </button>
+                              {assignedKey && (
+                                <button
+                                  className="shortcuts-btn shortcuts-btn-clear"
+                                  onClick={() => onClearShortcut('base', entry.repo.id)}
+                                  title="Remove shortcut"
+                                >
+                                  ✕
+                                </button>
+                              )}
+                            </>
+                          )}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Building shortcuts */}
+          {buildings.length > 0 && (
+            <div className="shortcuts-section">
+              <div className="shortcuts-section-title">BUILDINGS</div>
+              <table className="shortcuts-table">
+                <tbody>
+                  {buildings.map((building) => {
+                    const assignedKey = shortcuts.buildings[building.id]
+                    const isAssigning = assigningFor?.type === 'building' && assigningFor.id === building.id
+                    return (
+                      <tr key={building.id} className={`shortcuts-row${isAssigning ? ' shortcuts-row-assigning' : ''}`}>
+                        <td className="shortcuts-key-cell">
+                          {assignedKey
+                            ? <KeyBadge keyStr={assignedKey.toUpperCase()} />
+                            : <span className="shortcuts-unassigned">—</span>
+                          }
+                        </td>
+                        <td className="shortcuts-desc-cell">
+                          <span className="shortcuts-building-icon">▣</span>
+                          {' '}{building.name}
+                          <span className="shortcuts-building-type"> [{building.type}]</span>
+                        </td>
+                        <td className="shortcuts-action-cell">
+                          {isAssigning ? (
+                            <button className="shortcuts-btn shortcuts-btn-cancel" onClick={onCancelAssigning}>
+                              Cancel
+                            </button>
+                          ) : (
+                            <>
+                              <button
+                                className="shortcuts-btn"
+                                onClick={() => onStartAssigning('building', building.id)}
+                                title="Assign shortcut key"
+                              >
+                                {assignedKey ? 'Change' : 'Assign'}
+                              </button>
+                              {assignedKey && (
+                                <button
+                                  className="shortcuts-btn shortcuts-btn-clear"
+                                  onClick={() => onClearShortcut('building', building.id)}
+                                  title="Remove shortcut"
+                                >
+                                  ✕
+                                </button>
+                              )}
+                            </>
+                          )}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        <div className="shortcuts-panel-footer">
+          Shortcuts are saved automatically · Jump to base/building with camera zoom
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/hooks/useBattlefieldKeyboardShortcuts.ts
+++ b/gh-ctrl/client/src/hooks/useBattlefieldKeyboardShortcuts.ts
@@ -1,0 +1,225 @@
+import { useEffect, useCallback, useState } from 'react'
+import type { DashboardEntry, Building } from '../types'
+import type { Position } from '../components/battlefield/battlefieldConstants'
+
+const STORAGE_KEY = 'battlefield-shortcuts'
+
+export interface ShortcutConfig {
+  bases: Record<number, string>     // repoId -> key
+  buildings: Record<number, string>  // buildingId -> key
+}
+
+function loadShortcuts(): ShortcutConfig {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) return JSON.parse(raw)
+  } catch {}
+  return { bases: {}, buildings: {} }
+}
+
+function saveShortcuts(config: ShortcutConfig) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(config))
+}
+
+interface UseBattlefieldKeyboardShortcutsOptions {
+  entries: DashboardEntry[]
+  buildings: Building[]
+  positions: Record<number, Position>
+  buildingPositions: Record<number, Position>
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onZoomReset: () => void
+  onZoomToBase: (pos: Position) => void
+  onScan: () => void
+  onToggleFeed: () => void
+  onToggleTimers: () => void
+  onPan: (dx: number, dy: number) => void
+  onToggleShortcutsOverlay: () => void
+  enabled: boolean
+}
+
+export function useBattlefieldKeyboardShortcuts({
+  entries,
+  buildings,
+  positions,
+  buildingPositions,
+  onZoomIn,
+  onZoomOut,
+  onZoomReset,
+  onScan,
+  onToggleFeed,
+  onToggleTimers,
+  onPan,
+  onToggleShortcutsOverlay,
+  onZoomToBase,
+  enabled,
+}: UseBattlefieldKeyboardShortcutsOptions) {
+  const [shortcuts, setShortcuts] = useState<ShortcutConfig>(loadShortcuts)
+  const [assigningFor, setAssigningFor] = useState<{ type: 'base' | 'building'; id: number } | null>(null)
+
+  const assignShortcut = useCallback((type: 'base' | 'building', id: number, key: string) => {
+    setShortcuts(prev => {
+      const next: ShortcutConfig = {
+        bases: { ...prev.bases },
+        buildings: { ...prev.buildings },
+      }
+      // Remove same key from other entries to avoid conflicts
+      for (const k of Object.keys(next.bases)) {
+        if (next.bases[Number(k)] === key) delete next.bases[Number(k)]
+      }
+      for (const k of Object.keys(next.buildings)) {
+        if (next.buildings[Number(k)] === key) delete next.buildings[Number(k)]
+      }
+      if (type === 'base') next.bases[id] = key
+      else next.buildings[id] = key
+      saveShortcuts(next)
+      return next
+    })
+    setAssigningFor(null)
+  }, [])
+
+  const clearShortcut = useCallback((type: 'base' | 'building', id: number) => {
+    setShortcuts(prev => {
+      const next: ShortcutConfig = {
+        bases: { ...prev.bases },
+        buildings: { ...prev.buildings },
+      }
+      if (type === 'base') delete next.bases[id]
+      else delete next.buildings[id]
+      saveShortcuts(next)
+      return next
+    })
+  }, [])
+
+  const startAssigning = useCallback((type: 'base' | 'building', id: number) => {
+    setAssigningFor({ type, id })
+  }, [])
+
+  const cancelAssigning = useCallback(() => {
+    setAssigningFor(null)
+  }, [])
+
+  const PAN_STEP = 120
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Don't fire if typing in an input/textarea
+      const tag = (e.target as HTMLElement).tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement).isContentEditable) return
+      // Don't fire if a modal/dialog is open
+      if ((e.target as HTMLElement).closest('.modal-overlay, .map-dialog-overlay, [class*="dialog"], [class*="overlay"]')) return
+
+      // Handle assignment mode
+      if (assigningFor) {
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          setAssigningFor(null)
+          return
+        }
+        // Skip modifier-only keys
+        if (['Shift', 'Control', 'Alt', 'Meta'].includes(e.key)) return
+        e.preventDefault()
+        const key = e.key.toLowerCase()
+        assignShortcut(assigningFor.type, assigningFor.id, key)
+        return
+      }
+
+      // Built-in shortcuts
+      switch (e.key) {
+        case '+':
+        case '=':
+          e.preventDefault()
+          onZoomIn()
+          return
+        case '-':
+          e.preventDefault()
+          onZoomOut()
+          return
+        case '0':
+          e.preventDefault()
+          onZoomReset()
+          return
+        case 'ArrowUp':
+          e.preventDefault()
+          onPan(0, PAN_STEP)
+          return
+        case 'ArrowDown':
+          e.preventDefault()
+          onPan(0, -PAN_STEP)
+          return
+        case 'ArrowLeft':
+          e.preventDefault()
+          onPan(PAN_STEP, 0)
+          return
+        case 'ArrowRight':
+          e.preventDefault()
+          onPan(-PAN_STEP, 0)
+          return
+        case 'r':
+        case 'R':
+          if (!e.ctrlKey && !e.metaKey) {
+            e.preventDefault()
+            onScan()
+          }
+          return
+        case 'f':
+        case 'F':
+          if (!e.ctrlKey && !e.metaKey) {
+            e.preventDefault()
+            onToggleFeed()
+          }
+          return
+        case 't':
+        case 'T':
+          if (!e.ctrlKey && !e.metaKey) {
+            e.preventDefault()
+            onToggleTimers()
+          }
+          return
+        case '?':
+          e.preventDefault()
+          onToggleShortcutsOverlay()
+          return
+      }
+
+      // User-assigned shortcuts — base jump
+      const pressedKey = e.key.toLowerCase()
+      for (const [idStr, key] of Object.entries(shortcuts.bases)) {
+        if (key === pressedKey) {
+          const id = Number(idStr)
+          const pos = positions[id]
+          if (pos) {
+            e.preventDefault()
+            onZoomToBase(pos)
+          }
+          return
+        }
+      }
+
+      // User-assigned shortcuts — building jump
+      for (const [idStr, key] of Object.entries(shortcuts.buildings)) {
+        if (key === pressedKey) {
+          const id = Number(idStr)
+          const building = buildings.find(b => b.id === id)
+          const pos = buildingPositions[id] ?? (building ? { x: building.posX, y: building.posY } : null)
+          if (pos) {
+            e.preventDefault()
+            onZoomToBase(pos)
+          }
+          return
+        }
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [
+    enabled, assigningFor, shortcuts, entries, buildings, positions, buildingPositions,
+    onZoomIn, onZoomOut, onZoomReset, onZoomToBase, onScan, onToggleFeed, onToggleTimers,
+    onPan, onToggleShortcutsOverlay, assignShortcut,
+  ])
+
+  return { shortcuts, assigningFor, startAssigning, cancelAssigning, clearShortcut, assignShortcut }
+}

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -5669,3 +5669,229 @@ select.input {
   opacity: 0.6;
   line-height: 1.5;
 }
+
+/* ─── Keyboard Shortcuts Overlay ──────────────────────────────────────────── */
+
+.shortcuts-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(2px);
+}
+
+.shortcuts-panel {
+  background: var(--surface-1, #0d1117);
+  border: 1px solid rgba(57, 255, 20, 0.35);
+  box-shadow: 0 0 32px rgba(57, 255, 20, 0.12), 0 8px 40px rgba(0,0,0,0.7);
+  width: min(640px, 92vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-mono, monospace);
+  color: var(--text-1, #ccc);
+}
+
+.shortcuts-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px 9px;
+  border-bottom: 1px solid rgba(57, 255, 20, 0.18);
+  flex-shrink: 0;
+}
+
+.shortcuts-panel-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  color: var(--crt-green, #39ff14);
+  text-transform: uppercase;
+}
+
+.shortcuts-panel-close {
+  background: none;
+  border: none;
+  color: var(--text-2, #888);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 2px 4px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.shortcuts-panel-close:hover {
+  color: var(--crt-green, #39ff14);
+}
+
+.shortcuts-assigning-banner {
+  padding: 7px 14px;
+  background: rgba(57, 255, 20, 0.1);
+  border-bottom: 1px solid rgba(57, 255, 20, 0.25);
+  font-size: 10px;
+  letter-spacing: 1px;
+  color: var(--crt-green, #39ff14);
+  text-align: center;
+  animation: blink 0.8s step-end infinite;
+  flex-shrink: 0;
+}
+
+.shortcuts-assigning-banner kbd {
+  background: rgba(57, 255, 20, 0.15);
+  border: 1px solid rgba(57, 255, 20, 0.3);
+  border-radius: 2px;
+  padding: 0 5px;
+  font-size: 10px;
+  font-family: inherit;
+}
+
+.shortcuts-panel-body {
+  overflow-y: auto;
+  padding: 10px 0;
+  flex: 1;
+}
+
+.shortcuts-section {
+  margin-bottom: 6px;
+}
+
+.shortcuts-section-title {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  color: var(--text-2, #888);
+  padding: 4px 14px 3px;
+  text-transform: uppercase;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+  margin-bottom: 2px;
+}
+
+.shortcuts-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.shortcuts-row {
+  transition: background 0.1s;
+}
+
+.shortcuts-row:hover {
+  background: rgba(57, 255, 20, 0.04);
+}
+
+.shortcuts-row-assigning {
+  background: rgba(57, 255, 20, 0.08) !important;
+}
+
+.shortcuts-key-cell {
+  width: 80px;
+  padding: 4px 14px;
+  vertical-align: middle;
+  text-align: right;
+}
+
+.shortcuts-desc-cell {
+  padding: 4px 8px;
+  font-size: 10px;
+  color: var(--text-1, #ccc);
+  vertical-align: middle;
+}
+
+.shortcuts-action-cell {
+  padding: 4px 14px 4px 4px;
+  text-align: right;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.shortcut-key-badge {
+  display: inline-block;
+  background: rgba(57, 255, 20, 0.12);
+  border: 1px solid rgba(57, 255, 20, 0.35);
+  color: var(--crt-green, #39ff14);
+  font-size: 10px;
+  font-family: inherit;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 2px;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+.shortcuts-unassigned {
+  color: var(--text-2, #888);
+  font-size: 11px;
+  opacity: 0.5;
+}
+
+.shortcuts-base-color {
+  font-size: 9px;
+}
+
+.shortcuts-building-type {
+  font-size: 9px;
+  opacity: 0.5;
+  margin-left: 3px;
+}
+
+.shortcuts-building-icon {
+  font-size: 10px;
+  opacity: 0.6;
+}
+
+.shortcuts-btn {
+  background: none;
+  border: 1px solid rgba(57, 255, 20, 0.25);
+  color: var(--text-2, #888);
+  font-family: inherit;
+  font-size: 9px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-left: 3px;
+}
+
+.shortcuts-btn:hover {
+  background: rgba(57, 255, 20, 0.1);
+  border-color: rgba(57, 255, 20, 0.5);
+  color: var(--crt-green, #39ff14);
+}
+
+.shortcuts-btn-cancel {
+  border-color: rgba(255, 80, 80, 0.4);
+  color: rgba(255, 120, 120, 0.8);
+}
+
+.shortcuts-btn-cancel:hover {
+  background: rgba(255, 80, 80, 0.1);
+  border-color: rgba(255, 80, 80, 0.6);
+  color: #ff6060;
+}
+
+.shortcuts-btn-clear {
+  border-color: rgba(255, 80, 80, 0.25);
+  color: rgba(255, 120, 120, 0.6);
+  padding: 2px 5px;
+}
+
+.shortcuts-btn-clear:hover {
+  background: rgba(255, 80, 80, 0.1);
+  border-color: rgba(255, 80, 80, 0.5);
+  color: #ff6060;
+}
+
+.shortcuts-panel-footer {
+  padding: 7px 14px;
+  font-size: 9px;
+  color: var(--text-2, #888);
+  opacity: 0.5;
+  border-top: 1px solid rgba(57, 255, 20, 0.1);
+  text-align: center;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
Implements keyboard shortcuts for the Battlefield view as requested in #300.

**Built-in shortcuts:** `+/-` zoom, `0` reset view, arrow keys pan, `R` scan, `F` feed, `T` timers, `?` shortcuts overlay

**User-assignable shortcuts:** Click ⌨ KEYS in HUD or press `?` to open the shortcuts panel, assign any key to a base or building for instant camera jump + zoom. Saved in localStorage.

Closes #300

Generated with [Claude Code](https://claude.ai/code)