### PR TITLE
feat: Add GitHub Copilot Chat integration to ClawCom

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -454,6 +454,12 @@ export const api = {
       body: JSON.stringify(params),
     }),
 
+  copilotTest: (githubToken: string, copilotModel?: string) =>
+    request<{ ok: boolean; error?: string }>('/buildings/copilot-test', {
+      method: 'POST',
+      body: JSON.stringify({ githubToken, copilotModel }),
+    }),
+
   // ── GitLab API methods ──────────────────────────────────────────────────────
 
   getGitLabRepoData: (fullName: string) =>

--- a/gh-ctrl/client/src/components/ClawComBuilding.tsx
+++ b/gh-ctrl/client/src/components/ClawComBuilding.tsx
@@ -269,13 +269,17 @@ export function ClawComBuilding({
             right: 2,
             width: 8,
             height: 8,
-            borderRadius: config.clawType === 'claudechannel' ? '2px' : '50%',
+            borderRadius: config.clawType === 'claudechannel' || config.clawType === 'copilot' ? '2px' : '50%',
             background: isConfigured
-              ? config.clawType === 'claudechannel' ? '#a78bfa' : 'var(--green-neon)'
+              ? config.clawType === 'claudechannel' ? '#a78bfa'
+              : config.clawType === 'copilot' ? '#4493f8'
+              : 'var(--green-neon)'
               : '#888',
             border: '1px solid var(--bg-darker)',
           }} title={isConfigured
-            ? config.clawType === 'claudechannel' ? 'Claude Channel active' : 'Connected'
+            ? config.clawType === 'claudechannel' ? 'Claude Channel active'
+            : config.clawType === 'copilot' ? 'GitHub Copilot active'
+            : 'Connected'
             : 'Not configured'
           } />
         </div>
@@ -300,6 +304,8 @@ export function ClawComBuilding({
           {isConfigured
             ? config.clawType === 'claudechannel'
               ? '✦ CLAUDE ● ACTIVE'
+              : config.clawType === 'copilot'
+              ? '◎ COPILOT ● ACTIVE'
               : `${config.clawType?.toUpperCase() ?? 'CLAW'} ● ONLINE`
             : '⚙ SETUP REQUIRED'}
         </div>

--- a/gh-ctrl/client/src/components/ClawComSetupDialog.tsx
+++ b/gh-ctrl/client/src/components/ClawComSetupDialog.tsx
@@ -22,7 +22,8 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
   const [mcpWebhookUrl, setMcpWebhookUrl] = useState(existingConfig.mcpWebhookUrl ?? 'http://localhost:8788')
   const [channelSecret, setChannelSecret] = useState(existingConfig.channelSecret ?? '')
   const [enablePermissionRelay, setEnablePermissionRelay] = useState(existingConfig.enablePermissionRelay ?? false)
-  const [githubToken, setGithubToken] = useState(existingConfig.githubToken ?? '')
+  const hasExistingToken = Boolean(existingConfig.githubToken)
+  const [githubToken, setGithubToken] = useState('')
   const [copilotModel, setCopilotModel] = useState(existingConfig.copilotModel ?? 'gpt-4o')
   const [saving, setSaving] = useState(false)
   const [testing, setTesting] = useState(false)
@@ -33,7 +34,7 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
 
   async function handleSave() {
     if (isCopilot) {
-      if (!githubToken.trim()) {
+      if (!githubToken.trim() && !hasExistingToken) {
         onError('GitHub Token is required')
         return
       }
@@ -56,7 +57,7 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
             clawType,
             host: '',
             configured: true,
-            githubToken: githubToken.trim(),
+            githubToken: githubToken.trim() || existingConfig.githubToken,
             copilotModel: copilotModel || 'gpt-4o',
           }
         : isChannel
@@ -106,13 +107,7 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
     setTesting(true)
     setTestResult(null)
     try {
-      const res = await fetch('/api/buildings/copilot-test', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ githubToken: githubToken.trim() }),
-        signal: AbortSignal.timeout(10000),
-      })
-      const data = await res.json()
+      const data = await api.copilotTest(githubToken.trim(), copilotModel || 'gpt-4o')
       if (data.ok) {
         setTestResult('✓ Token valid — Copilot API reachable!')
       } else {
@@ -169,7 +164,7 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
                       type="password"
                       value={githubToken}
                       onChange={(e) => setGithubToken(e.target.value)}
-                      placeholder="ghp_..."
+                      placeholder={hasExistingToken ? '●●●●●●●● (leave blank to keep existing)' : 'ghp_...'}
                     />
                     <button
                       className="hud-btn"

--- a/gh-ctrl/client/src/components/ClawComSetupDialog.tsx
+++ b/gh-ctrl/client/src/components/ClawComSetupDialog.tsx
@@ -22,14 +22,22 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
   const [mcpWebhookUrl, setMcpWebhookUrl] = useState(existingConfig.mcpWebhookUrl ?? 'http://localhost:8788')
   const [channelSecret, setChannelSecret] = useState(existingConfig.channelSecret ?? '')
   const [enablePermissionRelay, setEnablePermissionRelay] = useState(existingConfig.enablePermissionRelay ?? false)
+  const [githubToken, setGithubToken] = useState(existingConfig.githubToken ?? '')
+  const [copilotModel, setCopilotModel] = useState(existingConfig.copilotModel ?? 'gpt-4o')
   const [saving, setSaving] = useState(false)
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<string | null>(null)
 
   const isChannel = clawType === 'claudechannel'
+  const isCopilot = clawType === 'copilot'
 
   async function handleSave() {
-    if (isChannel) {
+    if (isCopilot) {
+      if (!githubToken.trim()) {
+        onError('GitHub Token is required')
+        return
+      }
+    } else if (isChannel) {
       if (!mcpWebhookUrl.trim()) {
         onError('MCP Webhook URL is required')
         return
@@ -43,7 +51,15 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
 
     setSaving(true)
     try {
-      const config: ClawComConfig = isChannel
+      const config: ClawComConfig = isCopilot
+        ? {
+            clawType,
+            host: '',
+            configured: true,
+            githubToken: githubToken.trim(),
+            copilotModel: copilotModel || 'gpt-4o',
+          }
+        : isChannel
         ? {
             clawType,
             host: '',
@@ -85,6 +101,30 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
     }
   }
 
+  async function handleCopilotTest() {
+    if (!githubToken.trim()) return
+    setTesting(true)
+    setTestResult(null)
+    try {
+      const res = await fetch('/api/buildings/copilot-test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ githubToken: githubToken.trim() }),
+        signal: AbortSignal.timeout(10000),
+      })
+      const data = await res.json()
+      if (data.ok) {
+        setTestResult('✓ Token valid — Copilot API reachable!')
+      } else {
+        setTestResult(`✗ Error: ${data.error}`)
+      }
+    } catch (err: any) {
+      setTestResult(`✗ Unreachable: ${err.message}`)
+    } finally {
+      setTesting(false)
+    }
+  }
+
   return (
     <BaseDialog className="map-dialog" onClose={onClose}>
         <div className="map-dialog-title">&#x25a0; {building.name.toUpperCase()} — SETUP</div>
@@ -97,7 +137,9 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
           />
           <div className="clawcom-setup-form">
             <div className="clawcom-setup-desc">
-              {isChannel
+              {isCopilot
+                ? 'Connect ClawCom to GitHub Copilot. Requires a GitHub PAT (classic or fine-grained) with the copilot scope.'
+                : isChannel
                 ? 'Connect ClawCom to a running Claude Code session via the Claude Channels MCP protocol.'
                 : 'Configure the connection to an Openclaw or Nanoclaw. Once set up, you can send and receive commands via the integrated chat window.'}
             </div>
@@ -105,19 +147,65 @@ export function ClawComSetupDialog({ building, onClose, onConfigured, onError }:
             <div className="clawcom-setup-group">
               <label className="clawcom-setup-group-label">Claw Type</label>
               <div className="clawcom-setup-row">
-                {(['openclaw', 'nanoclaw', 'claudechannel'] as const).map((t) => (
+                {(['openclaw', 'nanoclaw', 'claudechannel', 'copilot'] as const).map((t) => (
                   <button
                     key={t}
                     className={`hud-btn${clawType === t ? ' active' : ''}`}
-                    onClick={() => setClawType(t)}
+                    onClick={() => { setClawType(t); setTestResult(null) }}
                   >
-                    {t === 'openclaw' ? '⚙ OPENCLAW' : t === 'nanoclaw' ? '⬡ NANOCLAW' : '✦ CLAUDE'}
+                    {t === 'openclaw' ? '⚙ OPENCLAW' : t === 'nanoclaw' ? '⬡ NANOCLAW' : t === 'claudechannel' ? '✦ CLAUDE' : '◎ COPILOT'}
                   </button>
                 ))}
               </div>
             </div>
 
-            {isChannel ? (
+            {isCopilot ? (
+              <>
+                <div className="clawcom-setup-group">
+                  <label className="clawcom-setup-group-label">GitHub Token <span style={{ color: 'var(--text-dim)', fontWeight: 400 }}>(copilot scope)</span></label>
+                  <div className="clawcom-setup-row">
+                    <input
+                      className="hud-input"
+                      type="password"
+                      value={githubToken}
+                      onChange={(e) => setGithubToken(e.target.value)}
+                      placeholder="ghp_..."
+                    />
+                    <button
+                      className="hud-btn"
+                      onClick={handleCopilotTest}
+                      disabled={testing || !githubToken.trim()}
+                      title="Test token"
+                    >
+                      {testing ? '◌' : 'TEST'}
+                    </button>
+                  </div>
+                  {testResult && (
+                    <div className={`clawcom-test-result ${testResult.startsWith('✓') ? 'clawcom-test-result--ok' : 'clawcom-test-result--err'}`}>
+                      {testResult}
+                    </div>
+                  )}
+                </div>
+
+                <div className="clawcom-setup-group">
+                  <label className="clawcom-setup-group-label">Model</label>
+                  <select
+                    className="hud-input"
+                    value={copilotModel}
+                    onChange={(e) => setCopilotModel(e.target.value)}
+                  >
+                    <option value="gpt-4o">gpt-4o</option>
+                    <option value="gpt-4o-mini">gpt-4o-mini</option>
+                    <option value="claude-3.5-sonnet">claude-3.5-sonnet</option>
+                    <option value="o1-mini">o1-mini</option>
+                  </select>
+                </div>
+
+                <div style={{ fontSize: 9, color: 'var(--text-dim)', marginTop: 4, lineHeight: 1.5 }}>
+                  Requires a GitHub Copilot Individual/Business/Enterprise subscription.
+                </div>
+              </>
+            ) : isChannel ? (
               <>
                 <div className="clawcom-setup-group">
                   <label className="clawcom-setup-group-label">MCP Webhook URL</label>

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -225,7 +225,7 @@ export interface MapTile {
 }
 
 export interface ClawComConfig {
-  clawType: 'openclaw' | 'nanoclaw' | 'claudechannel'
+  clawType: 'openclaw' | 'nanoclaw' | 'claudechannel' | 'copilot'
   host: string
   configured: boolean
   /** Claude Channel: URL of the MCP server webhook (default: http://localhost:8788) */
@@ -234,6 +234,10 @@ export interface ClawComConfig {
   channelSecret?: string
   /** Claude Channel: prompt the user before Claude runs destructive tools */
   enablePermissionRelay?: boolean
+  /** Copilot: GitHub PAT with copilot scope */
+  githubToken?: string
+  /** Copilot: model name (default: gpt-4o) */
+  copilotModel?: string
 }
 
 export type ChannelEventType =

--- a/gh-ctrl/src/routes/buildings.ts
+++ b/gh-ctrl/src/routes/buildings.ts
@@ -188,10 +188,11 @@ app.post('/:id/messages', async (c) => {
     } else if (config.clawType === 'copilot' && config.githubToken) {
       // GitHub Copilot: OpenAI-compatible chat completions API
       try {
-        const history = await db.select().from(clawcomMessages)
+        const history = (await db.select().from(clawcomMessages)
           .where(eq(clawcomMessages.buildingId, id))
-          .orderBy(asc(clawcomMessages.id))
-          .limit(20)
+          .orderBy(desc(clawcomMessages.id))
+          .limit(20))
+          .reverse()
 
         const messages = history.map((m) => ({
           role: m.direction === 'out' ? 'user' as const : 'assistant' as const,
@@ -371,10 +372,10 @@ app.post('/:id/permission', async (c) => {
   }
 })
 
-// POST /copilot-test — verify a GitHub token has Copilot API access
+// POST /copilot-test — verify a GitHub token has Copilot API access and optionally validate model
 app.post('/copilot-test', async (c) => {
   const body = await c.req.json()
-  const { githubToken } = body
+  const { githubToken, copilotModel } = body
   if (!githubToken) return c.json({ ok: false, error: 'githubToken required' }, 400)
 
   try {
@@ -385,8 +386,17 @@ app.post('/copilot-test', async (c) => {
       },
       signal: AbortSignal.timeout(8000),
     })
-    if (res.ok) return c.json({ ok: true })
-    return c.json({ ok: false, error: `HTTP ${res.status}` })
+    if (!res.ok) return c.json({ ok: false, error: `HTTP ${res.status}` })
+
+    if (copilotModel) {
+      const data = await res.json().catch(() => null)
+      const available: string[] = (data?.data ?? []).map((m: any) => m.id)
+      if (available.length > 0 && !available.includes(String(copilotModel))) {
+        return c.json({ ok: false, error: `Model '${copilotModel}' not available (available: ${available.join(', ')})` })
+      }
+    }
+
+    return c.json({ ok: true })
   } catch (err: any) {
     return c.json({ ok: false, error: err.message })
   }

--- a/gh-ctrl/src/routes/buildings.ts
+++ b/gh-ctrl/src/routes/buildings.ts
@@ -185,6 +185,47 @@ app.post('/:id/messages', async (c) => {
       } catch {
         // MCP server not reachable — message stored locally anyway
       }
+    } else if (config.clawType === 'copilot' && config.githubToken) {
+      // GitHub Copilot: OpenAI-compatible chat completions API
+      try {
+        const history = await db.select().from(clawcomMessages)
+          .where(eq(clawcomMessages.buildingId, id))
+          .orderBy(asc(clawcomMessages.id))
+          .limit(20)
+
+        const messages = history.map((m) => ({
+          role: m.direction === 'out' ? 'user' as const : 'assistant' as const,
+          content: m.content,
+        }))
+
+        const response = await fetch('https://api.githubcopilot.com/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${config.githubToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: config.copilotModel || 'gpt-4o',
+            messages,
+            stream: false,
+          }),
+          signal: AbortSignal.timeout(30000),
+        })
+
+        if (response.ok) {
+          const data = await response.json().catch(() => null)
+          const replyContent = data?.choices?.[0]?.message?.content
+          if (replyContent) {
+            await db.insert(clawcomMessages).values({
+              buildingId: id,
+              direction: 'in',
+              content: String(replyContent),
+            })
+          }
+        }
+      } catch {
+        // Copilot API not reachable — message stored locally anyway
+      }
     } else if (config.host) {
       // OpenClaw / NanoClaw: POST to {host}/message and expect an immediate reply
       try {
@@ -327,6 +368,27 @@ app.post('/:id/permission', async (c) => {
     return c.json(data, resp.status as any)
   } catch {
     return c.json({ error: 'MCP server not reachable' }, 503)
+  }
+})
+
+// POST /copilot-test — verify a GitHub token has Copilot API access
+app.post('/copilot-test', async (c) => {
+  const body = await c.req.json()
+  const { githubToken } = body
+  if (!githubToken) return c.json({ ok: false, error: 'githubToken required' }, 400)
+
+  try {
+    const res = await fetch('https://api.githubcopilot.com/models', {
+      headers: {
+        'Authorization': `Bearer ${String(githubToken)}`,
+        'Content-Type': 'application/json',
+      },
+      signal: AbortSignal.timeout(8000),
+    })
+    if (res.ok) return c.json({ ok: true })
+    return c.json({ ok: false, error: `HTTP ${res.status}` })
+  } catch (err: any) {
+    return c.json({ ok: false, error: err.message })
   }
 })
 


### PR DESCRIPTION
Closes #321

Adds GitHub Copilot as a fourth `clawType` in the ClawCom building.

## Changes
- `types.ts`: extend `ClawComConfig` with `copilot` type, `githubToken` and `copilotModel`
- `buildings.ts`: Copilot API branch in message handler + `/copilot-test` endpoint
- `ClawComSetupDialog.tsx`: Copilot setup UI (PAT, model selector, test button)
- `ClawComBuilding.tsx`: Copilot visual indicator

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Copilot as a supported configuration option alongside existing claw types
  * Users can now configure Copilot with GitHub authentication token and model selection
  * Added dedicated test functionality to verify Copilot configuration
  * Status indicator displays "◎ COPILOT ● ACTIVE" with distinct visual styling when Copilot is enabled
  * System now relays messages to GitHub Copilot API when configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->