### PR TITLE
feat: mobile responsive + multi-touch navigation

### DIFF
--- a/gh-ctrl/client/index.html
+++ b/gh-ctrl/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>V&amp;C - Command Center</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/logo-vcga.png" />

--- a/gh-ctrl/client/index.html
+++ b/gh-ctrl/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>V&amp;C - Command Center</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/logo-vcga.png" />

--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -23,6 +23,7 @@ export default function App() {
   const loadSettings = useAppStore((s) => s.loadSettings)
   const loadContacts = useAppStore((s) => s.loadContacts)
   const [appVersion, setAppVersion] = useState<string | null>(null)
+  const [sidebarOpen, setSidebarOpen] = useState(false)
   const [setupStatus, setSetupStatus] = useState<SetupStatus | null>(null)
   const [setupChecked, setSetupChecked] = useState(false)
   const [connectionChecked, setConnectionChecked] = useState(false)
@@ -120,7 +121,21 @@ export default function App() {
 
   return (
     <div className="app-layout">
-      <aside className="sidebar">
+      {/* Mobile: hamburger button to open sidebar drawer */}
+      <button
+        className="sidebar-hamburger"
+        onClick={() => setSidebarOpen(v => !v)}
+        aria-label="Toggle navigation"
+      >
+        &#x2630;
+      </button>
+
+      {/* Mobile: backdrop to close sidebar drawer */}
+      {sidebarOpen && (
+        <div className="sidebar-backdrop" onClick={() => setSidebarOpen(false)} />
+      )}
+
+      <aside className={`sidebar${sidebarOpen ? ' sidebar-open' : ''}`}>
         <div className="sidebar-logo">
           <img src="/logo-transparent.png" alt="V&C Command Center" className="sidebar-logo-img" />
         </div>
@@ -130,24 +145,28 @@ export default function App() {
             to="/"
             end
             className={({ isActive }) => `nav-btn${isActive ? ' active' : ''}`}
+            onClick={() => setSidebarOpen(false)}
           >
             <span className="nav-icon">&#x25a0;</span><span className="nav-label"> Battlefield</span>
           </NavLink>
           <NavLink
             to="/map-editor"
             className={({ isActive }) => `nav-btn${isActive ? ' active' : ''}`}
+            onClick={() => setSidebarOpen(false)}
           >
             <span className="nav-icon">&#x25a6;</span><span className="nav-label"> Map Editor</span>
           </NavLink>
           <NavLink
             to="/settings"
             className={({ isActive }) => `nav-btn${isActive ? ' active' : ''}`}
+            onClick={() => setSidebarOpen(false)}
           >
             <span className="nav-icon">&#x2699;</span><span className="nav-label"> Repositories</span>
           </NavLink>
           <NavLink
             to="/contacts"
             className={({ isActive }) => `nav-btn${isActive ? ' active' : ''}`}
+            onClick={() => setSidebarOpen(false)}
           >
             <span className="nav-icon">&#x2602;</span><span className="nav-label"> Contacts</span>
           </NavLink>
@@ -197,7 +216,7 @@ export default function App() {
         )}
       </aside>
 
-      <main className="main-content">
+      <main className="main-content" onClick={() => setSidebarOpen(false)}>
         <Routes>
           <Route path="/" element={<BattlefieldView />} />
           <Route path="/map-editor" element={<MapEditor />} />

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import type { DashboardEntry, GameMap, Badge } from '../types'
 import { BranchSiloPanel } from './BranchSiloPanel'
 import { SidePanel } from './SidePanel'
@@ -46,8 +46,14 @@ export function BattlefieldView() {
   const placedBadges = useAppStore((s) => s.placedBadges)
   const storePlaceBadge = useAppStore((s) => s.placeBadge)
   const updatePlacedBadgePosition = useAppStore((s) => s.updatePlacedBadgePosition)
-  // Camera: zoom, pan, wheel zoom
-  const camera = useBattlefieldCamera()
+  // Camera: zoom, pan, wheel zoom, touch
+  // onTap / onLongPress are set via refs inside the hook, so we pass stable callbacks
+  const tapCallbackRef = useRef<((x: number, y: number) => void) | undefined>(undefined)
+  const longPressCallbackRef = useRef<((x: number, y: number) => void) | undefined>(undefined)
+  const camera = useBattlefieldCamera({
+    onTap: useCallback((x, y) => tapCallbackRef.current?.(x, y), []),
+    onLongPress: useCallback((x, y) => longPressCallbackRef.current?.(x, y), []),
+  })
   const { offset, setOffset, zoom, isDraggingMap, setIsDraggingMap, dragStart, setDragStart, zoomRef, offsetRef, containerRef, handleZoomIn, handleZoomOut, handleZoomReset, handleZoomToBase } = camera
 
   // Base node positions
@@ -80,7 +86,22 @@ export function BattlefieldView() {
   const [showShortcuts, setShowShortcuts] = useState(false)
   const [showCommandPalette, setShowCommandPalette] = useState(false)
 
+  // Mobile: minimap hidden by default on small screens; landscape overlay
+  const isMobileScreen = useMemo(() => window.innerWidth <= 480, [])
+  const [showMinimap, setShowMinimap] = useState(!isMobileScreen)
+  const [isPortrait, setIsPortrait] = useState(() => window.innerWidth < window.innerHeight && window.innerWidth <= 768)
+
+  // Long-press context menu
+  type ContextMenu = { screenX: number; screenY: number } | null
+  const [contextMenu, setContextMenu] = useState<ContextMenu>(null)
+
   const autoScanTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const onResize = () => setIsPortrait(window.innerWidth < window.innerHeight && window.innerWidth <= 768)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
 
   const { play } = useSound()
 
@@ -203,12 +224,11 @@ export function BattlefieldView() {
     setDragStart({ x: e.clientX - offset.x, y: e.clientY - offset.y })
   }, [offset, isRelocateMode, placementMode, placingBadge, setIsDraggingMap, setDragStart])
 
-  const handleMapClick = useCallback(async (e: React.MouseEvent) => {
-    if ((e.target as HTMLElement).closest('.cnc-sidebar')) return
+  const handleClickAtPosition = useCallback(async (clientX: number, clientY: number) => {
     const rect = containerRef.current?.getBoundingClientRect()
     if (!rect) return
-    const mapX = (e.clientX - rect.left - offsetRef.current.x) / zoomRef.current
-    const mapY = (e.clientY - rect.top - offsetRef.current.y) / zoomRef.current
+    const mapX = (clientX - rect.left - offsetRef.current.x) / zoomRef.current
+    const mapY = (clientY - rect.top - offsetRef.current.y) / zoomRef.current
 
     if (placingBadge) {
       try {
@@ -268,6 +288,25 @@ export function BattlefieldView() {
     }
     setPlacementMode(null)
   }, [placementMode, placingBadge, loadBuildings, addToast, storePlaceBadge, loadRepos, onRefresh, activeMap, setPositions, containerRef, offsetRef, zoomRef])
+
+  const handleMapClick = useCallback((e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest('.cnc-sidebar')) return
+    handleClickAtPosition(e.clientX, e.clientY)
+  }, [handleClickAtPosition])
+
+  const handleTap = useCallback((clientX: number, clientY: number) => {
+    setContextMenu(null)
+    handleClickAtPosition(clientX, clientY)
+  }, [handleClickAtPosition])
+
+  const handleLongPress = useCallback((clientX: number, clientY: number) => {
+    setContextMenu({ screenX: clientX, screenY: clientY })
+    play('peep')
+  }, [play])
+
+  // Keep tap/long-press refs in sync so the camera hook always calls the latest versions
+  tapCallbackRef.current = handleTap
+  longPressCallbackRef.current = handleLongPress
 
   const handleMapMouseMove = useCallback((e: React.MouseEvent) => {
     if (placementMode) {
@@ -338,8 +377,15 @@ export function BattlefieldView() {
   useEffect(() => {
     if (!placementMode) return
     const onMove = (e: MouseEvent) => setGhostScreenPos({ x: e.clientX, y: e.clientY })
+    const onTouch = (e: TouchEvent) => {
+      if (e.touches.length > 0) setGhostScreenPos({ x: e.touches[0].clientX, y: e.touches[0].clientY })
+    }
     window.addEventListener('mousemove', onMove)
-    return () => window.removeEventListener('mousemove', onMove)
+    window.addEventListener('touchmove', onTouch, { passive: true })
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('touchmove', onTouch)
+    }
   }, [placementMode])
 
   const visibleEntries = activeMapRepoIds === null
@@ -400,6 +446,8 @@ export function BattlefieldView() {
         onZoomReset={() => handleZoomReset(positions)}
         onToggleShortcuts={handleToggleShortcuts}
         showShortcuts={showShortcuts}
+        showMinimap={showMinimap}
+        onToggleMinimap={() => setShowMinimap(v => !v)}
       />
 
       <BattlefieldMapLayer
@@ -438,7 +486,7 @@ export function BattlefieldView() {
         onStartBadgeRelocate={handleStartBadgeRelocate}
       />
 
-      {(visibleEntries.length > 0 || pendingRepos.length > 0) && (
+      {showMinimap && (visibleEntries.length > 0 || pendingRepos.length > 0) && (
         <BattlefieldMinimap entries={visibleEntries} positions={positions} offset={offset} zoom={zoom} onJump={setOffset} />
       )}
 
@@ -622,6 +670,80 @@ export function BattlefieldView() {
             />
           </div>
         </SidePanel>
+      )}
+
+      {/* Long-press context menu */}
+      {contextMenu && (
+        <div
+          className="battlefield-context-menu"
+          style={{ left: contextMenu.screenX, top: contextMenu.screenY }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="bcm-header">&#x25CF; FIELD OPS</div>
+          {(placementMode || placingBadge) ? (
+            <button className="bcm-btn bcm-btn-primary" onClick={() => {
+              setContextMenu(null)
+              handleClickAtPosition(contextMenu.screenX, contextMenu.screenY)
+            }}>
+              &#x2295; PLACE HERE
+            </button>
+          ) : (
+            <>
+              <button className="bcm-btn" onClick={() => {
+                setContextMenu(null)
+                play('peep')
+                onRefresh()
+              }}>
+                &#x25CE; SCAN ALL
+              </button>
+              <button className="bcm-btn" onClick={() => {
+                setContextMenu(null)
+                play('hydraulic')
+                setShowBuildMenu(true)
+              }}>
+                &#x25A3; BUILD HERE
+              </button>
+              <button className="bcm-btn" onClick={() => {
+                setContextMenu(null)
+                play('hydraulic')
+                setIsRelocateMode(v => !v)
+                setRelocatingId(null)
+                setRelocatingStart(null)
+              }}>
+                {isRelocateMode ? <span>&#x2716; CANCEL RELOCATE</span> : <span>&#x2316; RELOCATE BASE</span>}
+              </button>
+            </>
+          )}
+          <button className="bcm-btn bcm-btn-cancel" onClick={() => setContextMenu(null)}>
+            &#x2715; CANCEL
+          </button>
+        </div>
+      )}
+      {contextMenu && (
+        <div className="battlefield-context-backdrop" onClick={() => setContextMenu(null)} />
+      )}
+
+      {/* Mobile: fancy placement mode overlay */}
+      {(placementMode || placingBadge) && (
+        <div className="mobile-placement-hint">
+          <div className="mph-crosshair" />
+          <div className="mph-label">
+            {placingBadge ? `TAP TO DROP: ${placingBadge.name}` : `TAP TO PLACE: ${placementMode!.name}`}
+          </div>
+          <button className="mph-cancel" onClick={() => { setPlacementMode(null); setPlacingBadge(null) }}>
+            &#x2715; CANCEL
+          </button>
+        </div>
+      )}
+
+      {/* Landscape orientation overlay */}
+      {isPortrait && (
+        <div className="battlefield-landscape-overlay">
+          <div className="blo-icon">&#x21BA;</div>
+          <div className="blo-title">ROTATE DEVICE</div>
+          <div className="blo-sub">Command Center requires landscape orientation</div>
+        </div>
       )}
     </div>
   )

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -51,8 +51,8 @@ export function BattlefieldView() {
   const tapCallbackRef = useRef<((x: number, y: number) => void) | undefined>(undefined)
   const longPressCallbackRef = useRef<((x: number, y: number) => void) | undefined>(undefined)
   const camera = useBattlefieldCamera({
-    onTap: useCallback((x, y) => tapCallbackRef.current?.(x, y), []),
-    onLongPress: useCallback((x, y) => longPressCallbackRef.current?.(x, y), []),
+    onTap: useCallback((x: number, y: number) => tapCallbackRef.current?.(x, y), []),
+    onLongPress: useCallback((x: number, y: number) => longPressCallbackRef.current?.(x, y), []),
   })
   const { offset, setOffset, zoom, isDraggingMap, setIsDraggingMap, dragStart, setDragStart, zoomRef, offsetRef, containerRef, handleZoomIn, handleZoomOut, handleZoomReset, handleZoomToBase } = camera
 

--- a/gh-ctrl/client/src/components/MapEditor.tsx
+++ b/gh-ctrl/client/src/components/MapEditor.tsx
@@ -841,6 +841,20 @@ const ZOOM_MAX = 3
 const ZOOM_FACTOR = 1.15
 
 export function MapEditor() {
+  // Block on phones (≤480px); tablet (481–768px) is allowed
+  if (window.innerWidth <= 480) {
+    return (
+      <div className="map-editor-mobile-block">
+        <div className="meb-icon">&#x25A6;</div>
+        <div className="meb-title">TABLET REQUIRED</div>
+        <div className="meb-sub">Map Editor is not available on mobile devices.<br />Please use a tablet or desktop to access the Map Editor.</div>
+      </div>
+    )
+  }
+  return <MapEditorContent />
+}
+
+function MapEditorContent() {
   const onToast = useAppStore((s) => s.addToast)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { DashboardEntry, GameMap } from '../../types'
 import { CloseIcon, RelocateIcon, ScanIcon, BuildIcon, MapIcon, FeedIcon } from '../Icons'
 import { ZOOM_MIN, ZOOM_MAX } from './battlefieldConstants'
@@ -16,6 +17,7 @@ interface BattlefieldHUDProps {
   showFeedPanel: boolean
   showBadgeLibrary: boolean
   showTimers: boolean
+  showMinimap: boolean
   onScan: () => void
   onToggleRelocate: () => void
   onShowBuildMenu: () => void
@@ -28,6 +30,7 @@ interface BattlefieldHUDProps {
   onZoomOut: () => void
   onZoomReset: () => void
   onToggleShortcuts: () => void
+  onToggleMinimap: () => void
   showShortcuts: boolean
 }
 
@@ -45,6 +48,7 @@ export function BattlefieldHUD({
   showFeedPanel,
   showBadgeLibrary,
   showTimers,
+  showMinimap,
   onScan,
   onToggleRelocate,
   onShowBuildMenu,
@@ -57,8 +61,11 @@ export function BattlefieldHUD({
   onZoomOut,
   onZoomReset,
   onToggleShortcuts,
+  onToggleMinimap,
   showShortcuts,
 }: BattlefieldHUDProps) {
+  const [showOverflow, setShowOverflow] = useState(false)
+
   return (
     <div className="battlefield-hud">
       <div className="hud-brand">
@@ -105,8 +112,10 @@ export function BattlefieldHUD({
           {isRelocateMode ? <CloseIcon size={10} /> : <RelocateIcon size={11} />}
           <span className="hud-label"> {isRelocateMode ? 'CANCEL' : 'RELOCATE'}</span>
         </button>
+
+        {/* Desktop-only buttons — hidden on mobile via .hud-desktop-only */}
         <button
-          className="hud-btn"
+          className="hud-btn hud-desktop-only"
           onClick={onShowBuildMenu}
           title="Build options (ClawCom, etc.)"
           aria-label="Open build options"
@@ -114,7 +123,7 @@ export function BattlefieldHUD({
           <BuildIcon size={11} /><span className="hud-label"> BUILD</span>
         </button>
         <button
-          className={`hud-btn${showBadgeLibrary ? ' active' : ''}`}
+          className={`hud-btn hud-desktop-only${showBadgeLibrary ? ' active' : ''}`}
           onClick={onToggleBadgeLibrary}
           title="Badge Library — place custom markers on the battlefield"
           aria-label="Open badge library"
@@ -122,9 +131,9 @@ export function BattlefieldHUD({
         >
           ◈<span className="hud-label"> BADGES</span>
         </button>
-        <span className="hud-zoom-sep" />
+        <span className="hud-zoom-sep hud-desktop-only" />
         <button
-          className="hud-btn"
+          className="hud-btn hud-desktop-only"
           onClick={onShowMapSelector}
           title="Load a map from the Map Editor"
         >
@@ -132,7 +141,7 @@ export function BattlefieldHUD({
         </button>
         {activeMap && (
           <button
-            className="hud-btn hud-btn-icon"
+            className="hud-btn hud-btn-icon hud-desktop-only"
             onClick={onClearMap}
             title="Clear loaded map"
           >
@@ -141,7 +150,7 @@ export function BattlefieldHUD({
         )}
         <span className="hud-zoom-sep" />
         <button
-          className={`hud-btn${showFeedPanel ? ' active' : ''}`}
+          className={`hud-btn hud-desktop-only${showFeedPanel ? ' active' : ''}`}
           onClick={onToggleFeed}
           title="Toggle Intel Feed"
           aria-label="Toggle Intel Feed"
@@ -150,7 +159,7 @@ export function BattlefieldHUD({
           <FeedIcon size={11} /><span className="hud-label"> FEED</span>
         </button>
         <button
-          className={`hud-btn${showTimers ? ' active' : ''}`}
+          className={`hud-btn hud-desktop-only${showTimers ? ' active' : ''}`}
           onClick={onToggleTimers}
           title="Mission Timers — Deadline countdown for all maps"
           aria-label="Toggle mission timers"
@@ -163,8 +172,20 @@ export function BattlefieldHUD({
         <span className="hud-zoom-level" title="Click to reset zoom [0]" onClick={onZoomReset} role="button" aria-label={`Current zoom ${Math.round(zoom * 100)}%, click to reset`}>{Math.round(zoom * 100)}%</span>
         <button className="hud-btn hud-zoom-btn" onClick={onZoomIn} disabled={zoom >= ZOOM_MAX} title="Zoom in [+]" aria-label="Zoom in">+</button>
         <span className="hud-zoom-sep" />
+
+        {/* Minimap toggle — visible on all screen sizes */}
         <button
-          className={`hud-btn${showShortcuts ? ' active' : ''}`}
+          className={`hud-btn${showMinimap ? ' active' : ''}`}
+          onClick={onToggleMinimap}
+          title={showMinimap ? 'Hide minimap' : 'Show minimap'}
+          aria-label="Toggle minimap"
+          aria-pressed={showMinimap}
+        >
+          &#x25A1;<span className="hud-label"> MAP</span>
+        </button>
+
+        <button
+          className={`hud-btn hud-desktop-only${showShortcuts ? ' active' : ''}`}
           onClick={onToggleShortcuts}
           title="Keyboard Shortcuts [?]"
           aria-label="Toggle keyboard shortcuts overlay"
@@ -172,6 +193,42 @@ export function BattlefieldHUD({
         >
           ⌨<span className="hud-label"> KEYS</span>
         </button>
+
+        {/* Mobile overflow menu — visible only on mobile */}
+        <div className="hud-overflow-wrap hud-mobile-only">
+          <button
+            className={`hud-btn${showOverflow ? ' active' : ''}`}
+            onClick={(e) => { e.stopPropagation(); setShowOverflow(v => !v) }}
+            title="More options"
+            aria-label="More HUD options"
+          >
+            &#x22EF;
+          </button>
+          {showOverflow && (
+            <div className="hud-overflow-panel" onClick={(e) => e.stopPropagation()}>
+              <button className="hud-btn hud-overflow-item" onClick={() => { setShowOverflow(false); onShowBuildMenu() }}>
+                <BuildIcon size={11} /> BUILD
+              </button>
+              <button className={`hud-btn hud-overflow-item${showBadgeLibrary ? ' active' : ''}`} onClick={() => { setShowOverflow(false); onToggleBadgeLibrary() }}>
+                ◈ BADGES
+              </button>
+              <button className="hud-btn hud-overflow-item" onClick={() => { setShowOverflow(false); onShowMapSelector() }}>
+                <MapIcon size={11} /> {activeMap ? activeMap.name : 'MAP'}
+              </button>
+              {activeMap && (
+                <button className="hud-btn hud-overflow-item" onClick={() => { setShowOverflow(false); onClearMap() }}>
+                  <CloseIcon size={9} /> CLEAR MAP
+                </button>
+              )}
+              <button className={`hud-btn hud-overflow-item${showFeedPanel ? ' active' : ''}`} onClick={() => { setShowOverflow(false); onToggleFeed() }}>
+                <FeedIcon size={11} /> FEED
+              </button>
+              <button className={`hud-btn hud-overflow-item${showTimers ? ' active' : ''}`} onClick={() => { setShowOverflow(false); onToggleTimers() }}>
+                ⏱ TIMERS
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/gh-ctrl/client/src/hooks/useBattlefieldCamera.ts
+++ b/gh-ctrl/client/src/hooks/useBattlefieldCamera.ts
@@ -65,7 +65,7 @@ export function useBattlefieldCamera(options?: BattlefieldCameraOptions) {
 
   const handleTouchStart = useCallback((e: TouchEvent) => {
     const target = e.target as HTMLElement
-    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .battlefield-placement-banner, .battlefield-relocate-banner, .hud-overflow-panel')) return
+    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .battlefield-placement-banner, .battlefield-relocate-banner, .hud-overflow-panel, .mph-cancel, .battlefield-context-backdrop, .battlefield-landscape-overlay')) return
     e.preventDefault()
 
     const tc = touchMetaRef.current
@@ -100,7 +100,7 @@ export function useBattlefieldCamera(options?: BattlefieldCameraOptions) {
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
     const target = e.target as HTMLElement
-    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu')) return
+    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .mph-cancel, .battlefield-context-backdrop, .battlefield-landscape-overlay')) return
     e.preventDefault()
 
     const tc = touchMetaRef.current

--- a/gh-ctrl/client/src/hooks/useBattlefieldCamera.ts
+++ b/gh-ctrl/client/src/hooks/useBattlefieldCamera.ts
@@ -2,7 +2,25 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import type { Position } from '../components/battlefield/battlefieldConstants'
 import { ISO_MAP_CENTER_X, ISO_MAP_OFFSET_Y, ZOOM_MIN, ZOOM_MAX, ZOOM_FACTOR } from '../components/battlefield/battlefieldConstants'
 
-export function useBattlefieldCamera() {
+export interface BattlefieldCameraOptions {
+  onTap?: (clientX: number, clientY: number) => void
+  onLongPress?: (clientX: number, clientY: number) => void
+}
+
+function getTouchDist(t1: Touch, t2: Touch) {
+  return Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY)
+}
+
+function getTouchMid(t1: Touch, t2: Touch) {
+  return { x: (t1.clientX + t2.clientX) / 2, y: (t1.clientY + t2.clientY) / 2 }
+}
+
+export function useBattlefieldCamera(options?: BattlefieldCameraOptions) {
+  const onTapRef = useRef(options?.onTap)
+  const onLongPressRef = useRef(options?.onLongPress)
+  useEffect(() => { onTapRef.current = options?.onTap }, [options?.onTap])
+  useEffect(() => { onLongPressRef.current = options?.onLongPress }, [options?.onLongPress])
+
   const [offset, setOffset] = useState<Position>(() => ({
     x: window.innerWidth / 2 - ISO_MAP_CENTER_X,
     y: window.innerHeight / 2 - ISO_MAP_OFFSET_Y,
@@ -14,6 +32,16 @@ export function useBattlefieldCamera() {
   const zoomRef = useRef(zoom)
   const offsetRef = useRef(offset)
   const containerRef = useRef<HTMLDivElement>(null)
+
+  // Touch state — all stored in refs so event handlers always see latest values
+  const touchPanStartRef = useRef<{ touchX: number; touchY: number; offsetX: number; offsetY: number } | null>(null)
+  const pinchRef = useRef<{ dist: number; midX: number; midY: number } | null>(null)
+  const touchMetaRef = useRef<{
+    singleStart: { x: number; y: number; time: number; moved: boolean } | null
+    twoFingerActive: boolean
+    longPressTimer: ReturnType<typeof setTimeout> | null
+    longPressTriggered: boolean
+  }>({ singleStart: null, twoFingerActive: false, longPressTimer: null, longPressTriggered: false })
 
   useEffect(() => { zoomRef.current = zoom }, [zoom])
   useEffect(() => { offsetRef.current = offset }, [offset])
@@ -35,12 +63,135 @@ export function useBattlefieldCamera() {
     })
   }, [])
 
+  const handleTouchStart = useCallback((e: TouchEvent) => {
+    const target = e.target as HTMLElement
+    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .battlefield-placement-banner, .battlefield-relocate-banner, .hud-overflow-panel')) return
+    e.preventDefault()
+
+    const tc = touchMetaRef.current
+
+    if (e.touches.length === 1) {
+      const t = e.touches[0]
+      tc.singleStart = { x: t.clientX, y: t.clientY, time: Date.now(), moved: false }
+      tc.twoFingerActive = false
+      touchPanStartRef.current = { touchX: t.clientX, touchY: t.clientY, offsetX: offsetRef.current.x, offsetY: offsetRef.current.y }
+
+      if (tc.longPressTimer) clearTimeout(tc.longPressTimer)
+      tc.longPressTriggered = false
+      tc.longPressTimer = setTimeout(() => {
+        if (tc.singleStart && !tc.singleStart.moved) {
+          tc.longPressTriggered = true
+          touchPanStartRef.current = null
+          onLongPressRef.current?.(tc.singleStart.x, tc.singleStart.y)
+        }
+      }, 500)
+    } else if (e.touches.length >= 2) {
+      if (tc.longPressTimer) { clearTimeout(tc.longPressTimer); tc.longPressTimer = null }
+      tc.singleStart = null
+      tc.twoFingerActive = true
+      touchPanStartRef.current = null
+
+      const t1 = e.touches[0]
+      const t2 = e.touches[1]
+      const mid = getTouchMid(t1, t2)
+      pinchRef.current = { dist: getTouchDist(t1, t2), midX: mid.x, midY: mid.y }
+    }
+  }, [])
+
+  const handleTouchMove = useCallback((e: TouchEvent) => {
+    const target = e.target as HTMLElement
+    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu')) return
+    e.preventDefault()
+
+    const tc = touchMetaRef.current
+
+    if (e.touches.length === 1 && !tc.twoFingerActive) {
+      const t = e.touches[0]
+      if (tc.singleStart) {
+        const dx = Math.abs(t.clientX - tc.singleStart.x)
+        const dy = Math.abs(t.clientY - tc.singleStart.y)
+        if (dx > 6 || dy > 6) {
+          tc.singleStart.moved = true
+          if (tc.longPressTimer) { clearTimeout(tc.longPressTimer); tc.longPressTimer = null }
+        }
+      }
+      if (touchPanStartRef.current) {
+        const start = touchPanStartRef.current
+        setOffset({
+          x: start.offsetX + (t.clientX - start.touchX),
+          y: start.offsetY + (t.clientY - start.touchY),
+        })
+      }
+    } else if (e.touches.length >= 2) {
+      const t1 = e.touches[0]
+      const t2 = e.touches[1]
+      const newDist = getTouchDist(t1, t2)
+      const newMid = getTouchMid(t1, t2)
+
+      if (pinchRef.current) {
+        const { dist: oldDist, midX: oldMidX, midY: oldMidY } = pinchRef.current
+        const factor = newDist / oldDist
+        setZoom(prevZoom => {
+          const newZoom = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, prevZoom * factor))
+          setOffset(prevOffset => ({
+            x: newMid.x - (newMid.x - prevOffset.x) * (newZoom / prevZoom) + (newMid.x - oldMidX),
+            y: newMid.y - (newMid.y - prevOffset.y) * (newZoom / prevZoom) + (newMid.y - oldMidY),
+          }))
+          return newZoom
+        })
+      }
+      pinchRef.current = { dist: newDist, midX: newMid.x, midY: newMid.y }
+    }
+  }, [])
+
+  const handleTouchEnd = useCallback((e: TouchEvent) => {
+    const tc = touchMetaRef.current
+    if (tc.longPressTimer) { clearTimeout(tc.longPressTimer); tc.longPressTimer = null }
+
+    if (e.touches.length === 1) {
+      // Transitioned from 2-finger to 1-finger: restart single-finger pan
+      const t = e.touches[0]
+      tc.twoFingerActive = false
+      pinchRef.current = null
+      touchPanStartRef.current = { touchX: t.clientX, touchY: t.clientY, offsetX: offsetRef.current.x, offsetY: offsetRef.current.y }
+      return
+    }
+
+    if (e.touches.length === 0) {
+      pinchRef.current = null
+      tc.twoFingerActive = false
+
+      // Tap detection
+      if (tc.singleStart && !tc.singleStart.moved && !tc.longPressTriggered) {
+        const elapsed = Date.now() - tc.singleStart.time
+        if (elapsed < 350) {
+          const { x, y } = tc.singleStart
+          // Defer tap slightly so any setState from move handlers settle
+          setTimeout(() => onTapRef.current?.(x, y), 0)
+        }
+      }
+
+      tc.singleStart = null
+      touchPanStartRef.current = null
+    }
+  }, [])
+
   useEffect(() => {
     const el = containerRef.current
     if (!el) return
     el.addEventListener('wheel', handleWheel, { passive: false })
-    return () => el.removeEventListener('wheel', handleWheel)
-  }, [handleWheel])
+    el.addEventListener('touchstart', handleTouchStart, { passive: false })
+    el.addEventListener('touchmove', handleTouchMove, { passive: false })
+    el.addEventListener('touchend', handleTouchEnd)
+    el.addEventListener('touchcancel', handleTouchEnd)
+    return () => {
+      el.removeEventListener('wheel', handleWheel)
+      el.removeEventListener('touchstart', handleTouchStart)
+      el.removeEventListener('touchmove', handleTouchMove)
+      el.removeEventListener('touchend', handleTouchEnd)
+      el.removeEventListener('touchcancel', handleTouchEnd)
+    }
+  }, [handleWheel, handleTouchStart, handleTouchMove, handleTouchEnd])
 
   const handleZoomIn = useCallback(() => {
     setZoom(prev => {

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -5895,3 +5895,403 @@ select.input {
   letter-spacing: 0.5px;
   flex-shrink: 0;
 }
+
+/* ══════════════════════════════════════════════════════════
+   Mobile & Touch — Multi-touch navigation, landscape guard
+   ══════════════════════════════════════════════════════════ */
+
+/* Prevent browser pan/zoom on the battlefield; handled by our touch logic */
+.battlefield-container {
+  touch-action: none;
+}
+
+/* ── HUD: show/hide helpers ── */
+.hud-desktop-only {
+  display: inline-flex;
+}
+.hud-mobile-only {
+  display: none;
+}
+
+/* ── Sidebar hamburger (hidden on desktop) ── */
+.sidebar-hamburger {
+  display: none;
+}
+
+/* ── Sidebar backdrop (hidden on desktop) ── */
+.sidebar-backdrop {
+  display: none;
+}
+
+/* ── Long-press Context Menu ── */
+.battlefield-context-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 49;
+}
+
+.battlefield-context-menu {
+  position: fixed;
+  z-index: 50;
+  background: rgba(4, 10, 6, 0.97);
+  border: 1px solid rgba(57, 255, 20, 0.5);
+  border-radius: 6px;
+  padding: 6px;
+  min-width: 170px;
+  font-family: var(--font-mono);
+  box-shadow: 0 0 24px rgba(57, 255, 20, 0.2), 0 4px 16px rgba(0,0,0,0.8);
+  transform: translate(-50%, -50%);
+}
+
+.bcm-header {
+  font-size: 9px;
+  letter-spacing: 2px;
+  color: var(--crt-green, #39ff14);
+  text-shadow: 0 0 6px var(--crt-green, #39ff14);
+  padding: 2px 6px 6px;
+  border-bottom: 1px solid rgba(57, 255, 20, 0.2);
+  margin-bottom: 4px;
+}
+
+.bcm-btn {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--crt-green, #39ff14);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.8px;
+  text-align: left;
+  padding: 8px 10px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.12s;
+  min-height: 36px;
+}
+
+.bcm-btn:hover,
+.bcm-btn:active {
+  background: rgba(57, 255, 20, 0.1);
+}
+
+.bcm-btn-primary {
+  color: var(--green-neon, #39ff14);
+  font-weight: 600;
+}
+
+.bcm-btn-cancel {
+  color: var(--text-2, #4dcc00);
+  margin-top: 4px;
+  border-top: 1px solid rgba(57, 255, 20, 0.15);
+}
+
+/* ── Mobile placement hint (crosshair + label) ── */
+.mobile-placement-hint {
+  display: none;
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 15;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mph-crosshair {
+  width: 48px;
+  height: 48px;
+  border: 2px dashed rgba(57, 255, 20, 0.8);
+  border-radius: 50%;
+  box-shadow: 0 0 16px rgba(57, 255, 20, 0.4);
+  animation: mph-pulse 1.2s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes mph-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.2); opacity: 0.6; }
+}
+
+.mph-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  color: var(--crt-green, #39ff14);
+  text-shadow: 0 0 8px var(--crt-green, #39ff14);
+  background: rgba(4, 10, 6, 0.85);
+  padding: 6px 14px;
+  border: 1px solid rgba(57, 255, 20, 0.4);
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+.mph-cancel {
+  pointer-events: all;
+  background: rgba(248, 81, 73, 0.15);
+  border: 1px solid rgba(248, 81, 73, 0.5);
+  color: #f85149;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.8px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  min-height: 44px;
+  min-width: 44px;
+}
+
+/* ── Landscape orientation overlay ── */
+.battlefield-landscape-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 10, 6, 0.97);
+  z-index: 9999;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 16px;
+  font-family: var(--font-mono);
+  text-align: center;
+  padding: 24px;
+}
+
+.blo-icon {
+  font-size: 48px;
+  color: var(--crt-green, #39ff14);
+  text-shadow: 0 0 20px var(--crt-green, #39ff14);
+  animation: blo-spin 2s linear infinite;
+}
+
+@keyframes blo-spin {
+  0% { transform: rotate(0deg); }
+  25% { transform: rotate(90deg); }
+  50% { transform: rotate(90deg); }
+  100% { transform: rotate(90deg); }
+}
+
+.blo-title {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 4px;
+  color: var(--crt-green, #39ff14);
+  text-shadow: 0 0 12px var(--crt-green, #39ff14);
+}
+
+.blo-sub {
+  font-size: 12px;
+  color: var(--text-2, #4dcc00);
+  letter-spacing: 0.5px;
+  line-height: 1.6;
+}
+
+/* ── HUD Overflow Panel (mobile) ── */
+.hud-overflow-wrap {
+  position: relative;
+}
+
+.hud-overflow-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: rgba(4, 10, 6, 0.98);
+  border: 1px solid rgba(57, 255, 20, 0.4);
+  border-radius: 6px;
+  padding: 4px;
+  min-width: 140px;
+  z-index: 30;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.8);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hud-overflow-item {
+  width: 100%;
+  justify-content: flex-start !important;
+  padding: 8px 10px !important;
+  font-size: 10px !important;
+  min-height: 36px;
+}
+
+/* ── MapEditor mobile block ── */
+.map-editor-mobile-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 16px;
+  text-align: center;
+  padding: 32px 24px;
+  font-family: var(--font-mono);
+}
+
+.meb-icon {
+  font-size: 40px;
+  color: var(--crt-green, #39ff14);
+  text-shadow: 0 0 12px var(--crt-green, #39ff14);
+}
+
+.meb-title {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 3px;
+  color: var(--crt-green, #39ff14);
+  text-shadow: 0 0 8px var(--crt-green, #39ff14);
+}
+
+.meb-sub {
+  font-size: 12px;
+  color: var(--text-2, #4dcc00);
+  line-height: 1.7;
+  max-width: 320px;
+}
+
+/* ══════════════════════════════════════════════════════════
+   Responsive overrides for mobile (≤ 480px)
+   ══════════════════════════════════════════════════════════ */
+
+@media (max-width: 480px) {
+  /* Touch targets: all HUD buttons at least 44×44px */
+  .hud-btn {
+    min-height: 44px;
+    min-width: 44px;
+    padding: 4px 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Show/hide mobile vs desktop HUD elements */
+  .hud-desktop-only {
+    display: none !important;
+  }
+  .hud-mobile-only {
+    display: inline-flex;
+  }
+
+  /* Show placement hint on mobile */
+  .mobile-placement-hint {
+    display: flex;
+  }
+
+  /* Show landscape overlay when in portrait */
+  .battlefield-landscape-overlay {
+    display: flex;
+  }
+
+  /* Sidebar: full-screen drawer */
+  :root {
+    --sidebar-width: 0px;
+  }
+
+  .sidebar {
+    position: fixed;
+    left: -260px;
+    top: 0;
+    height: 100vh;
+    width: 240px;
+    z-index: 1001;
+    transition: left 0.25s ease;
+    padding: 16px 16px 20px;
+    gap: 20px;
+    align-items: flex-start;
+    overflow: hidden auto;
+  }
+
+  .sidebar.sidebar-open {
+    left: 0;
+    box-shadow: 4px 0 32px rgba(0, 0, 0, 0.8);
+  }
+
+  .sidebar-logo-img {
+    width: 120px;
+    height: 120px;
+  }
+
+  .nav-label {
+    display: inline !important;
+  }
+
+  .nav-icon {
+    font-size: 14px;
+  }
+
+  .sidebar-stats,
+  .sidebar-status,
+  .sidebar-version {
+    display: flex !important;
+  }
+
+  /* Backdrop */
+  .sidebar-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 1000;
+  }
+
+  /* Hamburger button in top-left */
+  .sidebar-hamburger {
+    display: flex;
+    position: fixed;
+    top: 8px;
+    left: 8px;
+    z-index: 999;
+    background: rgba(4, 10, 6, 0.92);
+    border: 1px solid rgba(57, 255, 20, 0.4);
+    color: var(--crt-green, #39ff14);
+    font-size: 16px;
+    padding: 6px 10px;
+    cursor: pointer;
+    border-radius: 4px;
+    min-height: 44px;
+    min-width: 44px;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+  }
+
+  /* Main content takes full width since sidebar is off-canvas */
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+
+  /* Minimap repositioning to not overlap mobile chrome */
+  .minimap {
+    bottom: 16px;
+    right: 8px;
+  }
+
+  /* Place banners above minimap area */
+  .battlefield-placement-banner,
+  .battlefield-relocate-banner {
+    bottom: 70px;
+    font-size: 10px;
+  }
+
+  /* Zoom bubble: bigger touch target */
+  .hud-zoom-btn {
+    min-height: 44px;
+    min-width: 44px;
+    font-size: 18px;
+    font-weight: 600;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════
+   Tablet responsive (481–768px): show mobile-only elements
+   too for touch interactions, but keep sidebar
+   ══════════════════════════════════════════════════════════ */
+
+@media (min-width: 481px) and (max-width: 768px) {
+  .hud-btn {
+    min-height: 36px;
+    min-width: 36px;
+  }
+}
+

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -6289,6 +6289,10 @@ select.input {
    ══════════════════════════════════════════════════════════ */
 
 @media (min-width: 481px) and (max-width: 768px) {
+  .battlefield-landscape-overlay {
+    display: flex;
+  }
+
   .hud-btn {
     min-height: 36px;
     min-width: 36px;


### PR DESCRIPTION
Implements mobile responsive design and multi-touch navigation for the Battlefield view.

## Changes
- Pinch-to-zoom + two-finger pan via native touch events
- Long-press context menu (500ms) with SCAN/BUILD/RELOCATE actions
- Minimap hidden by default on mobile, toggled via HUD button
- Landscape orientation overlay on portrait ≤768px
- Mobile HUD overflow menu (⋯) for secondary actions
- Mobile sidebar drawer with hamburger button
- MapEditor blocked on phones (≤480px), tablet-only message
- user-scalable=no viewport meta

Closes #322

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added touch gesture support including tap, long-press, and pinch-zoom on the battlefield.
  * Implemented mobile-responsive sidebar navigation with hamburger toggle.
  * Added long-press context menu for strategic actions on the battlefield.
  * Introduced mobile HUD overflow menu consolidating desktop controls into a collapsible panel.
  * Added minimap toggle control for flexible screen space management.
  * Implemented mobile placement hints and landscape orientation warnings.
  * Map Editor now requires minimum tablet width for accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->