### PR TITLE
feat: RemotePost — complete all 4 phases (#308)

### DIFF
--- a/gh-ctrl/client/package.json
+++ b/gh-ctrl/client/package.json
@@ -11,6 +11,10 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-search": "^0.15.0",
+    "@xterm/addon-web-links": "^0.11.0",
+    "@xterm/xterm": "^5.5.0",
     "keycloak-js": "^26.1.4",
     "lucide-react": "^0.475.0",
     "react": "^18.3.0",

--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData, SetupStatus, Building, ClawComMessage, Badge, PlacedBadge, HealthcheckResult, DeadlineTimer, ChannelEvent, MailMessage } from './types'
+import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData, SetupStatus, Building, ClawComMessage, Badge, PlacedBadge, HealthcheckResult, DeadlineTimer, ChannelEvent, MailMessage, SshConnection, SshSessionLog } from './types'
 
 export function getServerUrl(): string {
   return localStorage.getItem('serverUrl')?.replace(/\/$/, '') ?? ''
@@ -37,6 +37,20 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     throw new Error(err.error || res.statusText)
   }
   return res.json()
+}
+
+export function getShellWsUrl(buildingId: number, connectionId: number): string {
+  const serverUrl = getServerUrl()
+  const token = _getToken?.()
+  const qs = token
+    ? `?connectionId=${connectionId}&token=${encodeURIComponent(token)}`
+    : `?connectionId=${connectionId}`
+  if (serverUrl) {
+    const wsBase = serverUrl.replace(/^http/, 'ws')
+    return `${wsBase}/api/buildings/${buildingId}/shell/ws${qs}`
+  }
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${window.location.host}/api/buildings/${buildingId}/shell/ws${qs}`
 }
 
 export const api = {
@@ -537,4 +551,65 @@ export const api = {
 
   validateGitLabProject: (ns: string, project: string) =>
     request<{ ok: boolean; projectId: number; name: string }>(`/gitlab/validate/${ns}/${project}`),
+
+  // ── RemotePost / SSH shell API ──────────────────────────────────────────────
+
+  listShellConnections: (buildingId: number) =>
+    request<SshConnection[]>(`/buildings/${buildingId}/shell/connections`),
+
+  createShellConnection: (buildingId: number, params: {
+    label: string
+    host: string
+    port?: number
+    username: string
+    authType?: 'password' | 'key'
+    password?: string
+    privateKey?: string
+    tmuxSession?: string
+  }) =>
+    request<SshConnection>(`/buildings/${buildingId}/shell/connections`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
+
+  updateShellConnection: (buildingId: number, connectionId: number, params: Partial<{
+    label: string
+    host: string
+    port: number
+    username: string
+    authType: 'password' | 'key'
+    password: string
+    privateKey: string
+    tmuxSession: string
+  }>) =>
+    request<SshConnection>(`/buildings/${buildingId}/shell/connections/${connectionId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(params),
+    }),
+
+  deleteShellConnection: (buildingId: number, connectionId: number) =>
+    request<{ ok: boolean }>(`/buildings/${buildingId}/shell/connections/${connectionId}`, {
+      method: 'DELETE',
+    }),
+
+  testShellConnection: (buildingId: number, params: {
+    host: string
+    port?: number
+    username: string
+    authType?: 'password' | 'key'
+    password?: string
+    privateKey?: string
+  }) =>
+    request<{ ok: boolean; error?: string }>(`/buildings/${buildingId}/shell/connections/test`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
+
+  getShellHistory: (buildingId: number) =>
+    request<SshSessionLog[]>(`/buildings/${buildingId}/shell/history`),
+
+  getShellTmuxSessions: (buildingId: number, connectionId: number) =>
+    request<{ ok: boolean; sessions: string[]; error?: string }>(
+      `/buildings/${buildingId}/shell/connections/${connectionId}/tmux-sessions`
+    ),
 }

--- a/gh-ctrl/client/src/components/BuildOptionsMenu.tsx
+++ b/gh-ctrl/client/src/components/BuildOptionsMenu.tsx
@@ -36,6 +36,14 @@ const AVAILABLE_BUILDINGS: BuildingDef[] = [
     defaultColor: '#4488ff',
   },
   {
+    type: 'remoteShell',
+    name: 'RemotePost',
+    description:
+      'Remote terminal outpost — SSH into your servers directly from the battlefield. Stores encrypted connection profiles, supports tmux session persistence, and opens a full-screen xterm.js terminal.',
+    buildImage: '/buildings/healthcheck.png',
+    defaultColor: '#00aaff',
+  },
+  {
     type: 'new-base',
     name: 'Repository',
     description:

--- a/gh-ctrl/client/src/components/RemoteShellBuilding.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellBuilding.tsx
@@ -1,0 +1,302 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { api } from '../api'
+import { useAppStore } from '../store'
+import type { Building, RemoteShellConfig } from '../types'
+import { RemoteShellSetupDialog } from './RemoteShellSetupDialog'
+import { RemoteShellTerminalDialog } from './RemoteShellTerminalDialog'
+
+interface Position {
+  x: number
+  y: number
+}
+
+interface RemoteShellBuildingProps {
+  building: Building
+  position: Position
+  isRelocateMode: boolean
+  isBeingRelocated: boolean
+  onStartRelocate: (mouseX: number, mouseY: number) => void
+  addToast: (msg: string, type?: 'success' | 'error' | 'info') => void
+  isSelected?: boolean
+  onSelect?: () => void
+  onDeselect?: () => void
+}
+
+// Chroma-key: replace green pixels with the building's color
+function useColorizedImage(src: string, color: string): string | null {
+  const [dataUrl, setDataUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    img.onload = () => {
+      const canvas = document.createElement('canvas')
+      canvas.width = img.width
+      canvas.height = img.height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      ctx.drawImage(img, 0, 0)
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+      const data = imageData.data
+      const hex = color.replace('#', '')
+      const tr = parseInt(hex.slice(0, 2), 16)
+      const tg = parseInt(hex.slice(2, 4), 16)
+      const tb = parseInt(hex.slice(4, 6), 16)
+      for (let i = 0; i < data.length; i += 4) {
+        const r = data[i], g = data[i + 1], b = data[i + 2]
+        if (g > r * 1.3 && g > b * 1.3 && g > 80) {
+          const ratio = g / 255
+          data[i]     = Math.round(tr * ratio)
+          data[i + 1] = Math.round(tg * ratio)
+          data[i + 2] = Math.round(tb * ratio)
+        }
+      }
+      ctx.putImageData(imageData, 0, 0)
+      setDataUrl(canvas.toDataURL())
+    }
+    img.onerror = () => setDataUrl(null)
+    img.src = src
+  }, [src, color])
+
+  return dataUrl
+}
+
+export function RemoteShellBuilding({
+  building,
+  position,
+  isRelocateMode,
+  isBeingRelocated,
+  onStartRelocate,
+  addToast,
+  isSelected = false,
+  onSelect,
+  onDeselect,
+}: RemoteShellBuildingProps) {
+  const deleteBuilding      = useAppStore((s) => s.deleteBuilding)
+  const updateBuildingColor = useAppStore((s) => s.updateBuildingColor)
+
+  const [currentBuilding, setCurrentBuilding] = useState(building)
+  const [showSetup, setShowSetup]             = useState(false)
+  const [showTerminal, setShowTerminal]       = useState(false)
+  const [connectionCount, setConnectionCount] = useState(0)
+  const colorInputRef = useRef<HTMLInputElement>(null)
+
+  const colorizedSrc = useColorizedImage('/buildings/healthcheck.png', currentBuilding.color ?? '#00aaff')
+
+  useEffect(() => { setCurrentBuilding(building) }, [building])
+
+  const config: Partial<RemoteShellConfig> = (() => {
+    try { return JSON.parse(currentBuilding.config) } catch { return {} }
+  })()
+  const isConfigured = config.configured === true
+
+  const fetchConnectionCount = useCallback(async () => {
+    try {
+      const conns = await api.listShellConnections(currentBuilding.id)
+      setConnectionCount(conns.length)
+    } catch { /* ignore */ }
+  }, [currentBuilding.id])
+
+  useEffect(() => {
+    fetchConnectionCount()
+  }, [fetchConnectionCount])
+
+  // Sync selection state with dialog visibility
+  useEffect(() => {
+    if (isSelected) {
+      if (!isConfigured) {
+        setShowSetup(true)
+        setShowTerminal(false)
+      } else {
+        setShowTerminal(true)
+        setShowSetup(false)
+      }
+    } else {
+      setShowSetup(false)
+      setShowTerminal(false)
+    }
+  }, [isSelected, isConfigured])
+
+  function handleClick() {
+    if (isRelocateMode) return
+    onSelect?.()
+  }
+
+  function handleMouseDown(e: React.MouseEvent) {
+    if (isRelocateMode) {
+      e.stopPropagation()
+      onStartRelocate(e.clientX, e.clientY)
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm(`Delete "${currentBuilding.name}"?`)) return
+    try {
+      await deleteBuilding(currentBuilding.id)
+    } catch { /* toast shown by store */ }
+  }
+
+  async function handleColorChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const newColor = e.target.value
+    setCurrentBuilding((b) => ({ ...b, color: newColor }))
+    await updateBuildingColor(currentBuilding.id, newColor)
+  }
+
+  const buildingColor = currentBuilding.color ?? '#00aaff'
+
+  return (
+    <>
+      <div
+        className={`base-node clawcom-building${isSelected ? ' clawcom-selected' : ''}`}
+        style={{
+          position: 'absolute',
+          left: position.x,
+          top: position.y,
+          transform: 'translate(-50%, -50%)',
+          cursor: isRelocateMode ? 'grab' : 'pointer',
+          userSelect: 'none',
+          width: 140,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 4,
+          zIndex: isBeingRelocated ? 100 : 1,
+          opacity: isBeingRelocated ? 0.75 : 1,
+        }}
+        onMouseDown={handleMouseDown}
+        onClick={handleClick}
+      >
+        {/* Building image */}
+        <div className="clawcom-img-wrap" style={{ position: 'relative' }}>
+          {colorizedSrc ? (
+            <img
+              src={colorizedSrc}
+              alt={currentBuilding.name}
+              style={{
+                width: 100, height: 100, objectFit: 'contain',
+                imageRendering: 'auto',
+                filter: isBeingRelocated ? 'brightness(1.5)' : undefined,
+              }}
+              draggable={false}
+            />
+          ) : (
+            <div style={{
+              width: 100, height: 100,
+              background: 'var(--bg-panel)',
+              borderRadius: 4,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 36,
+              border: `2px solid ${buildingColor}44`,
+              filter: isBeingRelocated ? 'brightness(1.5)' : undefined,
+            }}>
+              &#x1F5A5;
+            </div>
+          )}
+
+          {/* Connection count badge */}
+          {connectionCount > 0 && (
+            <div style={{
+              position: 'absolute', top: -4, right: -4,
+              background: buildingColor, color: '#000',
+              borderRadius: '50%', width: 20, height: 20,
+              fontSize: 10, fontWeight: 700,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              border: '2px solid var(--bg-darker)',
+            }}>
+              {connectionCount > 9 ? '9+' : connectionCount}
+            </div>
+          )}
+
+          {/* Status dot */}
+          <div style={{
+            position: 'absolute', bottom: 2, right: 2,
+            width: 8, height: 8, borderRadius: '50%',
+            background: isConfigured ? 'var(--green-neon)' : '#888',
+            border: '1px solid var(--bg-darker)',
+          }} title={isConfigured ? 'Ready' : 'Not configured'} />
+        </div>
+
+        {/* Name label */}
+        <div style={{
+          fontSize: 11, fontWeight: 700,
+          color: buildingColor,
+          textAlign: 'center',
+          textShadow: `0 0 8px ${buildingColor}44`,
+          maxWidth: 130, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>
+          {currentBuilding.name}
+        </div>
+
+        {/* Status text */}
+        <div style={{ fontSize: 9, color: 'var(--text-dim)', textAlign: 'center' }}>
+          {isConfigured
+            ? `▣ ${connectionCount} CONN${connectionCount !== 1 ? 'S' : ''} ● READY`
+            : '⚙ SETUP REQUIRED'}
+        </div>
+
+        {/* Action bar */}
+        {!isRelocateMode && (
+          <div
+            className="clawcom-actions"
+            style={{ display: 'flex', gap: 4, marginTop: 2 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className="hud-btn"
+              style={{ fontSize: 9, padding: '1px 5px' }}
+              onClick={() => colorInputRef.current?.click()}
+              title="Change color"
+            >◈</button>
+            <input
+              ref={colorInputRef}
+              type="color"
+              value={buildingColor}
+              onChange={handleColorChange}
+              style={{ width: 0, height: 0, opacity: 0, position: 'absolute', pointerEvents: 'none' }}
+            />
+            <button
+              className="hud-btn"
+              style={{ fontSize: 9, padding: '1px 5px', color: '#ff6b6b' }}
+              onClick={handleDelete}
+              title="Demolish building"
+            >✕</button>
+          </div>
+        )}
+      </div>
+
+      {showSetup && createPortal(
+        <RemoteShellSetupDialog
+          building={currentBuilding}
+          onClose={() => onDeselect?.()}
+          onConfigured={(updated) => {
+            setCurrentBuilding(updated)
+            fetchConnectionCount()
+            addToast(`${updated.name} configured!`, 'success')
+          }}
+          onOpenTerminal={() => {
+            setShowSetup(false)
+            setShowTerminal(true)
+          }}
+          onError={(msg) => addToast(msg, 'error')}
+        />,
+        document.body
+      )}
+
+      {showTerminal && createPortal(
+        <RemoteShellTerminalDialog
+          building={currentBuilding}
+          onClose={() => onDeselect?.()}
+          onReconfigure={() => {
+            setShowTerminal(false)
+            setShowSetup(true)
+          }}
+          addToast={addToast}
+        />,
+        document.body
+      )}
+    </>
+  )
+}

--- a/gh-ctrl/client/src/components/RemoteShellSetupDialog.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellSetupDialog.tsx
@@ -1,0 +1,526 @@
+import { useState, useEffect } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
+import { api } from '../api'
+import { useAppStore } from '../store'
+import type { Building, SshConnection, SshSessionLog, RemoteShellConfig } from '../types'
+
+interface RemoteShellSetupDialogProps {
+  building: Building
+  onClose: () => void
+  onConfigured: (updated: Building) => void
+  onOpenTerminal?: () => void
+  onError: (msg: string) => void
+}
+
+type AuthType = 'password' | 'key'
+
+function formatDuration(ms: number | null) {
+  if (!ms) return '—'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ${s % 60}s`
+  return `${Math.floor(m / 60)}h ${m % 60}m`
+}
+
+function formatRelativeTime(ts: string | number | null) {
+  if (!ts) return '—'
+  const ms = typeof ts === 'string' ? new Date(ts).getTime() : Number(ts) * 1000
+  const diff = Date.now() - ms
+  const s = Math.floor(diff / 1000)
+  if (s < 60) return 'just now'
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  return `${Math.floor(h / 24)}d ago`
+}
+
+export function RemoteShellSetupDialog({ building, onClose, onConfigured, onOpenTerminal, onError }: RemoteShellSetupDialogProps) {
+  const loadBuildings = useAppStore((s) => s.loadBuildings)
+
+  const existingConfig: Partial<RemoteShellConfig> = (() => {
+    try { return JSON.parse(building.config) } catch { return {} }
+  })()
+
+  // Connection list state
+  const [connections, setConnections]       = useState<SshConnection[]>([])
+  const [history, setHistory]               = useState<SshSessionLog[]>([])
+  const [loadingConns, setLoadingConns]     = useState(true)
+  const [showHistory, setShowHistory]       = useState(false)
+
+  // Edit form state
+  const [editingId, setEditingId]           = useState<number | null>(null) // null = new
+  const [showForm, setShowForm]             = useState(false)
+  const [label, setLabel]                   = useState('')
+  const [host, setHost]                     = useState('')
+  const [port, setPort]                     = useState('22')
+  const [username, setUsername]             = useState('')
+  const [authType, setAuthType]             = useState<AuthType>('password')
+  const [password, setPassword]             = useState('')
+  const [privateKey, setPrivateKey]         = useState('')
+  const [tmuxSession, setTmuxSession]       = useState('')
+  const [showSecret, setShowSecret]         = useState(false)
+
+  // Config state
+  const [fontSize, setFontSize]             = useState(String(existingConfig.fontSize ?? 14))
+  const [fontFamily, setFontFamily]         = useState(existingConfig.fontFamily ?? 'monospace')
+  const [theme, setTheme]                   = useState<RemoteShellConfig['theme']>(existingConfig.theme ?? 'dark')
+
+  // Test state
+  const [testState, setTestState]           = useState<'idle' | 'testing' | 'ok' | 'error'>('idle')
+  const [testError, setTestError]           = useState('')
+  const [saving, setSaving]                 = useState(false)
+  const [deleting, setDeleting]             = useState<number | null>(null)
+
+  useEffect(() => {
+    loadConnections()
+    api.getShellHistory(building.id)
+      .then(setHistory)
+      .catch(() => { /* non-fatal */ })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [building.id])
+
+  async function loadConnections() {
+    setLoadingConns(true)
+    try {
+      const conns = await api.listShellConnections(building.id)
+      setConnections(conns)
+    } catch (err: any) {
+      onError(err.message)
+    } finally {
+      setLoadingConns(false)
+    }
+  }
+
+  function openNewForm() {
+    setEditingId(null)
+    setLabel('')
+    setHost('')
+    setPort('22')
+    setUsername('')
+    setAuthType('password')
+    setPassword('')
+    setPrivateKey('')
+    setTmuxSession('')
+    setShowSecret(false)
+    setTestState('idle')
+    setTestError('')
+    setShowForm(true)
+  }
+
+  function openEditForm(conn: SshConnection) {
+    setEditingId(conn.id)
+    setLabel(conn.label)
+    setHost(conn.host)
+    setPort(String(conn.port ?? 22))
+    setUsername(conn.username)
+    setAuthType((conn.authType as AuthType) ?? 'password')
+    setPassword('')
+    setPrivateKey('')
+    setTmuxSession(conn.tmuxSession ?? '')
+    setShowSecret(false)
+    setTestState('idle')
+    setTestError('')
+    setShowForm(true)
+  }
+
+  async function handleTestConnection() {
+    if (testState === 'testing') return
+    setTestState('testing')
+    setTestError('')
+    try {
+      const res = await api.testShellConnection(building.id, {
+        host: host.trim(),
+        port: Number(port) || 22,
+        username: username.trim(),
+        authType,
+        password: authType === 'password' ? password : undefined,
+        privateKey: authType === 'key' ? privateKey : undefined,
+      })
+      setTestState(res.ok ? 'ok' : 'error')
+      if (!res.ok) setTestError(res.error ?? 'Connection failed')
+    } catch (err: any) {
+      setTestState('error')
+      setTestError(err.message)
+    }
+  }
+
+  async function handleSaveConnection() {
+    if (saving || !label.trim() || !host.trim() || !username.trim()) return
+    setSaving(true)
+    try {
+      if (editingId !== null) {
+        await api.updateShellConnection(building.id, editingId, {
+          label: label.trim(),
+          host: host.trim(),
+          port: Number(port) || 22,
+          username: username.trim(),
+          authType,
+          ...(password ? { password } : {}),
+          ...(privateKey ? { privateKey } : {}),
+          tmuxSession: tmuxSession.trim() || undefined,
+        })
+      } else {
+        await api.createShellConnection(building.id, {
+          label: label.trim(),
+          host: host.trim(),
+          port: Number(port) || 22,
+          username: username.trim(),
+          authType,
+          ...(password ? { password } : {}),
+          ...(privateKey ? { privateKey } : {}),
+          tmuxSession: tmuxSession.trim() || undefined,
+        })
+      }
+      await loadConnections()
+      await loadBuildings()
+      // Get the updated building to notify parent
+      const allBuildings = await api.listBuildings()
+      const updated = allBuildings.find((b: Building) => b.id === building.id)
+      if (updated) onConfigured(updated)
+      setShowForm(false)
+    } catch (err: any) {
+      onError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDeleteConnection(id: number) {
+    if (!confirm('Delete this connection profile?')) return
+    setDeleting(id)
+    try {
+      await api.deleteShellConnection(building.id, id)
+      await loadConnections()
+      await loadBuildings()
+    } catch (err: any) {
+      onError(err.message)
+    } finally {
+      setDeleting(null)
+    }
+  }
+
+  async function handleSaveConfig() {
+    try {
+      const existing: Record<string, unknown> = (() => {
+        try { return JSON.parse(building.config) } catch { return {} }
+      })()
+      const newConfig: RemoteShellConfig = {
+        ...existing,
+        configured: connections.length > 0,
+        fontSize: Number(fontSize) || 14,
+        fontFamily: fontFamily.trim() || 'monospace',
+        theme,
+      }
+      await api.updateBuilding(building.id, { config: newConfig })
+      await loadBuildings()
+    } catch (err: any) {
+      onError(err.message)
+    }
+  }
+
+  const canSave = label.trim() && host.trim() && username.trim()
+  const canTest = host.trim() && username.trim()
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 1100,
+        background: 'rgba(0,0,0,0.85)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div style={{
+        background: 'var(--bg-panel)',
+        border: '1px solid var(--border-dim)',
+        borderRadius: 6, width: 540, maxHeight: '85vh',
+        display: 'flex', flexDirection: 'column',
+        overflow: 'hidden',
+        fontFamily: 'monospace',
+      }}>
+        {/* Header */}
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8,
+          padding: '10px 14px', borderBottom: '1px solid var(--border-dim)',
+        }}>
+          <span style={{ color: '#00ff88', fontWeight: 700 }}>▣ REMOTEPOST</span>
+          <span style={{ color: 'var(--text-dim)', fontSize: 11 }}>// {building.name}</span>
+          <div style={{ flex: 1 }} />
+          <button className="hud-btn" style={{ fontSize: 10, color: '#ff6b6b' }} onClick={onClose}>✕</button>
+        </div>
+
+        <div style={{ flex: 1, overflow: 'auto', padding: 14 }}>
+
+          {/* Connection profiles */}
+          <div style={{ marginBottom: 16 }}>
+            <div style={{
+              display: 'flex', alignItems: 'center',
+              marginBottom: 8, color: 'var(--text-dim)', fontSize: 10, fontWeight: 700,
+            }}>
+              <span>▶ CONNECTION PROFILES</span>
+              <button
+                className="hud-btn"
+                style={{ marginLeft: 'auto', fontSize: 9 }}
+                onClick={openNewForm}
+              >+ ADD</button>
+            </div>
+
+            {loadingConns && <div style={{ color: '#555', fontSize: 11 }}>Loading...</div>}
+
+            {!loadingConns && connections.length === 0 && (
+              <div style={{ color: '#555', fontSize: 11, textAlign: 'center', padding: '12px 0' }}>
+                No connection profiles yet. Add one to get started.
+              </div>
+            )}
+
+            {connections.map((conn) => (
+              <div
+                key={conn.id}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 8,
+                  padding: '6px 10px', marginBottom: 4,
+                  background: 'var(--bg-darker)', borderRadius: 4,
+                  border: '1px solid var(--border-dim)',
+                }}
+              >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ color: '#00ff88', fontSize: 12, fontWeight: 700 }}>{conn.label}</div>
+                  <div style={{ color: 'var(--text-dim)', fontSize: 10 }}>
+                    {conn.username}@{conn.host}:{conn.port ?? 22}
+                    {conn.authType && <> · {conn.authType}</>}
+                    {conn.tmuxSession && <> · tmux:{conn.tmuxSession}</>}
+                    {!conn.hasCredentials && <span style={{ color: '#ff4444' }}> · no creds</span>}
+                  </div>
+                </div>
+                <button
+                  className="hud-btn"
+                  style={{ fontSize: 9 }}
+                  onClick={() => openEditForm(conn)}
+                >✎ EDIT</button>
+                <button
+                  className="hud-btn"
+                  style={{ fontSize: 9, color: '#ff6b6b' }}
+                  disabled={deleting === conn.id}
+                  onClick={() => handleDeleteConnection(conn.id)}
+                >✕</button>
+              </div>
+            ))}
+          </div>
+
+          {/* Add / Edit form */}
+          {showForm && (
+            <div style={{
+              padding: 12, marginBottom: 16,
+              background: 'var(--bg-darker)', borderRadius: 4,
+              border: '1px solid #00ff8844',
+            }}>
+              <div style={{ color: '#00ff88', fontSize: 10, fontWeight: 700, marginBottom: 8 }}>
+                {editingId !== null ? '✎ EDIT CONNECTION' : '+ NEW CONNECTION'}
+              </div>
+
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 8 }}>
+                <div>
+                  <label style={{ color: 'var(--text-dim)', fontSize: 9, display: 'block', marginBottom: 3 }}>LABEL *</label>
+                  <input className="hud-input" value={label} onChange={(e) => setLabel(e.target.value)} placeholder="prod-server" style={{ width: '100%', boxSizing: 'border-box' }} />
+                </div>
+                <div>
+                  <label style={{ color: 'var(--text-dim)', fontSize: 9, display: 'block', marginBottom: 3 }}>TMUX SESSION</label>
+                  <input className="hud-input" value={tmuxSession} onChange={(e) => setTmuxSession(e.target.value)} placeholder="main (optional)" style={{ width: '100%', boxSizing: 'border-box' }} />
+                </div>
+              </div>
+
+              <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 8, marginBottom: 8 }}>
+                <div>
+                  <label style={{ color: 'var(--text-dim)', fontSize: 9, display: 'block', marginBottom: 3 }}>HOST *</label>
+                  <input className="hud-input" value={host} onChange={(e) => setHost(e.target.value)} placeholder="192.168.1.1" style={{ width: '100%', boxSizing: 'border-box' }} />
+                </div>
+                <div>
+                  <label style={{ color: 'var(--text-dim)', fontSize: 9, display: 'block', marginBottom: 3 }}>PORT</label>
+                  <input className="hud-input" value={port} onChange={(e) => setPort(e.target.value)} placeholder="22" type="number" style={{ width: '100%', boxSizing: 'border-box' }} />
+                </div>
+              </div>
+
+              <div style={{ marginBottom: 8 }}>
+                <label style={{ color: 'var(--text-dim)', fontSize: 9, display: 'block', marginBottom: 3 }}>USERNAME *</label>
+                <input className="hud-input" value={username} onChange={(e) => setUsername(e.target.value)} placeholder="admin" style={{ width: '100%', boxSizing: 'border-box' }} autoComplete="off" />
+              </div>
+
+              <div style={{ display: 'flex', gap: 6, marginBottom: 8 }}>
+                <button
+                  className={`hud-btn${authType === 'password' ? ' active' : ''}`}
+                  style={{ fontSize: 10 }}
+                  onClick={() => setAuthType('password')}
+                >PASSWORD</button>
+                <button
+                  className={`hud-btn${authType === 'key' ? ' active' : ''}`}
+                  style={{ fontSize: 10 }}
+                  onClick={() => setAuthType('key')}
+                >SSH KEY</button>
+              </div>
+
+              {authType === 'password' && (
+                <div style={{ marginBottom: 8, position: 'relative' }}>
+                  <label style={{ color: 'var(--text-dim)', fontSize: 9, display: 'block', marginBottom: 3 }}>
+                    PASSWORD {editingId !== null && '(leave blank to keep existing)'}
+                  </label>
+                  <div style={{ position: 'relative' }}>
+                    <input
+                      className="hud-input"
+                      type={showSecret ? 'text' : 'password'}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      placeholder={editingId !== null ? '••••••••' : 'Enter password'}
+                      style={{ width: '100%', boxSizing: 'border-box', paddingRight: 28 }}
+                      autoComplete="new-password"
+                    />
+                    <button
+                      style={{ position: 'absolute', right: 6, top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-dim)', padding: 0 }}
+                      onClick={() => setShowSecret((v) => !v)}
+                    >{showSecret ? <EyeOff size={12} /> : <Eye size={12} />}</button>
+                  </div>
+                </div>
+              )}
+
+              {authType === 'key' && (
+                <div style={{ marginBottom: 8 }}>
+                  <label style={{ color: 'var(--text-dim)', fontSize: 9, display: 'block', marginBottom: 3 }}>
+                    PRIVATE KEY {editingId !== null && '(leave blank to keep existing)'}
+                  </label>
+                  <textarea
+                    className="hud-input"
+                    value={privateKey}
+                    onChange={(e) => setPrivateKey(e.target.value)}
+                    placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
+                    rows={5}
+                    style={{ width: '100%', boxSizing: 'border-box', resize: 'vertical', fontSize: 10 }}
+                  />
+                </div>
+              )}
+
+              {/* Test result */}
+              {testState !== 'idle' && (
+                <div style={{
+                  padding: '4px 8px', borderRadius: 3, marginBottom: 8, fontSize: 10,
+                  background: testState === 'ok' ? '#00ff8822' : testState === 'error' ? '#ff444422' : '#ffaa0022',
+                  color: testState === 'ok' ? '#00ff88' : testState === 'error' ? '#ff4444' : '#ffaa00',
+                  border: `1px solid ${testState === 'ok' ? '#00ff8844' : testState === 'error' ? '#ff444444' : '#ffaa0044'}`,
+                }}>
+                  {testState === 'testing' && '⌛ Testing connection...'}
+                  {testState === 'ok' && '✓ Connection successful'}
+                  {testState === 'error' && `✗ ${testError}`}
+                </div>
+              )}
+
+              <div style={{ display: 'flex', gap: 6 }}>
+                <button
+                  className="hud-btn"
+                  style={{ fontSize: 10 }}
+                  disabled={!canTest || testState === 'testing'}
+                  onClick={handleTestConnection}
+                >
+                  {testState === 'testing' ? 'TESTING...' : '⚡ TEST'}
+                </button>
+                <div style={{ flex: 1 }} />
+                <button
+                  className="hud-btn"
+                  style={{ fontSize: 10 }}
+                  onClick={() => setShowForm(false)}
+                >CANCEL</button>
+                <button
+                  className="hud-btn hud-btn-new-base"
+                  style={{ fontSize: 10 }}
+                  disabled={!canSave || saving}
+                  onClick={handleSaveConnection}
+                >
+                  {saving ? 'SAVING...' : '✓ SAVE'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Terminal appearance */}
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ color: 'var(--text-dim)', fontSize: 10, fontWeight: 700, marginBottom: 8 }}>
+              ▶ TERMINAL APPEARANCE
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
+              <div>
+                <label style={{ color: 'var(--text-dim)', fontSize: 9, display: 'block', marginBottom: 3 }}>THEME</label>
+                <select
+                  className="hud-input"
+                  value={theme}
+                  onChange={(e) => setTheme(e.target.value as RemoteShellConfig['theme'])}
+                  style={{ width: '100%', boxSizing: 'border-box' }}
+                >
+                  <option value="dark">Dark (default)</option>
+                  <option value="dracula">Dracula</option>
+                  <option value="solarized">Solarized</option>
+                </select>
+              </div>
+              <div>
+                <label style={{ color: 'var(--text-dim)', fontSize: 9, display: 'block', marginBottom: 3 }}>FONT SIZE</label>
+                <input className="hud-input" type="number" value={fontSize} onChange={(e) => setFontSize(e.target.value)} min={8} max={32} style={{ width: '100%', boxSizing: 'border-box' }} />
+              </div>
+              <div>
+                <label style={{ color: 'var(--text-dim)', fontSize: 9, display: 'block', marginBottom: 3 }}>FONT FAMILY</label>
+                <input className="hud-input" value={fontFamily} onChange={(e) => setFontFamily(e.target.value)} placeholder="monospace" style={{ width: '100%', boxSizing: 'border-box' }} />
+              </div>
+            </div>
+            <div style={{ marginTop: 8, textAlign: 'right' }}>
+              <button className="hud-btn" style={{ fontSize: 10 }} onClick={handleSaveConfig}>SAVE APPEARANCE</button>
+            </div>
+          </div>
+
+          {/* History */}
+          {history.length > 0 && (
+            <div>
+              <button
+                className="hud-btn"
+                style={{ fontSize: 10, marginBottom: 8 }}
+                onClick={() => setShowHistory((v) => !v)}
+              >
+                {showHistory ? '▼' : '▶'} HISTORY ({history.length})
+              </button>
+              {showHistory && (
+                <div>
+                  {history.map((h) => (
+                    <div
+                      key={h.id}
+                      style={{
+                        display: 'flex', gap: 8, alignItems: 'center',
+                        padding: '4px 8px', marginBottom: 2,
+                        background: 'var(--bg-darker)', borderRadius: 3, fontSize: 10,
+                      }}
+                    >
+                      <span style={{ color: '#00ff88', minWidth: 100 }}>{h.connectionLabel ?? '—'}</span>
+                      <span style={{ color: 'var(--text-dim)' }}>{formatRelativeTime(h.connectedAt)}</span>
+                      <span style={{ color: 'var(--text-dim)' }}>·</span>
+                      <span style={{ color: 'var(--text-dim)' }}>{formatDuration(h.durationMs)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          padding: '8px 14px', borderTop: '1px solid var(--border-dim)',
+          display: 'flex', justifyContent: 'flex-end', gap: 8,
+        }}>
+          <button className="hud-btn" style={{ fontSize: 10 }} onClick={onClose}>
+            CLOSE
+          </button>
+          {connections.length > 0 && onOpenTerminal && (
+            <button className="hud-btn hud-btn-new-base" style={{ fontSize: 10 }} onClick={onOpenTerminal}>
+              ▣ OPEN TERMINAL
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/components/RemoteShellTerminalDialog.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellTerminalDialog.tsx
@@ -1,0 +1,205 @@
+import { useState, useEffect } from 'react'
+import { api } from '../api'
+import type { Building, SshConnection, RemoteShellConfig } from '../types'
+import { RemoteShellTerminalTab } from './RemoteShellTerminalTab'
+
+interface RemoteShellTerminalDialogProps {
+  building: Building
+  onClose: () => void
+  onReconfigure: () => void
+  addToast: (msg: string, type?: 'success' | 'error' | 'info') => void
+}
+
+interface TabSession {
+  id: string
+  connection: SshConnection
+}
+
+export function RemoteShellTerminalDialog({
+  building,
+  onClose,
+  onReconfigure,
+  addToast,
+}: RemoteShellTerminalDialogProps) {
+  const [connections, setConnections] = useState<SshConnection[]>([])
+  const [tabs, setTabs]               = useState<TabSession[]>([])
+  const [activeTabId, setActiveTabId] = useState<string>('')
+  const [loading, setLoading]         = useState(true)
+
+  const config: Partial<RemoteShellConfig> = (() => {
+    try { return JSON.parse(building.config) } catch { return {} }
+  })()
+
+  useEffect(() => {
+    api.listShellConnections(building.id)
+      .then((conns) => {
+        setConnections(conns)
+        // Open default (or first) connection as the initial tab
+        const defaultConn = conns.find((c) => c.id === config.defaultConnectionId) ?? conns[0]
+        if (defaultConn) {
+          const firstTab: TabSession = { id: `tab-${Date.now()}`, connection: defaultConn }
+          setTabs([firstTab])
+          setActiveTabId(firstTab.id)
+        }
+      })
+      .catch(() => addToast('Failed to load connections', 'error'))
+      .finally(() => setLoading(false))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [building.id])
+
+  function openNewTab(connection: SshConnection) {
+    const newTab: TabSession = { id: `tab-${Date.now()}`, connection }
+    setTabs((prev) => [...prev, newTab])
+    setActiveTabId(newTab.id)
+  }
+
+  function closeTab(tabId: string) {
+    setTabs((prev) => {
+      const next = prev.filter((t) => t.id !== tabId)
+      if (activeTabId === tabId && next.length > 0) {
+        setActiveTabId(next[next.length - 1].id)
+      }
+      return next
+    })
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 1100,
+        display: 'flex', flexDirection: 'column',
+        background: '#0a0a0a',
+        fontFamily: 'monospace',
+      }}
+    >
+      {/* Header bar */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '4px 10px', background: '#111', borderBottom: '1px solid #1a1a1a',
+        flexShrink: 0,
+      }}>
+        <span style={{ color: '#00ff88', fontWeight: 700, fontSize: 12 }}>
+          ▣ REMOTEPOST — {building.name}
+        </span>
+        <div style={{ flex: 1 }} />
+        <button
+          className="hud-btn"
+          style={{ fontSize: 10 }}
+          onClick={onReconfigure}
+          title="Manage connections"
+        >⚙ CONNECTIONS</button>
+        <button
+          className="hud-btn"
+          style={{ fontSize: 10, color: '#ff6b6b' }}
+          onClick={onClose}
+          title="Close [Esc]"
+        >✕ CLOSE</button>
+      </div>
+
+      {/* Tab bar */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 1,
+        padding: '3px 8px 0', background: '#0f0f0f', borderBottom: '1px solid #1a1a1a',
+        flexShrink: 0, overflowX: 'auto',
+      }}>
+        {tabs.map((tab) => (
+          <div
+            key={tab.id}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 4,
+              padding: '3px 10px 3px 10px',
+              background: activeTabId === tab.id ? '#1a1a1a' : 'transparent',
+              borderRadius: '4px 4px 0 0',
+              border: activeTabId === tab.id ? '1px solid #2a2a2a' : '1px solid transparent',
+              borderBottom: activeTabId === tab.id ? '1px solid #1a1a1a' : '1px solid transparent',
+              cursor: 'pointer',
+              fontSize: 11, color: activeTabId === tab.id ? '#00ff88' : '#666',
+              whiteSpace: 'nowrap',
+            }}
+            onClick={() => setActiveTabId(tab.id)}
+          >
+            <span>▸</span>
+            <span>{tab.connection.label}</span>
+            <button
+              style={{
+                background: 'none', border: 'none', cursor: 'pointer',
+                color: '#666', fontSize: 10, padding: '0 0 0 4px',
+              }}
+              onClick={(e) => { e.stopPropagation(); closeTab(tab.id) }}
+              title="Close tab"
+            >✕</button>
+          </div>
+        ))}
+
+        {/* Add tab button */}
+        {connections.length > 0 && (
+          <div style={{ position: 'relative' }}>
+            <select
+              style={{
+                background: 'transparent', border: '1px solid #333',
+                color: '#888', fontSize: 11, cursor: 'pointer', borderRadius: 3,
+                padding: '2px 6px', marginLeft: 4,
+              }}
+              value=""
+              onChange={(e) => {
+                const conn = connections.find((c) => String(c.id) === e.target.value)
+                if (conn) openNewTab(conn)
+                e.target.value = ''
+              }}
+              title="Open new tab"
+            >
+              <option value="" disabled>+ New Tab</option>
+              {connections.map((c) => (
+                <option key={c.id} value={String(c.id)}>{c.label}</option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      {/* Terminal area */}
+      <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
+        {loading && (
+          <div style={{
+            position: 'absolute', inset: 0, display: 'flex',
+            alignItems: 'center', justifyContent: 'center',
+            color: '#00ff88', fontSize: 12,
+          }}>
+            Loading connections...
+          </div>
+        )}
+
+        {!loading && tabs.length === 0 && (
+          <div style={{
+            position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column',
+            alignItems: 'center', justifyContent: 'center',
+            color: '#555', fontSize: 12, gap: 10,
+          }}>
+            <div>No connections available.</div>
+            <button className="hud-btn" onClick={onReconfigure}>⚙ Manage Connections</button>
+          </div>
+        )}
+
+        {tabs.map((tab) => (
+          <div
+            key={tab.id}
+            style={{
+              position: 'absolute', inset: 0,
+              display: activeTabId === tab.id ? 'flex' : 'none',
+              flexDirection: 'column',
+            }}
+          >
+            <RemoteShellTerminalTab
+              buildingId={building.id}
+              connection={tab.connection}
+              theme={config.theme}
+              fontSize={config.fontSize}
+              fontFamily={config.fontFamily}
+              isActive={activeTabId === tab.id}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/components/RemoteShellTerminalTab.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellTerminalTab.tsx
@@ -1,0 +1,452 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { getShellWsUrl } from '../api'
+import type { SshConnection, ShellStatus } from '../types'
+// @ts-ignore — installed via npm, types included
+import { Terminal } from '@xterm/xterm'
+// @ts-ignore
+import { FitAddon } from '@xterm/addon-fit'
+// @ts-ignore
+import { WebLinksAddon } from '@xterm/addon-web-links'
+// @ts-ignore
+import { SearchAddon } from '@xterm/addon-search'
+import '@xterm/xterm/css/xterm.css'
+
+interface RemoteShellTerminalTabProps {
+  buildingId: number
+  connection: SshConnection
+  theme?: 'dark' | 'dracula' | 'solarized'
+  fontSize?: number
+  fontFamily?: string
+  isActive: boolean
+}
+
+const THEMES = {
+  dark: {
+    background:   '#0d0d0d',
+    foreground:   '#c8f0c8',
+    cursor:       '#00ff88',
+    black:        '#1a1a1a',
+    red:          '#ff5555',
+    green:        '#50fa7b',
+    yellow:       '#f1fa8c',
+    blue:         '#6272a4',
+    magenta:      '#ff79c6',
+    cyan:         '#8be9fd',
+    white:        '#f8f8f2',
+    brightBlack:  '#44475a',
+    brightRed:    '#ff6e6e',
+    brightGreen:  '#69ff94',
+    brightYellow: '#ffffa5',
+    brightBlue:   '#d6acff',
+    brightMagenta:'#ff92df',
+    brightCyan:   '#a4ffff',
+    brightWhite:  '#ffffff',
+  },
+  dracula: {
+    background:   '#282a36',
+    foreground:   '#f8f8f2',
+    cursor:       '#f8f8f2',
+    black:        '#21222c',
+    red:          '#ff5555',
+    green:        '#50fa7b',
+    yellow:       '#f1fa8c',
+    blue:         '#bd93f9',
+    magenta:      '#ff79c6',
+    cyan:         '#8be9fd',
+    white:        '#f8f8f2',
+    brightBlack:  '#6272a4',
+    brightRed:    '#ff6e6e',
+    brightGreen:  '#69ff94',
+    brightYellow: '#ffffa5',
+    brightBlue:   '#d6acff',
+    brightMagenta:'#ff92df',
+    brightCyan:   '#a4ffff',
+    brightWhite:  '#ffffff',
+  },
+  solarized: {
+    background:   '#002b36',
+    foreground:   '#839496',
+    cursor:       '#93a1a1',
+    black:        '#073642',
+    red:          '#dc322f',
+    green:        '#859900',
+    yellow:       '#b58900',
+    blue:         '#268bd2',
+    magenta:      '#d33682',
+    cyan:         '#2aa198',
+    white:        '#eee8d5',
+    brightBlack:  '#002b36',
+    brightRed:    '#cb4b16',
+    brightGreen:  '#586e75',
+    brightYellow: '#657b83',
+    brightBlue:   '#839496',
+    brightMagenta:'#6c71c4',
+    brightCyan:   '#93a1a1',
+    brightWhite:  '#fdf6e3',
+  },
+}
+
+// Tmux key sequences (Ctrl+B prefix = \x02)
+const TMUX_ACTIONS = [
+  { label: '+ WIN',    title: 'New tmux window (Ctrl+B c)',      seq: '\x02c' },
+  { label: '▶ NEXT',  title: 'Next tmux window (Ctrl+B n)',      seq: '\x02n' },
+  { label: '◀ PREV',  title: 'Prev tmux window (Ctrl+B p)',      seq: '\x02p' },
+  { label: '⏏ DETACH', title: 'Detach tmux session (Ctrl+B d)',  seq: '\x02d' },
+]
+
+export function RemoteShellTerminalTab({
+  buildingId,
+  connection,
+  theme = 'dark',
+  fontSize = 14,
+  fontFamily = 'monospace',
+  isActive,
+}: RemoteShellTerminalTabProps) {
+  const containerRef   = useRef<HTMLDivElement>(null)
+  const termRef        = useRef<Terminal | null>(null)
+  const fitAddonRef    = useRef<FitAddon | null>(null)
+  const searchAddonRef = useRef<SearchAddon | null>(null)
+  const wsRef          = useRef<WebSocket | null>(null)
+  const [status, setStatus] = useState<ShellStatus>('connecting')
+  const [statusMsg, setStatusMsg] = useState('')
+
+  // Search bar state
+  const [searchVisible, setSearchVisible] = useState(false)
+  const [searchQuery, setSearchQuery]     = useState('')
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  // ── Connect / Reconnect ────────────────────────────────────────────────────
+  const connectWS = useCallback(() => {
+    if (!containerRef.current || !termRef.current) return
+
+    setStatus('connecting')
+    setStatusMsg('')
+
+    const term = termRef.current
+    term.write('\r\n\x1b[33mConnecting to ' + connection.label + '...\x1b[0m\r\n')
+
+    const url = getShellWsUrl(buildingId, connection.id)
+    const ws  = new WebSocket(url)
+    ws.binaryType = 'arraybuffer'
+    wsRef.current = ws
+
+    ws.onmessage = (evt) => {
+      if (typeof evt.data === 'string') {
+        try {
+          const msg = JSON.parse(evt.data)
+          if (msg.type === 'status') {
+            if (msg.state === 'connected') {
+              setStatus('connected')
+              setStatusMsg('')
+            } else if (msg.state === 'disconnected') {
+              setStatus('disconnected')
+              setStatusMsg(msg.error ?? '')
+              term.write('\r\n\x1b[31m[Disconnected]\x1b[0m\r\n')
+            } else if (msg.state === 'error') {
+              setStatus('error')
+              setStatusMsg(msg.error ?? 'Unknown error')
+              term.write('\r\n\x1b[31m[Error: ' + (msg.error ?? 'Unknown') + ']\x1b[0m\r\n')
+            }
+          }
+        } catch {
+          term.write(evt.data)
+        }
+      } else if (evt.data instanceof ArrayBuffer) {
+        term.write(new Uint8Array(evt.data))
+      }
+    }
+
+    ws.onerror = () => {
+      setStatus('error')
+      setStatusMsg('WebSocket error')
+      term.write('\r\n\x1b[31m[Connection error]\x1b[0m\r\n')
+    }
+
+    ws.onclose = () => {
+      setStatus((prev) => (prev === 'error' ? 'error' : 'disconnected'))
+    }
+  }, [buildingId, connection.id, connection.label])
+
+  // ── Terminal initialization ────────────────────────────────────────────────
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const term = new Terminal({
+      theme: THEMES[theme] ?? THEMES.dark,
+      fontSize,
+      fontFamily,
+      cursorBlink: true,
+      convertEol:  false,
+      scrollback:  5000,
+    })
+
+    const fitAddon    = new FitAddon()
+    const linksAddon  = new WebLinksAddon()
+    const searchAddon = new SearchAddon()
+    term.loadAddon(fitAddon)
+    term.loadAddon(linksAddon)
+    term.loadAddon(searchAddon)
+    term.open(containerRef.current)
+    fitAddon.fit()
+
+    termRef.current     = term
+    fitAddonRef.current  = fitAddon
+    searchAddonRef.current = searchAddon
+
+    // Forward keystrokes to SSH
+    term.onData((data: string) => {
+      const ws = wsRef.current
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(data)
+      }
+    })
+
+    // Forward binary data (paste, etc.)
+    term.onBinary((data: string) => {
+      const ws = wsRef.current
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        const bytes = Uint8Array.from(data, (c) => c.charCodeAt(0))
+        ws.send(bytes.buffer)
+      }
+    })
+
+    // Keyboard shortcut: Ctrl+Shift+F → toggle search bar
+    term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key === 'F') {
+        e.preventDefault()
+        setSearchVisible((v) => !v)
+        return false
+      }
+      return true
+    })
+
+    // Initial connection
+    const url = getShellWsUrl(buildingId, connection.id)
+    const ws  = new WebSocket(url)
+    ws.binaryType = 'arraybuffer'
+    wsRef.current = ws
+
+    term.write('\r\n\x1b[33mConnecting to ' + connection.label + '...\x1b[0m\r\n')
+
+    ws.onmessage = (evt) => {
+      if (typeof evt.data === 'string') {
+        try {
+          const msg = JSON.parse(evt.data)
+          if (msg.type === 'status') {
+            if (msg.state === 'connected') {
+              setStatus('connected')
+              setStatusMsg('')
+            } else if (msg.state === 'disconnected') {
+              setStatus('disconnected')
+              setStatusMsg(msg.error ?? '')
+              term.write('\r\n\x1b[31m[Disconnected]\x1b[0m\r\n')
+            } else if (msg.state === 'error') {
+              setStatus('error')
+              setStatusMsg(msg.error ?? 'Unknown error')
+              term.write('\r\n\x1b[31m[Error: ' + (msg.error ?? 'Unknown') + ']\x1b[0m\r\n')
+            }
+          }
+        } catch {
+          term.write(evt.data)
+        }
+      } else if (evt.data instanceof ArrayBuffer) {
+        term.write(new Uint8Array(evt.data))
+      }
+    }
+
+    ws.onerror = () => {
+      setStatus('error')
+      setStatusMsg('WebSocket error')
+      term.write('\r\n\x1b[31m[Connection error]\x1b[0m\r\n')
+    }
+
+    ws.onclose = () => {
+      setStatus((prev) => (prev === 'error' ? 'error' : 'disconnected'))
+    }
+
+    return () => {
+      ws.close()
+      term.dispose()
+      wsRef.current  = null
+      termRef.current = null
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [buildingId, connection.id, theme, fontSize, fontFamily])
+
+  // ── Resize observer ────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!containerRef.current) return
+    const obs = new ResizeObserver(() => {
+      if (!fitAddonRef.current || !wsRef.current) return
+      try {
+        fitAddonRef.current.fit()
+        const term = termRef.current
+        if (term && wsRef.current.readyState === WebSocket.OPEN) {
+          wsRef.current.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }))
+        }
+      } catch { /* ignore */ }
+    })
+    obs.observe(containerRef.current)
+    return () => obs.disconnect()
+  }, [])
+
+  // ── Focus when tab becomes active ─────────────────────────────────────────
+  useEffect(() => {
+    if (isActive) {
+      termRef.current?.focus()
+      fitAddonRef.current?.fit()
+    }
+  }, [isActive])
+
+  // ── Search helpers ─────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (searchVisible) {
+      setTimeout(() => searchInputRef.current?.focus(), 50)
+    } else {
+      termRef.current?.focus()
+    }
+  }, [searchVisible])
+
+  function handleSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Escape') {
+      setSearchVisible(false)
+    } else if (e.key === 'Enter') {
+      if (e.shiftKey) {
+        searchAddonRef.current?.findPrevious(searchQuery, { caseSensitive: false, incremental: false })
+      } else {
+        searchAddonRef.current?.findNext(searchQuery, { caseSensitive: false, incremental: false })
+      }
+    }
+  }
+
+  // ── Reconnect ──────────────────────────────────────────────────────────────
+  function handleReconnect() {
+    wsRef.current?.close()
+    wsRef.current = null
+    connectWS()
+  }
+
+  // ── Send tmux sequence ─────────────────────────────────────────────────────
+  function sendTmux(seq: string) {
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(seq)
+    }
+  }
+
+  const statusColor = {
+    idle:         '#888',
+    connecting:   '#ffaa00',
+    connected:    '#00ff88',
+    disconnected: '#888',
+    error:        '#ff4444',
+  }[status]
+
+  const isDisconnected = status === 'disconnected' || status === 'error'
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#0d0d0d' }}>
+
+      {/* Tmux quick-action toolbar — only shown when tmuxSession is configured */}
+      {connection.tmuxSession && (
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 4,
+          padding: '2px 10px', background: '#0a0a1a', borderBottom: '1px solid #1a1a2e',
+          flexShrink: 0,
+        }}>
+          <span style={{ fontSize: 9, color: '#4488ff', marginRight: 4, fontWeight: 700 }}>
+            TMUX:{connection.tmuxSession}
+          </span>
+          {TMUX_ACTIONS.map((action) => (
+            <button
+              key={action.seq}
+              className="hud-btn"
+              style={{ fontSize: 9, padding: '1px 6px', color: '#88aaff' }}
+              title={action.title}
+              disabled={!isActive || status !== 'connected'}
+              onClick={() => sendTmux(action.seq)}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Status bar */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '2px 10px', background: '#111', borderBottom: '1px solid #222',
+        fontSize: 10, color: '#888', flexShrink: 0,
+      }}>
+        <span style={{ width: 7, height: 7, borderRadius: '50%', background: statusColor, display: 'inline-block' }} />
+        <span style={{ color: '#aaa' }}>{connection.label}</span>
+        <span>·</span>
+        <span>{connection.username}@{connection.host}:{connection.port ?? 22}</span>
+        {connection.tmuxSession && <><span>·</span><span style={{ color: '#00aaff' }}>tmux:{connection.tmuxSession}</span></>}
+        {statusMsg && <><span>·</span><span style={{ color: '#ff4444' }}>{statusMsg}</span></>}
+        <span style={{ marginLeft: 'auto', textTransform: 'uppercase' }}>{status}</span>
+        {/* Reconnect button — shown when disconnected or errored */}
+        {isDisconnected && (
+          <button
+            className="hud-btn"
+            style={{ fontSize: 9, padding: '1px 6px', color: '#00ff88', marginLeft: 4 }}
+            onClick={handleReconnect}
+            title="Reconnect"
+          >⟳ RECONNECT</button>
+        )}
+        {/* Search toggle */}
+        <button
+          className="hud-btn"
+          style={{ fontSize: 9, padding: '1px 6px', color: searchVisible ? '#00ff88' : '#666', marginLeft: 2 }}
+          onClick={() => setSearchVisible((v) => !v)}
+          title="Search terminal output (Ctrl+Shift+F)"
+        >⌕</button>
+      </div>
+
+      {/* Search bar — shown when searchVisible */}
+      {searchVisible && (
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 6,
+          padding: '3px 10px', background: '#111', borderBottom: '1px solid #333',
+          flexShrink: 0,
+        }}>
+          <input
+            ref={searchInputRef}
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value)
+              if (e.target.value) {
+                searchAddonRef.current?.findNext(e.target.value, { caseSensitive: false, incremental: true })
+              }
+            }}
+            onKeyDown={handleSearchKeyDown}
+            placeholder="Search… (Enter=next, Shift+Enter=prev, Esc=close)"
+            style={{
+              flex: 1, background: '#0d0d0d', border: '1px solid #333',
+              color: '#c8f0c8', padding: '2px 8px', fontSize: 11,
+              borderRadius: 3, outline: 'none', fontFamily: 'monospace',
+            }}
+          />
+          <button
+            className="hud-btn"
+            style={{ fontSize: 9 }}
+            onClick={() => searchAddonRef.current?.findPrevious(searchQuery, { caseSensitive: false, incremental: false })}
+          >▲</button>
+          <button
+            className="hud-btn"
+            style={{ fontSize: 9 }}
+            onClick={() => searchAddonRef.current?.findNext(searchQuery, { caseSensitive: false, incremental: false })}
+          >▼</button>
+          <button
+            className="hud-btn"
+            style={{ fontSize: 9, color: '#ff6b6b' }}
+            onClick={() => setSearchVisible(false)}
+          >✕</button>
+        </div>
+      )}
+
+      {/* Terminal */}
+      <div ref={containerRef} style={{ flex: 1, overflow: 'hidden' }} />
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldMapLayer.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldMapLayer.tsx
@@ -9,6 +9,7 @@ import { BaseNode } from '../BaseNode'
 import { ClawComBuilding } from '../ClawComBuilding'
 import { HealthcheckBuilding } from '../HealthcheckBuilding'
 import { MailboxBuilding } from '../MailboxBuilding'
+import { RemoteShellBuilding } from '../RemoteShellBuilding'
 import { BadgeMarker } from '../BadgeMarker'
 import { UserUnit } from './UserUnit'
 import type { Repo } from '../../types'
@@ -205,6 +206,9 @@ export function BattlefieldMapLayer({
         }
         if (building.type === 'snailbox') {
           return <MailboxBuilding {...commonProps} />
+        }
+        if (building.type === 'remoteShell') {
+          return <RemoteShellBuilding {...commonProps} />
         }
         return <ClawComBuilding {...commonProps} />
       })}

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -378,3 +378,37 @@ export interface BattlefieldUser {
   avatarUrl: string
   lastRepoId?: number
 }
+
+export interface RemoteShellConfig {
+  configured: boolean
+  defaultConnectionId?: number
+  fontFamily?: string
+  fontSize?: number
+  theme?: 'dark' | 'dracula' | 'solarized'
+}
+
+export interface SshConnection {
+  id: number
+  buildingId: number
+  label: string
+  host: string
+  port: number | null
+  username: string
+  authType: string | null
+  hasCredentials: boolean
+  tmuxSession: string | null
+  createdAt: string | number | null
+  updatedAt: string | number | null
+}
+
+export interface SshSessionLog {
+  id: number
+  buildingId: number
+  connectionId: number | null
+  connectionLabel: string | null
+  connectedAt: string | number | null
+  disconnectedAt: string | number | null
+  durationMs: number | null
+}
+
+export type ShellStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error'

--- a/gh-ctrl/package.json
+++ b/gh-ctrl/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.2",
     "concurrently": "^8.2.0",
+    "ssh2": "^1.16.0",
     "drizzle-orm": "^0.31.0",
     "hono": "^4.4.0",
     "imapflow": "^1.2.18",
@@ -30,6 +31,7 @@
   "devDependencies": {
     "drizzle-kit": "^0.22.0",
     "@types/bun": "latest",
+    "@types/ssh2": "^1.15.0",
     "@playwright/test": "^1.45.0"
   }
 }

--- a/gh-ctrl/src/db/index.ts
+++ b/gh-ctrl/src/db/index.ts
@@ -168,4 +168,32 @@ sqlite.exec(`
   )
 `)
 
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS ssh_connections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    building_id INTEGER NOT NULL REFERENCES buildings(id) ON DELETE CASCADE,
+    label TEXT NOT NULL,
+    host TEXT NOT NULL,
+    port INTEGER DEFAULT 22,
+    username TEXT NOT NULL,
+    auth_type TEXT DEFAULT 'password',
+    encrypted_creds TEXT,
+    tmux_session TEXT,
+    created_at INTEGER DEFAULT (unixepoch()),
+    updated_at INTEGER DEFAULT (unixepoch())
+  )
+`)
+
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS ssh_session_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    building_id INTEGER NOT NULL REFERENCES buildings(id) ON DELETE CASCADE,
+    connection_id INTEGER,
+    connection_label TEXT,
+    connected_at INTEGER DEFAULT (unixepoch()),
+    disconnected_at INTEGER,
+    duration_ms INTEGER
+  )
+`)
+
 export const db = drizzle(sqlite, { schema })

--- a/gh-ctrl/src/db/schema.ts
+++ b/gh-ctrl/src/db/schema.ts
@@ -122,3 +122,29 @@ export const mailFolders = sqliteTable('mail_folders', {
   delimiter:   text('delimiter').notNull().default('/'),
   syncedAt:    integer('synced_at'),
 })
+
+// SSH connection profiles for RemotePost buildings
+export const sshConnections = sqliteTable('ssh_connections', {
+  id:             integer('id').primaryKey({ autoIncrement: true }),
+  buildingId:     integer('building_id').notNull().references(() => buildings.id, { onDelete: 'cascade' }),
+  label:          text('label').notNull(),
+  host:           text('host').notNull(),
+  port:           integer('port').default(22),
+  username:       text('username').notNull(),
+  authType:       text('auth_type').default('password'), // 'password' | 'key'
+  encryptedCreds: text('encrypted_creds'),               // AES-256-GCM encrypted JSON
+  tmuxSession:    text('tmux_session'),                  // null = no tmux, string = session name
+  createdAt:      integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+  updatedAt:      integer('updated_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+})
+
+// Audit log for SSH connects / disconnects
+export const sshSessionLog = sqliteTable('ssh_session_log', {
+  id:              integer('id').primaryKey({ autoIncrement: true }),
+  buildingId:      integer('building_id').notNull().references(() => buildings.id, { onDelete: 'cascade' }),
+  connectionId:    integer('connection_id'),              // FK to sshConnections (nullable if deleted)
+  connectionLabel: text('connection_label'),              // snapshot of label at connect time
+  connectedAt:     integer('connected_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+  disconnectedAt:  integer('disconnected_at', { mode: 'timestamp' }),
+  durationMs:      integer('duration_ms'),
+})

--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -10,6 +10,7 @@ import setupRouter from './routes/setup'
 import buildingsRouter from './routes/buildings'
 import badgesRouter from './routes/badges'
 import timersRouter from './routes/timers'
+import shellRouter, { shellWebsocket } from './routes/shell'
 import pkg from '../package.json'
 import { existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
@@ -56,6 +57,7 @@ app.route('/api/setup', setupRouter)
 app.route('/api/buildings', buildingsRouter)
 app.route('/api/badges', badgesRouter)
 app.route('/api/timers', timersRouter)
+app.route('/api/buildings', shellRouter)
 
 app.get('/api/health', (c) => c.json({ ok: true }))
 app.get('/api/version', (c) => c.json({ version: pkg.version }))
@@ -72,4 +74,4 @@ seedDefaultMaps().catch((err) => console.error('[seed] error:', err))
 initHealthcheckService().catch((err) => console.error('[healthcheck-service] init error:', err))
 initMailboxService().catch((err) => console.error('[mailbox-service] init error:', err))
 
-export default { port: 3001, hostname: '0.0.0.0', fetch: app.fetch }
+export default { port: 3001, hostname: '0.0.0.0', fetch: app.fetch, websocket: shellWebsocket }

--- a/gh-ctrl/src/routes/shell.ts
+++ b/gh-ctrl/src/routes/shell.ts
@@ -1,0 +1,459 @@
+import { Hono } from 'hono'
+import { createBunWebSocket } from 'hono/bun'
+import { db } from '../db'
+import { buildings, sshConnections, sshSessionLog } from '../db/schema'
+import { eq, and, desc } from 'drizzle-orm'
+import { createCipheriv, createDecipheriv, randomBytes, createHash } from 'node:crypto'
+import { Client } from 'ssh2'
+import type { ConnectConfig } from 'ssh2'
+
+export const { upgradeWebSocket, websocket: shellWebsocket } = createBunWebSocket()
+
+const app = new Hono()
+
+// ── Credential encryption (AES-256-GCM) ─────────────────────────────────────
+
+const ALGO = 'aes-256-gcm'
+
+function getEncryptionKey(): Buffer {
+  const secret = process.env.SHELL_SECRET ?? 'default-insecure-key-change-me'
+  return createHash('sha256').update(secret).digest()
+}
+
+function encryptCreds(plain: string): string {
+  const key = getEncryptionKey()
+  const iv = randomBytes(12)
+  const cipher = createCipheriv(ALGO, key, iv)
+  const encrypted = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()])
+  const tag = (cipher as any).getAuthTag() as Buffer
+  return JSON.stringify({
+    iv:   iv.toString('hex'),
+    tag:  tag.toString('hex'),
+    data: encrypted.toString('hex'),
+  })
+}
+
+function decryptCreds(stored: string): string {
+  const key = getEncryptionKey()
+  const { iv, tag, data } = JSON.parse(stored)
+  const decipher = createDecipheriv(ALGO, key, Buffer.from(iv, 'hex'))
+  ;(decipher as any).setAuthTag(Buffer.from(tag, 'hex'))
+  return (decipher.update(Buffer.from(data, 'hex')) as Buffer).toString('utf8') + decipher.final('utf8')
+}
+
+// Return profile without secret fields
+function maskProfile(p: typeof sshConnections.$inferSelect) {
+  const { encryptedCreds: _, ...rest } = p
+  return { ...rest, hasCredentials: !!_ }
+}
+
+// ── Connection profile CRUD ──────────────────────────────────────────────────
+
+// GET /:id/shell/connections — list connection profiles for building
+app.get('/:id/shell/connections', async (c) => {
+  const buildingId = Number(c.req.param('id'))
+  const building = await db.select().from(buildings).where(eq(buildings.id, buildingId)).limit(1)
+  if (building.length === 0) return c.json({ error: 'Building not found' }, 404)
+  if (building[0].type !== 'remoteShell') return c.json({ error: 'Not a remoteShell building' }, 400)
+
+  const profiles = await db.select().from(sshConnections)
+    .where(eq(sshConnections.buildingId, buildingId))
+    .orderBy(sshConnections.createdAt)
+  return c.json(profiles.map(maskProfile))
+})
+
+// POST /:id/shell/connections — create a connection profile
+app.post('/:id/shell/connections', async (c) => {
+  const buildingId = Number(c.req.param('id'))
+  const building = await db.select().from(buildings).where(eq(buildings.id, buildingId)).limit(1)
+  if (building.length === 0) return c.json({ error: 'Building not found' }, 404)
+  if (building[0].type !== 'remoteShell') return c.json({ error: 'Not a remoteShell building' }, 400)
+
+  const body = await c.req.json()
+  const { label, host, port = 22, username, authType = 'password', password, privateKey, tmuxSession } = body
+
+  if (!label?.trim() || !host?.trim() || !username?.trim()) {
+    return c.json({ error: 'label, host and username are required' }, 400)
+  }
+
+  let encryptedCreds: string | null = null
+  if (authType === 'password' && password) {
+    encryptedCreds = encryptCreds(JSON.stringify({ password }))
+  } else if (authType === 'key' && privateKey) {
+    encryptedCreds = encryptCreds(JSON.stringify({ privateKey }))
+  }
+
+  const safeTmux = tmuxSession ? tmuxSession.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64) : null
+
+  const [created] = await db.insert(sshConnections).values({
+    buildingId,
+    label: String(label).trim(),
+    host:  String(host).trim(),
+    port:  Number(port) || 22,
+    username: String(username).trim(),
+    authType: String(authType),
+    encryptedCreds,
+    tmuxSession: safeTmux,
+  }).returning()
+
+  // Mark building as configured
+  const existingConfig = (() => { try { return JSON.parse(building[0].config ?? '{}') } catch { return {} } })()
+  if (!existingConfig.configured) {
+    await db.update(buildings).set({
+      config: JSON.stringify({ ...existingConfig, configured: true }),
+      updatedAt: new Date(),
+    }).where(eq(buildings.id, buildingId))
+  }
+
+  return c.json(maskProfile(created), 201)
+})
+
+// PATCH /:id/shell/connections/:cid — update a connection profile
+app.patch('/:id/shell/connections/:cid', async (c) => {
+  const buildingId = Number(c.req.param('id'))
+  const cid        = Number(c.req.param('cid'))
+
+  const existing = await db.select().from(sshConnections)
+    .where(and(eq(sshConnections.id, cid), eq(sshConnections.buildingId, buildingId)))
+    .limit(1)
+  if (existing.length === 0) return c.json({ error: 'Connection not found' }, 404)
+
+  const body = await c.req.json()
+  const updates: Partial<typeof sshConnections.$inferInsert> = { updatedAt: new Date() }
+
+  if (body.label    !== undefined) updates.label    = String(body.label).trim()
+  if (body.host     !== undefined) updates.host     = String(body.host).trim()
+  if (body.port     !== undefined) updates.port     = Number(body.port) || 22
+  if (body.username !== undefined) updates.username = String(body.username).trim()
+  if (body.authType !== undefined) updates.authType = String(body.authType)
+  if (body.tmuxSession !== undefined) {
+    updates.tmuxSession = body.tmuxSession
+      ? String(body.tmuxSession).replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64)
+      : null
+  }
+
+  if (body.password) {
+    updates.encryptedCreds = encryptCreds(JSON.stringify({ password: body.password }))
+  } else if (body.privateKey) {
+    updates.encryptedCreds = encryptCreds(JSON.stringify({ privateKey: body.privateKey }))
+  }
+
+  const [updated] = await db.update(sshConnections).set(updates)
+    .where(eq(sshConnections.id, cid)).returning()
+  return c.json(maskProfile(updated))
+})
+
+// DELETE /:id/shell/connections/:cid — delete a connection profile
+app.delete('/:id/shell/connections/:cid', async (c) => {
+  const buildingId = Number(c.req.param('id'))
+  const cid        = Number(c.req.param('cid'))
+
+  const existing = await db.select().from(sshConnections)
+    .where(and(eq(sshConnections.id, cid), eq(sshConnections.buildingId, buildingId)))
+    .limit(1)
+  if (existing.length === 0) return c.json({ error: 'Connection not found' }, 404)
+
+  await db.delete(sshConnections).where(eq(sshConnections.id, cid))
+
+  // If no connections remain, mark building as unconfigured
+  const remaining = await db.select().from(sshConnections)
+    .where(eq(sshConnections.buildingId, buildingId))
+    .limit(1)
+  if (remaining.length === 0) {
+    const bldg = await db.select().from(buildings).where(eq(buildings.id, buildingId)).limit(1)
+    if (bldg.length > 0) {
+      const cfg = (() => { try { return JSON.parse(bldg[0].config ?? '{}') } catch { return {} } })()
+      await db.update(buildings).set({
+        config: JSON.stringify({ ...cfg, configured: false }),
+        updatedAt: new Date(),
+      }).where(eq(buildings.id, buildingId))
+    }
+  }
+
+  return c.json({ ok: true })
+})
+
+// POST /:id/shell/connections/test — test a connection without opening a PTY
+app.post('/:id/shell/connections/test', async (c) => {
+  const buildingId = Number(c.req.param('id'))
+  const building = await db.select().from(buildings).where(eq(buildings.id, buildingId)).limit(1)
+  if (building.length === 0) return c.json({ error: 'Building not found' }, 404)
+
+  const body = await c.req.json()
+  const { host, port = 22, username, authType = 'password', password, privateKey } = body
+
+  if (!host?.trim() || !username?.trim()) {
+    return c.json({ ok: false, error: 'host and username are required' }, 400)
+  }
+
+  return new Promise((resolve) => {
+    const conn = new Client()
+    const timeout = setTimeout(() => {
+      conn.end()
+      resolve(c.json({ ok: false, error: 'Connection timed out after 10 seconds' }))
+    }, 10_000)
+
+    conn.on('ready', () => {
+      clearTimeout(timeout)
+      conn.end()
+      resolve(c.json({ ok: true }))
+    })
+
+    conn.on('error', (err) => {
+      clearTimeout(timeout)
+      resolve(c.json({ ok: false, error: err.message }))
+    })
+
+    const config: ConnectConfig = {
+      host:     String(host).trim(),
+      port:     Number(port) || 22,
+      username: String(username).trim(),
+      readyTimeout: 10_000,
+    }
+
+    if (authType === 'password' && password) {
+      config.password = String(password)
+    } else if (authType === 'key' && privateKey) {
+      config.privateKey = String(privateKey)
+    }
+
+    try {
+      conn.connect(config)
+    } catch (err: any) {
+      clearTimeout(timeout)
+      resolve(c.json({ ok: false, error: err.message }))
+    }
+  })
+})
+
+// GET /:id/shell/history — connection history (last 50)
+app.get('/:id/shell/history', async (c) => {
+  const buildingId = Number(c.req.param('id'))
+  const rows = await db.select().from(sshSessionLog)
+    .where(eq(sshSessionLog.buildingId, buildingId))
+    .orderBy(desc(sshSessionLog.connectedAt))
+    .limit(50)
+  return c.json(rows)
+})
+
+// GET /:id/shell/connections/:cid/tmux-sessions — list active tmux sessions on remote
+app.get('/:id/shell/connections/:cid/tmux-sessions', async (c) => {
+  const buildingId = Number(c.req.param('id'))
+  const cid        = Number(c.req.param('cid'))
+
+  const profiles = await db.select().from(sshConnections)
+    .where(and(eq(sshConnections.id, cid), eq(sshConnections.buildingId, buildingId)))
+    .limit(1)
+  if (profiles.length === 0) return c.json({ error: 'Connection not found' }, 404)
+
+  const profile = profiles[0]
+  let creds: { password?: string; privateKey?: string } = {}
+  if (profile.encryptedCreds) {
+    try { creds = JSON.parse(decryptCreds(profile.encryptedCreds)) } catch { /* ignore */ }
+  }
+
+  return new Promise((resolve) => {
+    const conn = new Client()
+    const timeout = setTimeout(() => {
+      conn.end()
+      resolve(c.json({ ok: false, error: 'Connection timed out', sessions: [] }))
+    }, 10_000)
+
+    conn.on('ready', () => {
+      conn.exec('tmux ls 2>/dev/null || echo "__NO_TMUX__"', (err, stream) => {
+        if (err) {
+          clearTimeout(timeout)
+          conn.end()
+          resolve(c.json({ ok: false, error: err.message, sessions: [] }))
+          return
+        }
+        let output = ''
+        stream.on('data', (data: Buffer) => { output += data.toString() })
+        stream.stderr.on('data', (data: Buffer) => { output += data.toString() })
+        stream.on('close', () => {
+          clearTimeout(timeout)
+          conn.end()
+          if (output.includes('__NO_TMUX__') || output.includes('no server running')) {
+            resolve(c.json({ ok: true, sessions: [] }))
+            return
+          }
+          const sessions = output.trim().split('\n')
+            .filter((line) => line.trim() && !line.startsWith('error:'))
+            .map((line) => {
+              const match = line.match(/^([^:]+):/)
+              return match ? match[1].trim() : line.trim()
+            })
+            .filter(Boolean)
+          resolve(c.json({ ok: true, sessions }))
+        })
+      })
+    })
+
+    conn.on('error', (err) => {
+      clearTimeout(timeout)
+      resolve(c.json({ ok: false, error: err.message, sessions: [] }))
+    })
+
+    const authOptions: ConnectConfig = {
+      host:         profile.host,
+      port:         profile.port ?? 22,
+      username:     profile.username,
+      readyTimeout: 10_000,
+    }
+    if (profile.authType === 'key' && creds.privateKey) {
+      authOptions.privateKey = creds.privateKey
+    } else if (creds.password) {
+      authOptions.password = creds.password
+    }
+
+    try { conn.connect(authOptions) } catch (err: any) {
+      clearTimeout(timeout)
+      resolve(c.json({ ok: false, error: err.message, sessions: [] }))
+    }
+  })
+})
+
+// ── WebSocket PTY bridge ─────────────────────────────────────────────────────
+
+app.get(
+  '/:id/shell/ws',
+  upgradeWebSocket(async (c) => {
+    const buildingId   = Number(c.req.param('id'))
+    const connectionId = Number(c.req.query('connectionId'))
+
+    // Validate building + connection exist before the WS handshake
+    const profiles = await db.select().from(sshConnections)
+      .where(and(eq(sshConnections.id, connectionId), eq(sshConnections.buildingId, buildingId)))
+      .limit(1)
+
+    if (profiles.length === 0) {
+      return {
+        onOpen(_evt: Event, ws: any) {
+          ws.send(JSON.stringify({ type: 'status', state: 'error', error: 'Connection profile not found' }))
+          ws.close()
+        },
+      }
+    }
+
+    const profile = profiles[0]
+    let creds: { password?: string; privateKey?: string } = {}
+    if (profile.encryptedCreds) {
+      try { creds = JSON.parse(decryptCreds(profile.encryptedCreds)) } catch { /* ignore */ }
+    }
+
+    // Session state — closed over per WebSocket connection
+    let sshStream: any = null
+    let sshConn:   any = null
+    let logEntryId: number | null = null
+    const connectTime = Date.now()
+
+    return {
+      async onOpen(_evt: Event, ws: any) {
+        // Log session start
+        try {
+          const [entry] = await db.insert(sshSessionLog).values({
+            buildingId,
+            connectionId,
+            connectionLabel: profile.label,
+          }).returning()
+          logEntryId = entry.id
+        } catch { /* log failure is non-fatal */ }
+
+        const conn = new Client()
+        sshConn = conn
+
+        const authOptions: ConnectConfig = {
+          host:         profile.host,
+          port:         profile.port ?? 22,
+          username:     profile.username,
+          readyTimeout: 15_000,
+        }
+
+        if (profile.authType === 'key' && creds.privateKey) {
+          authOptions.privateKey = creds.privateKey
+        } else if (creds.password) {
+          authOptions.password = creds.password
+        }
+
+        conn.on('ready', () => {
+          conn.shell({ term: 'xterm-256color', cols: 80, rows: 24 }, (err: Error | null, stream: any) => {
+            if (err) {
+              ws.send(JSON.stringify({ type: 'status', state: 'error', error: err.message }))
+              ws.close()
+              return
+            }
+            sshStream = stream
+
+            if (profile.tmuxSession) {
+              const safe = profile.tmuxSession.replace(/[^a-zA-Z0-9_-]/g, '')
+              stream.write(`tmux new-session -A -s ${safe}\r`)
+            }
+
+            ws.send(JSON.stringify({ type: 'status', state: 'connected' }))
+
+            stream.on('data', (data: Buffer) => {
+              try { ws.send(data) } catch { /* client gone */ }
+            })
+
+            stream.stderr?.on('data', (data: Buffer) => {
+              try { ws.send(data) } catch { /* client gone */ }
+            })
+
+            stream.on('close', () => {
+              ws.send(JSON.stringify({ type: 'status', state: 'disconnected' }))
+              ws.close()
+            })
+          })
+        })
+
+        conn.on('error', (err: Error) => {
+          try {
+            ws.send(JSON.stringify({ type: 'status', state: 'error', error: err.message }))
+            ws.close()
+          } catch { /* ignore */ }
+        })
+
+        try {
+          conn.connect(authOptions)
+        } catch (err: any) {
+          ws.send(JSON.stringify({ type: 'status', state: 'error', error: err.message }))
+          ws.close()
+        }
+      },
+
+      onMessage(evt: MessageEvent, _ws: any) {
+        if (!sshStream) return
+        const { data } = evt
+        if (typeof data === 'string') {
+          try {
+            const msg = JSON.parse(data)
+            if (msg.type === 'resize' && typeof msg.cols === 'number' && typeof msg.rows === 'number') {
+              sshStream.setWindow?.(msg.rows, msg.cols, 0, 0)
+            }
+            // Other JSON control messages are silently handled (no SSH write)
+          } catch {
+            // Not JSON — forward raw string as keyboard input
+            sshStream.write(data)
+          }
+        } else if (data instanceof ArrayBuffer) {
+          sshStream.write(Buffer.from(data))
+        } else if (data instanceof Uint8Array) {
+          sshStream.write(Buffer.from(data))
+        }
+      },
+
+      onClose() {
+        sshConn?.end()
+        if (logEntryId !== null) {
+          const durationMs = Date.now() - connectTime
+          db.update(sshSessionLog)
+            .set({ disconnectedAt: new Date(), durationMs })
+            .where(eq(sshSessionLog.id, logEntryId!))
+            .catch(() => { /* non-fatal */ })
+        }
+      },
+    }
+  })
+)
+
+export default app


### PR DESCRIPTION
Completes the RemotePost SSH/TMux/Terminal building by implementing the remaining Phase 3 and 4 items from #308.

**Phase 3 (TMux) additions:**
- Tmux quick-action toolbar: New Window, Next, Prev, Detach buttons (send Ctrl+B key sequences over the live WebSocket)
- `GET /buildings/:id/shell/connections/:cid/tmux-sessions` — runs `tmux ls` via SSH exec and returns session names

**Phase 4 (Polish) additions:**
- Reconnect button: shown in status bar when disconnected/errored, reopens WebSocket without destroying the terminal instance
- SearchAddon: Ctrl+Shift+F toggles search overlay with incremental search and prev/next navigation

Also includes the full Phase 1+2 foundation (DB schema, backend routes, frontend components) ported from the previous branch.

Closes #308

Generated with [Claude Code](https://claude.ai/code)) · [`claude/issue-308-20260331-1946`](https://github.com/svengraziani/vibe-and-conquer/tree/claude/issue-308-20260331-1946