### PR TITLE
feat: APM enhancements — Command Palette, tests, accessibility

### DIFF
--- a/gh-ctrl/client/src/__tests__/components/BattlefieldShortcutsOverlay.test.tsx
+++ b/gh-ctrl/client/src/__tests__/components/BattlefieldShortcutsOverlay.test.tsx
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BattlefieldShortcutsOverlay } from '../../components/battlefield/BattlefieldShortcutsOverlay'
+import type { DashboardEntry, Building } from '../../types'
+import type { ShortcutConfig } from '../../hooks/useBattlefieldKeyboardShortcuts'
+
+function makeEntry(id: number, name = `repo-${id}`): DashboardEntry {
+  return {
+    repo: { id, owner: 'owner', name, fullName: `owner/${name}`, description: null, color: '#aabbcc', provider: 'github' },
+    data: {
+      prs: [], issues: [], branches: [], stats: { openPRs: 0, openIssues: 0, conflicts: 0, needsReview: 0, runningActions: 0 },
+      defaultBranch: 'main',
+    },
+  } as unknown as DashboardEntry
+}
+
+function makeBuilding(id: number, name = `building-${id}`): Building {
+  return { id, name, type: 'clawcom', posX: 0, posY: 0 } as Building
+}
+
+const emptyShortcuts: ShortcutConfig = { bases: {}, buildings: {} }
+
+describe('BattlefieldShortcutsOverlay', () => {
+  it('has role="dialog" and aria-modal="true"', () => {
+    const { container } = render(
+      <BattlefieldShortcutsOverlay
+        entries={[]}
+        buildings={[]}
+        shortcuts={emptyShortcuts}
+        assigningFor={null}
+        onClose={vi.fn()}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    const panel = container.querySelector('[role="dialog"]')
+    expect(panel).not.toBeNull()
+    expect(panel?.getAttribute('aria-modal')).toBe('true')
+  })
+
+  it('renders built-in NAVIGATION shortcuts', () => {
+    render(
+      <BattlefieldShortcutsOverlay
+        entries={[]}
+        buildings={[]}
+        shortcuts={emptyShortcuts}
+        assigningFor={null}
+        onClose={vi.fn()}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    expect(screen.getByText('NAVIGATION')).toBeInTheDocument()
+    expect(screen.getByText('Zoom in')).toBeInTheDocument()
+    expect(screen.getByText('Pan camera')).toBeInTheDocument()
+  })
+
+  it('renders a row for each DashboardEntry', () => {
+    const entries = [makeEntry(1, 'alpha'), makeEntry(2, 'beta')]
+    render(
+      <BattlefieldShortcutsOverlay
+        entries={entries}
+        buildings={[]}
+        shortcuts={emptyShortcuts}
+        assigningFor={null}
+        onClose={vi.fn()}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    expect(screen.getByText('beta')).toBeInTheDocument()
+  })
+
+  it('renders a row for each Building', () => {
+    const buildings = [makeBuilding(10, 'ClawTower'), makeBuilding(11, 'HealthHub')]
+    render(
+      <BattlefieldShortcutsOverlay
+        entries={[]}
+        buildings={buildings}
+        shortcuts={emptyShortcuts}
+        assigningFor={null}
+        onClose={vi.fn()}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    expect(screen.getByText('ClawTower')).toBeInTheDocument()
+    expect(screen.getByText('HealthHub')).toBeInTheDocument()
+  })
+
+  it('"Assign" button calls onStartAssigning with correct type and id', () => {
+    const onStartAssigning = vi.fn()
+    const entries = [makeEntry(5, 'delta')]
+    render(
+      <BattlefieldShortcutsOverlay
+        entries={entries}
+        buildings={[]}
+        shortcuts={emptyShortcuts}
+        assigningFor={null}
+        onClose={vi.fn()}
+        onStartAssigning={onStartAssigning}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    const assignBtn = screen.getByRole('button', { name: /assign shortcut.*delta/i })
+    fireEvent.click(assignBtn)
+    expect(onStartAssigning).toHaveBeenCalledWith('base', 5)
+  })
+
+  it('"✕" clear button calls onClearShortcut when a key is assigned', () => {
+    const onClearShortcut = vi.fn()
+    const entries = [makeEntry(3, 'gamma')]
+    const shortcuts: ShortcutConfig = { bases: { 3: 'q' }, buildings: {} }
+    render(
+      <BattlefieldShortcutsOverlay
+        entries={entries}
+        buildings={[]}
+        shortcuts={shortcuts}
+        assigningFor={null}
+        onClose={vi.fn()}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={onClearShortcut}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    const clearBtn = screen.getByRole('button', { name: /remove shortcut.*gamma/i })
+    fireEvent.click(clearBtn)
+    expect(onClearShortcut).toHaveBeenCalledWith('base', 3)
+  })
+
+  it('"Cancel" button calls onCancelAssigning when assigningFor is set', () => {
+    const onCancelAssigning = vi.fn()
+    const entries = [makeEntry(1, 'repo-1')]
+    render(
+      <BattlefieldShortcutsOverlay
+        entries={entries}
+        buildings={[]}
+        shortcuts={emptyShortcuts}
+        assigningFor={{ type: 'base', id: 1 }}
+        onClose={vi.fn()}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={onCancelAssigning}
+      />
+    )
+    const cancelBtn = screen.getAllByRole('button', { name: /cancel/i })[0]
+    fireEvent.click(cancelBtn)
+    expect(onCancelAssigning).toHaveBeenCalled()
+  })
+
+  it('clicking the backdrop calls onClose', () => {
+    const onClose = vi.fn()
+    const { container } = render(
+      <BattlefieldShortcutsOverlay
+        entries={[]}
+        buildings={[]}
+        shortcuts={emptyShortcuts}
+        assigningFor={null}
+        onClose={onClose}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    const backdrop = container.querySelector('.shortcuts-overlay')!
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('close ✕ button calls onClose', () => {
+    const onClose = vi.fn()
+    render(
+      <BattlefieldShortcutsOverlay
+        entries={[]}
+        buildings={[]}
+        shortcuts={emptyShortcuts}
+        assigningFor={null}
+        onClose={onClose}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    const closeBtn = screen.getByRole('button', { name: /close shortcuts overlay/i })
+    fireEvent.click(closeBtn)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('assigning banner is shown when assigningFor is non-null', () => {
+    const entries = [makeEntry(2)]
+    render(
+      <BattlefieldShortcutsOverlay
+        entries={entries}
+        buildings={[]}
+        shortcuts={emptyShortcuts}
+        assigningFor={{ type: 'base', id: 2 }}
+        onClose={vi.fn()}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('assigning banner is NOT shown when assigningFor is null', () => {
+    render(
+      <BattlefieldShortcutsOverlay
+        entries={[]}
+        buildings={[]}
+        shortcuts={emptyShortcuts}
+        assigningFor={null}
+        onClose={vi.fn()}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('KeyBadge renders the assigned key string', () => {
+    const entries = [makeEntry(7, 'echo')]
+    const shortcuts: ShortcutConfig = { bases: { 7: 'z' }, buildings: {} }
+    render(
+      <BattlefieldShortcutsOverlay
+        entries={entries}
+        buildings={[]}
+        shortcuts={shortcuts}
+        assigningFor={null}
+        onClose={vi.fn()}
+        onStartAssigning={vi.fn()}
+        onClearShortcut={vi.fn()}
+        onCancelAssigning={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Z')).toBeInTheDocument()
+  })
+})

--- a/gh-ctrl/client/src/__tests__/components/CommandPalette.test.tsx
+++ b/gh-ctrl/client/src/__tests__/components/CommandPalette.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CommandPalette } from '../../components/battlefield/CommandPalette'
+import type { DashboardEntry, Building } from '../../types'
+
+function makeEntry(id: number, name = `repo-${id}`): DashboardEntry {
+  return {
+    repo: { id, owner: 'owner', name, fullName: `owner/${name}`, description: null, color: '#fff', provider: 'github' },
+    data: {
+      prs: [], issues: [], branches: [], stats: { openPRs: 0, openIssues: 0, conflicts: 0, needsReview: 0, runningActions: 0 },
+      defaultBranch: 'main',
+    },
+  } as unknown as DashboardEntry
+}
+
+function makeBuilding(id: number, name = `building-${id}`): Building {
+  return { id, name, type: 'clawcom', posX: 100, posY: 200 } as Building
+}
+
+const defaultProps = {
+  entries: [] as DashboardEntry[],
+  buildings: [] as Building[],
+  positions: {} as Record<number, { x: number; y: number }>,
+  buildingPositions: {} as Record<number, { x: number; y: number }>,
+  onZoomToBase: vi.fn(),
+  onScan: vi.fn(),
+  onToggleFeed: vi.fn(),
+  onToggleTimers: vi.fn(),
+  onZoomReset: vi.fn(),
+  onClose: vi.fn(),
+}
+
+describe('CommandPalette', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('has role="dialog" and aria-modal="true"', () => {
+    const { container } = render(<CommandPalette {...defaultProps} />)
+    const dialog = container.querySelector('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    expect(dialog?.getAttribute('aria-modal')).toBe('true')
+  })
+
+  it('renders search input focused', () => {
+    render(<CommandPalette {...defaultProps} />)
+    const input = screen.getByRole('textbox')
+    expect(input).toBeInTheDocument()
+  })
+
+  it('renders built-in ACTION commands when no search query', () => {
+    render(<CommandPalette {...defaultProps} />)
+    expect(screen.getByText('Scan / Refresh')).toBeInTheDocument()
+    expect(screen.getByText('Toggle Intel Feed')).toBeInTheDocument()
+    expect(screen.getByText('Toggle Timers')).toBeInTheDocument()
+    expect(screen.getByText('Reset View')).toBeInTheDocument()
+  })
+
+  it('renders BASE commands for each entry with a position', () => {
+    const entries = [makeEntry(1, 'alpha'), makeEntry(2, 'beta')]
+    const positions = { 1: { x: 100, y: 200 }, 2: { x: 300, y: 400 } }
+    render(<CommandPalette {...defaultProps} entries={entries} positions={positions} />)
+    expect(screen.getByText('Jump to alpha')).toBeInTheDocument()
+    expect(screen.getByText('Jump to beta')).toBeInTheDocument()
+  })
+
+  it('renders BUILDING commands for each building', () => {
+    const buildings = [makeBuilding(10, 'ClawCom HQ')]
+    const buildingPositions = { 10: { x: 500, y: 500 } }
+    render(<CommandPalette {...defaultProps} buildings={buildings} buildingPositions={buildingPositions} />)
+    expect(screen.getByText('Go to ClawCom HQ')).toBeInTheDocument()
+  })
+
+  it('renders CREATE commands when onCreateIssue is provided', () => {
+    const entries = [makeEntry(1, 'myrepo')]
+    const positions = { 1: { x: 0, y: 0 } }
+    const onCreateIssue = vi.fn()
+    render(<CommandPalette {...defaultProps} entries={entries} positions={positions} onCreateIssue={onCreateIssue} />)
+    expect(screen.getByText('Create issue in myrepo')).toBeInTheDocument()
+  })
+
+  it('filters results by fuzzy match on typing', () => {
+    render(<CommandPalette {...defaultProps} />)
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'scan' } })
+    expect(screen.getByText('Scan / Refresh')).toBeInTheDocument()
+    expect(screen.queryByText('Toggle Intel Feed')).toBeNull()
+  })
+
+  it('shows "No commands found" when no results match', () => {
+    render(<CommandPalette {...defaultProps} />)
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'xyzxyzxyz_never_matches' } })
+    expect(screen.getByText('No commands found')).toBeInTheDocument()
+  })
+
+  it('ArrowDown moves selection to next item', () => {
+    render(<CommandPalette {...defaultProps} />)
+    const input = screen.getByRole('textbox')
+    const itemsBefore = screen.getAllByRole('option')
+    expect(itemsBefore[0].getAttribute('aria-selected')).toBe('true')
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    const itemsAfter = screen.getAllByRole('option')
+    expect(itemsAfter[0].getAttribute('aria-selected')).toBe('false')
+    expect(itemsAfter[1].getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('ArrowUp moves selection to previous item', () => {
+    render(<CommandPalette {...defaultProps} />)
+    const input = screen.getByRole('textbox')
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+
+    const items = screen.getAllByRole('option')
+    expect(items[0].getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('Enter executes selected command and closes', () => {
+    const onScan = vi.fn()
+    const onClose = vi.fn()
+    render(<CommandPalette {...defaultProps} onScan={onScan} onClose={onClose} />)
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'scan' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onScan).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('Escape calls onClose', () => {
+    const onClose = vi.fn()
+    render(<CommandPalette {...defaultProps} onClose={onClose} />)
+    const input = screen.getByRole('textbox')
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('"Jump to [repo]" command calls onZoomToBase with correct position', () => {
+    const onZoomToBase = vi.fn()
+    const entries = [makeEntry(5, 'targetrepo')]
+    const positions = { 5: { x: 999, y: 888 } }
+    render(<CommandPalette {...defaultProps} entries={entries} positions={positions} onZoomToBase={onZoomToBase} />)
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'targetrepo' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onZoomToBase).toHaveBeenCalledWith({ x: 999, y: 888 })
+  })
+
+  it('"Scan / Refresh" calls onScan', () => {
+    const onScan = vi.fn()
+    const onClose = vi.fn()
+    render(<CommandPalette {...defaultProps} onScan={onScan} onClose={onClose} />)
+    const item = screen.getByText('Scan / Refresh')
+    fireEvent.click(item)
+    expect(onScan).toHaveBeenCalled()
+  })
+
+  it('clicking backdrop calls onClose', () => {
+    const onClose = vi.fn()
+    const { container } = render(<CommandPalette {...defaultProps} onClose={onClose} />)
+    const overlay = container.querySelector('.command-palette-overlay')!
+    fireEvent.click(overlay)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('recently used commands appear first', () => {
+    // Pre-seed localStorage with a recent command
+    localStorage.setItem('command-palette-recent', JSON.stringify(['action-timers']))
+    const onClose = vi.fn()
+    render(<CommandPalette {...defaultProps} onClose={onClose} />)
+    const items = screen.getAllByRole('option')
+    // The first item should be "Toggle Timers" since it's in recent
+    expect(items[0].textContent).toContain('Toggle Timers')
+  })
+})

--- a/gh-ctrl/client/src/__tests__/hooks/useBattlefieldCamera.test.ts
+++ b/gh-ctrl/client/src/__tests__/hooks/useBattlefieldCamera.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useBattlefieldCamera } from '../../hooks/useBattlefieldCamera'
+import { ZOOM_MIN, ZOOM_MAX } from '../../components/battlefield/battlefieldConstants'
+
+describe('useBattlefieldCamera', () => {
+  beforeEach(() => {
+    // Provide deterministic window dimensions
+    Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true, writable: true })
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true, writable: true })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('initialises with zoom 1', () => {
+    const { result } = renderHook(() => useBattlefieldCamera())
+    expect(result.current.zoom).toBe(1)
+  })
+
+  it('handleZoomIn increases zoom', () => {
+    const { result } = renderHook(() => useBattlefieldCamera())
+    const before = result.current.zoom
+    act(() => {
+      result.current.handleZoomIn()
+    })
+    expect(result.current.zoom).toBeGreaterThan(before)
+  })
+
+  it('handleZoomOut decreases zoom', () => {
+    const { result } = renderHook(() => useBattlefieldCamera())
+    act(() => {
+      result.current.handleZoomIn()
+    })
+    const before = result.current.zoom
+    act(() => {
+      result.current.handleZoomOut()
+    })
+    expect(result.current.zoom).toBeLessThan(before)
+  })
+
+  it('handleZoomIn clamps at ZOOM_MAX', () => {
+    const { result } = renderHook(() => useBattlefieldCamera())
+    // Repeatedly zoom in beyond max
+    for (let i = 0; i < 100; i++) {
+      act(() => { result.current.handleZoomIn() })
+    }
+    expect(result.current.zoom).toBeLessThanOrEqual(ZOOM_MAX)
+  })
+
+  it('handleZoomOut clamps at ZOOM_MIN', () => {
+    const { result } = renderHook(() => useBattlefieldCamera())
+    for (let i = 0; i < 100; i++) {
+      act(() => { result.current.handleZoomOut() })
+    }
+    expect(result.current.zoom).toBeGreaterThanOrEqual(ZOOM_MIN)
+  })
+
+  it('handleZoomReset restores zoom to 1 and centers on positions', () => {
+    const { result } = renderHook(() => useBattlefieldCamera())
+
+    // First zoom in
+    act(() => { result.current.handleZoomIn() })
+    expect(result.current.zoom).not.toBe(1)
+
+    // Reset with known positions
+    const positions = { 1: { x: 400, y: 300 } }
+    act(() => { result.current.handleZoomReset(positions) })
+
+    expect(result.current.zoom).toBe(1)
+  })
+
+  it('handleZoomReset with no positions uses default offset', () => {
+    const { result } = renderHook(() => useBattlefieldCamera())
+    act(() => { result.current.handleZoomIn() })
+    act(() => { result.current.handleZoomReset({}) })
+    expect(result.current.zoom).toBe(1)
+  })
+
+  it('handleZoomToBase centers camera on position and sets zoom >= 1.5', () => {
+    const { result } = renderHook(() => useBattlefieldCamera())
+    const pos = { x: 600, y: 400 }
+    act(() => { result.current.handleZoomToBase(pos) })
+    expect(result.current.zoom).toBeGreaterThanOrEqual(1.5)
+    // Offset should place pos at center of screen
+    expect(result.current.offset.x).toBe(window.innerWidth / 2 - pos.x * result.current.zoom)
+    expect(result.current.offset.y).toBe(window.innerHeight / 2 - pos.y * result.current.zoom)
+  })
+})

--- a/gh-ctrl/client/src/__tests__/hooks/useBattlefieldKeyboardShortcuts.test.ts
+++ b/gh-ctrl/client/src/__tests__/hooks/useBattlefieldKeyboardShortcuts.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useBattlefieldKeyboardShortcuts } from '../../hooks/useBattlefieldKeyboardShortcuts'
+import type { DashboardEntry, Building } from '../../types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(id: number, name = `repo-${id}`): DashboardEntry {
+  return {
+    repo: { id, owner: 'owner', name, fullName: `owner/${name}`, description: null, color: '#ff0000', provider: 'github' },
+    data: {
+      prs: [], issues: [], branches: [], stats: { openPRs: 0, openIssues: 0, conflicts: 0, needsReview: 0, runningActions: 0 },
+      defaultBranch: 'main',
+    },
+  } as unknown as DashboardEntry
+}
+
+function makeBuilding(id: number, name = `building-${id}`): Building {
+  return { id, name, type: 'clawcom', posX: 100, posY: 200 } as Building
+}
+
+function fireKeydown(key: string, options: Partial<KeyboardEventInit> = {}) {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...options })
+  window.dispatchEvent(event)
+  return event
+}
+
+function defaultOptions() {
+  return {
+    entries: [] as DashboardEntry[],
+    buildings: [] as Building[],
+    positions: {} as Record<number, { x: number; y: number }>,
+    buildingPositions: {} as Record<number, { x: number; y: number }>,
+    onZoomIn: vi.fn(),
+    onZoomOut: vi.fn(),
+    onZoomReset: vi.fn(),
+    onZoomToBase: vi.fn(),
+    onScan: vi.fn(),
+    onToggleFeed: vi.fn(),
+    onToggleTimers: vi.fn(),
+    onPan: vi.fn(),
+    onToggleShortcutsOverlay: vi.fn(),
+    onToggleCommandPalette: vi.fn(),
+    enabled: true,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useBattlefieldKeyboardShortcuts', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  // ── Persistence ──────────────────────────────────────────────────────────
+
+  it('loads shortcut config from localStorage on init', () => {
+    const stored = { bases: { 1: 'a' }, buildings: { 2: 'b' } }
+    localStorage.setItem('battlefield-shortcuts', JSON.stringify(stored))
+
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    expect(result.current.shortcuts.bases[1]).toBe('a')
+    expect(result.current.shortcuts.buildings[2]).toBe('b')
+  })
+
+  it('uses empty config when localStorage has no shortcuts', () => {
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    expect(result.current.shortcuts.bases).toEqual({})
+    expect(result.current.shortcuts.buildings).toEqual({})
+  })
+
+  // ── assignShortcut ───────────────────────────────────────────────────────
+
+  it('assignShortcut stores to localStorage and updates state', () => {
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    act(() => {
+      result.current.assignShortcut('base', 1, 'q')
+    })
+
+    expect(result.current.shortcuts.bases[1]).toBe('q')
+    const stored = JSON.parse(localStorage.getItem('battlefield-shortcuts')!)
+    expect(stored.bases[1]).toBe('q')
+  })
+
+  it('assignShortcut removes duplicate key from other bases', () => {
+    localStorage.setItem('battlefield-shortcuts', JSON.stringify({ bases: { 1: 'q', 2: 'w' }, buildings: {} }))
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    act(() => {
+      result.current.assignShortcut('base', 3, 'q')
+    })
+
+    expect(result.current.shortcuts.bases[3]).toBe('q')
+    expect(result.current.shortcuts.bases[1]).toBeUndefined()
+    expect(result.current.shortcuts.bases[2]).toBe('w')
+  })
+
+  it('assignShortcut removes duplicate key from buildings', () => {
+    localStorage.setItem('battlefield-shortcuts', JSON.stringify({ bases: {}, buildings: { 10: 'z' } }))
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    act(() => {
+      result.current.assignShortcut('base', 1, 'z')
+    })
+
+    expect(result.current.shortcuts.bases[1]).toBe('z')
+    expect(result.current.shortcuts.buildings[10]).toBeUndefined()
+  })
+
+  // ── clearShortcut ────────────────────────────────────────────────────────
+
+  it('clearShortcut removes entry and saves to localStorage', () => {
+    localStorage.setItem('battlefield-shortcuts', JSON.stringify({ bases: { 1: 'q' }, buildings: {} }))
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    act(() => {
+      result.current.clearShortcut('base', 1)
+    })
+
+    expect(result.current.shortcuts.bases[1]).toBeUndefined()
+    const stored = JSON.parse(localStorage.getItem('battlefield-shortcuts')!)
+    expect(stored.bases[1]).toBeUndefined()
+  })
+
+  // ── startAssigning / cancelAssigning ─────────────────────────────────────
+
+  it('startAssigning sets assigningFor', () => {
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    act(() => {
+      result.current.startAssigning('base', 42)
+    })
+
+    expect(result.current.assigningFor).toEqual({ type: 'base', id: 42 })
+  })
+
+  it('cancelAssigning clears assigningFor', () => {
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    act(() => {
+      result.current.startAssigning('building', 7)
+    })
+    act(() => {
+      result.current.cancelAssigning()
+    })
+
+    expect(result.current.assigningFor).toBeNull()
+  })
+
+  // ── Built-in zoom/pan shortcuts ──────────────────────────────────────────
+
+  it('+ fires onZoomIn', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('+')
+    expect(opts.onZoomIn).toHaveBeenCalled()
+  })
+
+  it('= fires onZoomIn', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('=')
+    expect(opts.onZoomIn).toHaveBeenCalled()
+  })
+
+  it('- fires onZoomOut', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('-')
+    expect(opts.onZoomOut).toHaveBeenCalled()
+  })
+
+  it('0 fires onZoomReset', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('0')
+    expect(opts.onZoomReset).toHaveBeenCalled()
+  })
+
+  it('ArrowUp calls onPan(0, +PAN_STEP)', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('ArrowUp')
+    expect(opts.onPan).toHaveBeenCalledWith(0, 120)
+  })
+
+  it('ArrowDown calls onPan(0, -PAN_STEP)', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('ArrowDown')
+    expect(opts.onPan).toHaveBeenCalledWith(0, -120)
+  })
+
+  it('ArrowLeft calls onPan(+PAN_STEP, 0)', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('ArrowLeft')
+    expect(opts.onPan).toHaveBeenCalledWith(120, 0)
+  })
+
+  it('ArrowRight calls onPan(-PAN_STEP, 0)', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('ArrowRight')
+    expect(opts.onPan).toHaveBeenCalledWith(-120, 0)
+  })
+
+  it('r fires onScan', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('r')
+    expect(opts.onScan).toHaveBeenCalled()
+  })
+
+  it('R fires onScan', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('R')
+    expect(opts.onScan).toHaveBeenCalled()
+  })
+
+  it('f fires onToggleFeed', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('f')
+    expect(opts.onToggleFeed).toHaveBeenCalled()
+  })
+
+  it('t fires onToggleTimers', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('t')
+    expect(opts.onToggleTimers).toHaveBeenCalled()
+  })
+
+  it('? fires onToggleShortcutsOverlay', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('?')
+    expect(opts.onToggleShortcutsOverlay).toHaveBeenCalled()
+  })
+
+  // ── Ctrl+K / Command Palette ─────────────────────────────────────────────
+
+  it('Ctrl+K fires onToggleCommandPalette', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('k', { ctrlKey: true })
+    expect(opts.onToggleCommandPalette).toHaveBeenCalled()
+  })
+
+  it('Meta+K fires onToggleCommandPalette', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('k', { metaKey: true })
+    expect(opts.onToggleCommandPalette).toHaveBeenCalled()
+  })
+
+  // ── User-assigned shortcuts ──────────────────────────────────────────────
+
+  it('user-assigned base key fires onZoomToBase with correct position', () => {
+    localStorage.setItem('battlefield-shortcuts', JSON.stringify({ bases: { 5: 'g' }, buildings: {} }))
+    const opts = {
+      ...defaultOptions(),
+      entries: [makeEntry(5)],
+      positions: { 5: { x: 300, y: 400 } },
+    }
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('g')
+    expect(opts.onZoomToBase).toHaveBeenCalledWith({ x: 300, y: 400 })
+  })
+
+  it('user-assigned building key fires onZoomToBase', () => {
+    localStorage.setItem('battlefield-shortcuts', JSON.stringify({ bases: {}, buildings: { 20: 'h' } }))
+    const building = makeBuilding(20)
+    const opts = {
+      ...defaultOptions(),
+      buildings: [building],
+      buildingPositions: { 20: { x: 500, y: 600 } },
+    }
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('h')
+    expect(opts.onZoomToBase).toHaveBeenCalledWith({ x: 500, y: 600 })
+  })
+
+  // ── Disabled / ignored states ────────────────────────────────────────────
+
+  it('does nothing when enabled = false', () => {
+    const opts = { ...defaultOptions(), enabled: false }
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    fireKeydown('+')
+    expect(opts.onZoomIn).not.toHaveBeenCalled()
+  })
+
+  it('ignores keydown when target is INPUT', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: '+', bubbles: true, cancelable: true }))
+    document.body.removeChild(input)
+    expect(opts.onZoomIn).not.toHaveBeenCalled()
+  })
+
+  it('ignores keydown when target is TEXTAREA', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: '+', bubbles: true, cancelable: true }))
+    document.body.removeChild(textarea)
+    expect(opts.onZoomIn).not.toHaveBeenCalled()
+  })
+
+  it('ignores keydown when target is contentEditable', () => {
+    const opts = defaultOptions()
+    renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+    const div = document.createElement('div')
+    div.contentEditable = 'true'
+    document.body.appendChild(div)
+    div.dispatchEvent(new KeyboardEvent('keydown', { key: '+', bubbles: true, cancelable: true }))
+    document.body.removeChild(div)
+    expect(opts.onZoomIn).not.toHaveBeenCalled()
+  })
+
+  // ── Assignment mode ──────────────────────────────────────────────────────
+
+  it('Escape while in assignment mode cancels assignment', () => {
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    act(() => {
+      result.current.startAssigning('base', 1)
+    })
+
+    expect(result.current.assigningFor).not.toBeNull()
+
+    act(() => {
+      fireKeydown('Escape')
+    })
+
+    expect(result.current.assigningFor).toBeNull()
+    expect(opts.onZoomReset).not.toHaveBeenCalled()
+  })
+
+  it('pressing a key while in assignment mode assigns it', () => {
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    act(() => {
+      result.current.startAssigning('base', 1)
+    })
+
+    act(() => {
+      fireKeydown('x')
+    })
+
+    expect(result.current.shortcuts.bases[1]).toBe('x')
+    expect(result.current.assigningFor).toBeNull()
+  })
+
+  it('modifier-only keys are skipped during assignment mode', () => {
+    const opts = defaultOptions()
+    const { result } = renderHook(() => useBattlefieldKeyboardShortcuts(opts))
+
+    act(() => {
+      result.current.startAssigning('base', 1)
+    })
+
+    act(() => {
+      fireKeydown('Shift')
+    })
+
+    expect(result.current.assigningFor).not.toBeNull()
+    expect(result.current.shortcuts.bases[1]).toBeUndefined()
+  })
+})

--- a/gh-ctrl/client/src/__tests__/hooks/useBattlefieldKeyboardShortcuts.test.ts
+++ b/gh-ctrl/client/src/__tests__/hooks/useBattlefieldKeyboardShortcuts.test.ts
@@ -332,7 +332,7 @@ describe('useBattlefieldKeyboardShortcuts', () => {
     const opts = defaultOptions()
     renderHook(() => useBattlefieldKeyboardShortcuts(opts))
     const div = document.createElement('div')
-    div.contentEditable = 'true'
+    div.setAttribute('contenteditable', 'true')
     document.body.appendChild(div)
     div.dispatchEvent(new KeyboardEvent('keydown', { key: '+', bubbles: true, cancelable: true }))
     document.body.removeChild(div)

--- a/gh-ctrl/client/src/__tests__/hooks/useBattlefieldPositions.test.ts
+++ b/gh-ctrl/client/src/__tests__/hooks/useBattlefieldPositions.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useBattlefieldPositions } from '../../hooks/useBattlefieldPositions'
+import type { DashboardEntry } from '../../types'
+
+function makeEntry(id: number): DashboardEntry {
+  return {
+    repo: { id, owner: 'owner', name: `repo-${id}`, fullName: `owner/repo-${id}`, description: null, color: '#fff', provider: 'github' },
+    data: {
+      prs: [], issues: [], branches: [], stats: { openPRs: 0, openIssues: 0, conflicts: 0, needsReview: 0, runningActions: 0 },
+      defaultBranch: 'main',
+    },
+  } as unknown as DashboardEntry
+}
+
+describe('useBattlefieldPositions', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true, writable: true })
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true, writable: true })
+  })
+
+  it('initialises positions for provided entries', () => {
+    const entries = [makeEntry(1), makeEntry(2)]
+    const { result } = renderHook(() => useBattlefieldPositions({ entries, loading: false }))
+    expect(result.current.positions[1]).toBeDefined()
+    expect(result.current.positions[2]).toBeDefined()
+  })
+
+  it('handleStartRelocate sets relocatingId and relocatingStart', () => {
+    const entries = [makeEntry(1)]
+    const { result } = renderHook(() => useBattlefieldPositions({ entries, loading: false }))
+    const pos = result.current.positions[1]
+
+    act(() => {
+      result.current.handleStartRelocate(1, 300, 400)
+    })
+
+    expect(result.current.relocatingId).toBe(1)
+    expect(result.current.relocatingStart).toEqual({
+      mouseX: 300,
+      mouseY: 400,
+      nodeX: pos.x,
+      nodeY: pos.y,
+    })
+  })
+
+  it('handleStartRelocate does nothing when id has no position', () => {
+    const { result } = renderHook(() => useBattlefieldPositions({ entries: [], loading: false }))
+    act(() => {
+      result.current.handleStartRelocate(999, 0, 0)
+    })
+    expect(result.current.relocatingId).toBeNull()
+  })
+
+  it('getAutoCenterOffset returns null while loading', () => {
+    const entries = [makeEntry(1)]
+    const { result } = renderHook(() => useBattlefieldPositions({ entries, loading: true }))
+    expect(result.current.getAutoCenterOffset()).toBeNull()
+  })
+
+  it('getAutoCenterOffset returns null when entries are empty', () => {
+    const { result } = renderHook(() => useBattlefieldPositions({ entries: [], loading: false }))
+    expect(result.current.getAutoCenterOffset()).toBeNull()
+  })
+
+  it('getAutoCenterOffset returns an offset centered on positions', () => {
+    const entries = [makeEntry(1), makeEntry(2)]
+    const { result } = renderHook(() => useBattlefieldPositions({ entries, loading: false }))
+    const offset = result.current.getAutoCenterOffset()
+    // Should return a valid Position (not null) on first call
+    expect(offset).not.toBeNull()
+    expect(typeof offset?.x).toBe('number')
+    expect(typeof offset?.y).toBe('number')
+  })
+
+  it('getAutoCenterOffset only returns non-null once (hasAutoCenteredRef guard)', () => {
+    const entries = [makeEntry(1)]
+    const { result } = renderHook(() => useBattlefieldPositions({ entries, loading: false }))
+    const first = result.current.getAutoCenterOffset()
+    const second = result.current.getAutoCenterOffset()
+    expect(first).not.toBeNull()
+    expect(second).toBeNull()
+  })
+})

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -22,6 +22,7 @@ import { BattlefieldMapLayer } from './battlefield/BattlefieldMapLayer'
 import { BattlefieldMinimap } from './battlefield/BattlefieldMinimap'
 import { LoadBattlefieldMapDialog } from './battlefield/LoadBattlefieldMapDialog'
 import { BattlefieldShortcutsOverlay } from './battlefield/BattlefieldShortcutsOverlay'
+import { CommandPalette } from './battlefield/CommandPalette'
 import { useBattlefieldCamera } from '../hooks/useBattlefieldCamera'
 import { useBattlefieldPositions } from '../hooks/useBattlefieldPositions'
 import { useBattlefieldDraggables } from '../hooks/useBattlefieldDraggables'
@@ -77,6 +78,7 @@ export function BattlefieldView() {
   const [showTimers, setShowTimers] = useState(false)
   const [placingBadge, setPlacingBadge] = useState<Badge | null>(null)
   const [showShortcuts, setShowShortcuts] = useState(false)
+  const [showCommandPalette, setShowCommandPalette] = useState(false)
 
   const autoScanTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -89,6 +91,11 @@ export function BattlefieldView() {
   const handleToggleShortcuts = useCallback(() => {
     play('peep')
     setShowShortcuts(v => !v)
+  }, [play])
+
+  const handleToggleCommandPalette = useCallback(() => {
+    play('peep')
+    setShowCommandPalette(v => !v)
   }, [play])
 
   const keyboardShortcuts = useBattlefieldKeyboardShortcuts({
@@ -105,6 +112,7 @@ export function BattlefieldView() {
     onToggleTimers: () => { play('peep'); setShowTimers(v => !v) },
     onPan: handlePan,
     onToggleShortcutsOverlay: handleToggleShortcuts,
+    onToggleCommandPalette: handleToggleCommandPalette,
     enabled: !placementMode && !placingBadge,
   })
 
@@ -566,6 +574,23 @@ export function BattlefieldView() {
           onStartAssigning={keyboardShortcuts.startAssigning}
           onClearShortcut={keyboardShortcuts.clearShortcut}
           onCancelAssigning={keyboardShortcuts.cancelAssigning}
+        />
+      )}
+
+      {showCommandPalette && (
+        <CommandPalette
+          entries={visibleEntries}
+          buildings={storeBuildings}
+          positions={positions}
+          buildingPositions={buildingPositions}
+          onZoomToBase={handleZoomToBase}
+          onScan={() => { play('peep'); onRefresh() }}
+          onToggleFeed={() => { play('peep'); setShowFeedPanel(v => !v); setBranchSiloEntry(null); setDetailEntry(null); setSelectedBuildingId(null) }}
+          onToggleTimers={() => { play('peep'); setShowTimers(v => !v) }}
+          onZoomReset={() => handleZoomReset(positions)}
+          onCreateIssue={(entry) => setModalState({ mode: 'create-issue', fullName: entry.repo.fullName, owner: entry.repo.owner, repoName: entry.repo.name, provider: entry.repo.provider })}
+          onConstructBuilding={() => setShowBuildMenu(true)}
+          onClose={() => setShowCommandPalette(false)}
         />
       )}
 

--- a/gh-ctrl/client/src/components/Toast.tsx
+++ b/gh-ctrl/client/src/components/Toast.tsx
@@ -28,9 +28,13 @@ export function ToastArea({ toasts }: { toasts: Toast[] }) {
   if (toasts.length === 0) return null
 
   return (
-    <div className="toast-area">
+    <div className="toast-area" aria-live="polite" aria-atomic="false">
       {toasts.map((toast) => (
-        <div key={toast.id} className={`toast ${toast.type}`}>
+        <div
+          key={toast.id}
+          className={`toast ${toast.type}`}
+          role={toast.type === 'error' ? 'alert' : 'status'}
+        >
           {toast.message}
         </div>
       ))}

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
@@ -90,6 +90,7 @@ export function BattlefieldHUD({
           onClick={onScan}
           disabled={loading}
           title="Scan all bases"
+          aria-label={loading ? 'Scanning bases' : 'Scan all bases'}
         >
           {loading ? <span className="spinning-process">&#x2699;</span> : <ScanIcon size={11} />}
           <span className="hud-label"> {loading ? 'SCANNING' : 'SCAN'}</span>
@@ -98,6 +99,8 @@ export function BattlefieldHUD({
           className={`hud-btn${isRelocateMode ? ' active' : ''}`}
           onClick={onToggleRelocate}
           title={isRelocateMode ? 'Cancel relocate' : 'Relocate a base'}
+          aria-label={isRelocateMode ? 'Cancel relocate mode' : 'Relocate a base'}
+          aria-pressed={isRelocateMode}
         >
           {isRelocateMode ? <CloseIcon size={10} /> : <RelocateIcon size={11} />}
           <span className="hud-label"> {isRelocateMode ? 'CANCEL' : 'RELOCATE'}</span>
@@ -105,7 +108,8 @@ export function BattlefieldHUD({
         <button
           className="hud-btn"
           onClick={onShowBuildMenu}
-          title="Bau Optionen (ClawCom, etc.)"
+          title="Build options (ClawCom, etc.)"
+          aria-label="Open build options"
         >
           <BuildIcon size={11} /><span className="hud-label"> BUILD</span>
         </button>
@@ -113,6 +117,8 @@ export function BattlefieldHUD({
           className={`hud-btn${showBadgeLibrary ? ' active' : ''}`}
           onClick={onToggleBadgeLibrary}
           title="Badge Library — place custom markers on the battlefield"
+          aria-label="Open badge library"
+          aria-pressed={showBadgeLibrary}
         >
           ◈<span className="hud-label"> BADGES</span>
         </button>
@@ -138,6 +144,8 @@ export function BattlefieldHUD({
           className={`hud-btn${showFeedPanel ? ' active' : ''}`}
           onClick={onToggleFeed}
           title="Toggle Intel Feed"
+          aria-label="Toggle Intel Feed"
+          aria-pressed={showFeedPanel}
         >
           <FeedIcon size={11} /><span className="hud-label"> FEED</span>
         </button>
@@ -145,18 +153,22 @@ export function BattlefieldHUD({
           className={`hud-btn${showTimers ? ' active' : ''}`}
           onClick={onToggleTimers}
           title="Mission Timers — Deadline countdown for all maps"
+          aria-label="Toggle mission timers"
+          aria-pressed={showTimers}
         >
           ⏱<span className="hud-label"> TIMERS</span>
         </button>
         <span className="hud-zoom-sep" />
-        <button className="hud-btn hud-zoom-btn" onClick={onZoomOut} disabled={zoom <= ZOOM_MIN} title="Zoom out [−]">−</button>
-        <span className="hud-zoom-level" title="Click to reset zoom [0]" onClick={onZoomReset}>{Math.round(zoom * 100)}%</span>
-        <button className="hud-btn hud-zoom-btn" onClick={onZoomIn} disabled={zoom >= ZOOM_MAX} title="Zoom in [+]">+</button>
+        <button className="hud-btn hud-zoom-btn" onClick={onZoomOut} disabled={zoom <= ZOOM_MIN} title="Zoom out [−]" aria-label="Zoom out">−</button>
+        <span className="hud-zoom-level" title="Click to reset zoom [0]" onClick={onZoomReset} role="button" aria-label={`Current zoom ${Math.round(zoom * 100)}%, click to reset`}>{Math.round(zoom * 100)}%</span>
+        <button className="hud-btn hud-zoom-btn" onClick={onZoomIn} disabled={zoom >= ZOOM_MAX} title="Zoom in [+]" aria-label="Zoom in">+</button>
         <span className="hud-zoom-sep" />
         <button
           className={`hud-btn${showShortcuts ? ' active' : ''}`}
           onClick={onToggleShortcuts}
           title="Keyboard Shortcuts [?]"
+          aria-label="Toggle keyboard shortcuts overlay"
+          aria-pressed={showShortcuts}
         >
           ⌨<span className="hud-label"> KEYS</span>
         </button>

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldShortcutsOverlay.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldShortcutsOverlay.tsx
@@ -21,6 +21,7 @@ const BUILT_IN_SHORTCUTS = [
   { key: 'F', description: 'Toggle Intel Feed' },
   { key: 'T', description: 'Toggle Timers' },
   { key: '?', description: 'Toggle this overlay' },
+  { key: 'Ctrl+K', description: 'Open Command Palette' },
 ]
 
 function KeyBadge({ keyStr }: { keyStr: string }) {
@@ -40,15 +41,21 @@ export function BattlefieldShortcutsOverlay({
   onCancelAssigning,
 }: BattlefieldShortcutsOverlayProps) {
   return (
-    <div className="shortcuts-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose() }}>
+    <div
+      className="shortcuts-overlay"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard Shortcuts"
+    >
       <div className="shortcuts-panel">
         <div className="shortcuts-panel-header">
           <span className="shortcuts-panel-title">⌨ KEYBOARD SHORTCUTS</span>
-          <button className="shortcuts-panel-close" onClick={onClose} title="Close">✕</button>
+          <button className="shortcuts-panel-close" onClick={onClose} aria-label="Close shortcuts overlay">✕</button>
         </div>
 
         {assigningFor && (
-          <div className="shortcuts-assigning-banner">
+          <div className="shortcuts-assigning-banner" role="status" aria-live="polite">
             Press any key to assign — <kbd>Esc</kbd> to cancel
           </div>
         )}
@@ -94,7 +101,7 @@ export function BattlefieldShortcutsOverlay({
                         </td>
                         <td className="shortcuts-action-cell">
                           {isAssigning ? (
-                            <button className="shortcuts-btn shortcuts-btn-cancel" onClick={onCancelAssigning}>
+                            <button className="shortcuts-btn shortcuts-btn-cancel" onClick={onCancelAssigning} aria-label={`Cancel assigning shortcut for ${entry.repo.name}`}>
                               Cancel
                             </button>
                           ) : (
@@ -102,7 +109,7 @@ export function BattlefieldShortcutsOverlay({
                               <button
                                 className="shortcuts-btn"
                                 onClick={() => onStartAssigning('base', entry.repo.id)}
-                                title="Assign shortcut key"
+                                aria-label={`${assignedKey ? 'Change' : 'Assign'} shortcut for ${entry.repo.name}`}
                               >
                                 {assignedKey ? 'Change' : 'Assign'}
                               </button>
@@ -110,7 +117,7 @@ export function BattlefieldShortcutsOverlay({
                                 <button
                                   className="shortcuts-btn shortcuts-btn-clear"
                                   onClick={() => onClearShortcut('base', entry.repo.id)}
-                                  title="Remove shortcut"
+                                  aria-label={`Remove shortcut for ${entry.repo.name}`}
                                 >
                                   ✕
                                 </button>
@@ -150,7 +157,7 @@ export function BattlefieldShortcutsOverlay({
                         </td>
                         <td className="shortcuts-action-cell">
                           {isAssigning ? (
-                            <button className="shortcuts-btn shortcuts-btn-cancel" onClick={onCancelAssigning}>
+                            <button className="shortcuts-btn shortcuts-btn-cancel" onClick={onCancelAssigning} aria-label={`Cancel assigning shortcut for ${building.name}`}>
                               Cancel
                             </button>
                           ) : (
@@ -158,7 +165,7 @@ export function BattlefieldShortcutsOverlay({
                               <button
                                 className="shortcuts-btn"
                                 onClick={() => onStartAssigning('building', building.id)}
-                                title="Assign shortcut key"
+                                aria-label={`${assignedKey ? 'Change' : 'Assign'} shortcut for ${building.name}`}
                               >
                                 {assignedKey ? 'Change' : 'Assign'}
                               </button>
@@ -166,7 +173,7 @@ export function BattlefieldShortcutsOverlay({
                                 <button
                                   className="shortcuts-btn shortcuts-btn-clear"
                                   onClick={() => onClearShortcut('building', building.id)}
-                                  title="Remove shortcut"
+                                  aria-label={`Remove shortcut for ${building.name}`}
                                 >
                                   ✕
                                 </button>

--- a/gh-ctrl/client/src/components/battlefield/CommandPalette.tsx
+++ b/gh-ctrl/client/src/components/battlefield/CommandPalette.tsx
@@ -1,0 +1,286 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import type { DashboardEntry, Building } from '../../types'
+import type { Position } from './battlefieldConstants'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CommandCategory = 'BASE' | 'BUILDING' | 'ACTION' | 'NAV' | 'CREATE'
+
+export interface PaletteCommand {
+  id: string
+  category: CommandCategory
+  label: string
+  execute: () => void
+}
+
+interface CommandPaletteProps {
+  entries: DashboardEntry[]
+  buildings: Building[]
+  positions: Record<number, Position>
+  buildingPositions: Record<number, Position>
+  onZoomToBase: (pos: Position) => void
+  onScan: () => void
+  onToggleFeed: () => void
+  onToggleTimers: () => void
+  onZoomReset: () => void
+  onOpenSettings?: () => void
+  onOpenMapEditor?: () => void
+  onCreateIssue?: (entry: DashboardEntry) => void
+  onConstructBuilding?: () => void
+  onClose: () => void
+}
+
+// ---------------------------------------------------------------------------
+// localStorage persistence for recently-used commands
+// ---------------------------------------------------------------------------
+
+const RECENT_KEY = 'command-palette-recent'
+const MAX_RECENT = 5
+
+function loadRecent(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY)
+    if (raw) return JSON.parse(raw)
+  } catch {}
+  return []
+}
+
+function saveRecent(ids: string[]) {
+  localStorage.setItem(RECENT_KEY, JSON.stringify(ids.slice(0, MAX_RECENT)))
+}
+
+function addRecent(id: string) {
+  const current = loadRecent().filter(r => r !== id)
+  saveRecent([id, ...current])
+}
+
+// ---------------------------------------------------------------------------
+// Fuzzy match helper
+// ---------------------------------------------------------------------------
+
+function fuzzyMatch(query: string, text: string): boolean {
+  if (!query) return true
+  const q = query.toLowerCase()
+  const t = text.toLowerCase()
+  let qi = 0
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) qi++
+  }
+  return qi === q.length
+}
+
+// ---------------------------------------------------------------------------
+// Category badge
+// ---------------------------------------------------------------------------
+
+const CATEGORY_LABEL: Record<CommandCategory, string> = {
+  BASE: 'BASE',
+  BUILDING: 'BUILD',
+  ACTION: 'ACTION',
+  NAV: 'NAV',
+  CREATE: 'CREATE',
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function CommandPalette({
+  entries,
+  buildings,
+  positions,
+  buildingPositions,
+  onZoomToBase,
+  onScan,
+  onToggleFeed,
+  onToggleTimers,
+  onZoomReset,
+  onOpenSettings,
+  onOpenMapEditor,
+  onCreateIssue,
+  onConstructBuilding,
+  onClose,
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
+
+  // Build the full command list
+  const allCommands = useCallback((): PaletteCommand[] => {
+    const cmds: PaletteCommand[] = []
+
+    // BASE commands
+    for (const entry of entries) {
+      const pos = positions[entry.repo.id]
+      if (pos) {
+        cmds.push({
+          id: `base-${entry.repo.id}`,
+          category: 'BASE',
+          label: `Jump to ${entry.repo.name}`,
+          execute: () => onZoomToBase(pos),
+        })
+      }
+    }
+
+    // BUILDING commands
+    for (const building of buildings) {
+      const pos = buildingPositions[building.id] ?? { x: building.posX, y: building.posY }
+      cmds.push({
+        id: `building-${building.id}`,
+        category: 'BUILDING',
+        label: `Go to ${building.name}`,
+        execute: () => onZoomToBase(pos),
+      })
+    }
+
+    // ACTION commands
+    cmds.push(
+      { id: 'action-scan', category: 'ACTION', label: 'Scan / Refresh', execute: onScan },
+      { id: 'action-feed', category: 'ACTION', label: 'Toggle Intel Feed', execute: onToggleFeed },
+      { id: 'action-timers', category: 'ACTION', label: 'Toggle Timers', execute: onToggleTimers },
+      { id: 'action-reset', category: 'ACTION', label: 'Reset View', execute: onZoomReset },
+    )
+
+    // NAV commands
+    if (onOpenSettings) {
+      cmds.push({ id: 'nav-settings', category: 'NAV', label: 'Open Settings', execute: onOpenSettings })
+    }
+    if (onOpenMapEditor) {
+      cmds.push({ id: 'nav-map-editor', category: 'NAV', label: 'Open Map Editor', execute: onOpenMapEditor })
+    }
+
+    // CREATE commands
+    for (const entry of entries) {
+      if (onCreateIssue) {
+        cmds.push({
+          id: `create-issue-${entry.repo.id}`,
+          category: 'CREATE',
+          label: `Create issue in ${entry.repo.name}`,
+          execute: () => onCreateIssue(entry),
+        })
+      }
+    }
+    if (onConstructBuilding) {
+      cmds.push({ id: 'create-building', category: 'CREATE', label: 'Construct building', execute: onConstructBuilding })
+    }
+
+    return cmds
+  }, [entries, buildings, positions, buildingPositions, onZoomToBase, onScan, onToggleFeed, onToggleTimers, onZoomReset, onOpenSettings, onOpenMapEditor, onCreateIssue, onConstructBuilding])
+
+  // Sort: recent first, then by category order
+  const getFilteredCommands = useCallback((): PaletteCommand[] => {
+    const recent = loadRecent()
+    const cmds = allCommands()
+    const filtered = cmds.filter(c => fuzzyMatch(query, `${c.category} ${c.label}`))
+    filtered.sort((a, b) => {
+      const ai = recent.indexOf(a.id)
+      const bi = recent.indexOf(b.id)
+      if (ai !== -1 && bi !== -1) return ai - bi
+      if (ai !== -1) return -1
+      if (bi !== -1) return 1
+      return 0
+    })
+    return filtered
+  }, [allCommands, query])
+
+  const filtered = getFilteredCommands()
+
+  // Reset selection when query changes
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [query])
+
+  // Focus input on mount
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const item = listRef.current?.children[selectedIndex] as HTMLElement | undefined
+    item?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIndex])
+
+  const executeCommand = useCallback((cmd: PaletteCommand) => {
+    addRecent(cmd.id)
+    cmd.execute()
+    onClose()
+  }, [onClose])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setSelectedIndex(i => Math.min(i + 1, filtered.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setSelectedIndex(i => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      const cmd = filtered[selectedIndex]
+      if (cmd) executeCommand(cmd)
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      onClose()
+    }
+  }, [filtered, selectedIndex, executeCommand, onClose])
+
+  return (
+    <div
+      className="command-palette-overlay"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command Palette"
+    >
+      <div className="command-palette-panel">
+        <div className="command-palette-input-row">
+          <span className="command-palette-prompt">&gt;</span>
+          <input
+            ref={inputRef}
+            className="command-palette-input"
+            type="text"
+            placeholder="Type a command or search..."
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-label="Command search"
+            aria-autocomplete="list"
+            aria-controls="command-palette-list"
+            aria-activedescendant={filtered[selectedIndex] ? `cmd-item-${filtered[selectedIndex].id}` : undefined}
+          />
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="command-palette-empty" role="status">No commands found</div>
+        ) : (
+          <ul
+            ref={listRef}
+            id="command-palette-list"
+            className="command-palette-list"
+            role="listbox"
+          >
+            {filtered.map((cmd, index) => (
+              <li
+                key={cmd.id}
+                id={`cmd-item-${cmd.id}`}
+                className={`command-palette-item${index === selectedIndex ? ' selected' : ''}`}
+                role="option"
+                aria-selected={index === selectedIndex}
+                onClick={() => executeCommand(cmd)}
+                onMouseEnter={() => setSelectedIndex(index)}
+              >
+                <span className={`command-palette-category command-palette-category-${cmd.category.toLowerCase()}`}>
+                  [{CATEGORY_LABEL[cmd.category]}]
+                </span>
+                <span className="command-palette-label">{cmd.label}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/components/battlefield/CommandPalette.tsx
+++ b/gh-ctrl/client/src/components/battlefield/CommandPalette.tsx
@@ -201,7 +201,7 @@ export function CommandPalette({
   // Scroll selected item into view
   useEffect(() => {
     const item = listRef.current?.children[selectedIndex] as HTMLElement | undefined
-    item?.scrollIntoView({ block: 'nearest' })
+    item?.scrollIntoView?.({ block: 'nearest' })
   }, [selectedIndex])
 
   const executeCommand = useCallback((cmd: PaletteCommand) => {

--- a/gh-ctrl/client/src/hooks/useBattlefieldKeyboardShortcuts.ts
+++ b/gh-ctrl/client/src/hooks/useBattlefieldKeyboardShortcuts.ts
@@ -35,6 +35,7 @@ interface UseBattlefieldKeyboardShortcutsOptions {
   onToggleTimers: () => void
   onPan: (dx: number, dy: number) => void
   onToggleShortcutsOverlay: () => void
+  onToggleCommandPalette?: () => void
   enabled: boolean
 }
 
@@ -51,6 +52,7 @@ export function useBattlefieldKeyboardShortcuts({
   onToggleTimers,
   onPan,
   onToggleShortcutsOverlay,
+  onToggleCommandPalette,
   onZoomToBase,
   enabled,
 }: UseBattlefieldKeyboardShortcutsOptions) {
@@ -123,6 +125,13 @@ export function useBattlefieldKeyboardShortcuts({
         e.preventDefault()
         const key = e.key.toLowerCase()
         assignShortcut(assigningFor.type, assigningFor.id, key)
+        return
+      }
+
+      // Ctrl+K / Cmd+K — Command Palette
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault()
+        onToggleCommandPalette?.()
         return
       }
 
@@ -218,7 +227,7 @@ export function useBattlefieldKeyboardShortcuts({
   }, [
     enabled, assigningFor, shortcuts, entries, buildings, positions, buildingPositions,
     onZoomIn, onZoomOut, onZoomReset, onZoomToBase, onScan, onToggleFeed, onToggleTimers,
-    onPan, onToggleShortcutsOverlay, assignShortcut,
+    onPan, onToggleShortcutsOverlay, onToggleCommandPalette, assignShortcut,
   ])
 
   return { shortcuts, assigningFor, startAssigning, cancelAssigning, clearShortcut, assignShortcut }

--- a/gh-ctrl/client/src/hooks/useBattlefieldKeyboardShortcuts.ts
+++ b/gh-ctrl/client/src/hooks/useBattlefieldKeyboardShortcuts.ts
@@ -108,10 +108,10 @@ export function useBattlefieldKeyboardShortcuts({
 
     const onKeyDown = (e: KeyboardEvent) => {
       // Don't fire if typing in an input/textarea
-      const tag = (e.target as HTMLElement).tagName
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement).isContentEditable) return
+      const target = e.target as HTMLElement
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable || target.getAttribute?.('contenteditable') === 'true') return
       // Don't fire if a modal/dialog is open
-      if ((e.target as HTMLElement).closest('.modal-overlay, .map-dialog-overlay, [class*="dialog"], [class*="overlay"]')) return
+      if (target.closest?.('.modal-overlay, .map-dialog-overlay, [class*="dialog"], [class*="overlay"]')) return
 
       // Handle assignment mode
       if (assigningFor) {


### PR DESCRIPTION
Implements the APM enhancements from #307.

## Changes

**Command Palette (Ctrl+K)**
- New `CommandPalette.tsx` component with fuzzy search, categories (BASE/BUILDING/ACTION/NAV/CREATE)
- Full keyboard navigation (↑/↓/Enter/Escape) and recently-used persistence
- Ctrl+K / Cmd+K wired into `useBattlefieldKeyboardShortcuts`
- Ctrl+K listed in the shortcuts overlay NAVIGATION table

**Accessibility**
- Shortcuts overlay: `role="dialog"`, `aria-modal`, `aria-live` on assigning banner, descriptive `aria-label` on buttons
- Toast: `aria-live="polite"`, `role="alert"` for errors
- HUD: `aria-label` + `aria-pressed` on all toggle buttons

**Tests (72 new cases)**
- `useBattlefieldKeyboardShortcuts`, `useBattlefieldCamera`, `useBattlefieldPositions`
- `BattlefieldShortcutsOverlay`, `CommandPalette`

Closes #307

Generated with [Claude Code](https://claude.ai/code)