### PR TITLE
feat: use SVG icons for repo setup indicators

### DIFF
--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 import type { DashboardEntry, GHPR, GHIssue, Branch, WorkflowRun, RepoMeta } from '../types'
 import { getPROrigin, getRepoUrl, getMRLabel } from '../types'
 import type { ModalState } from './ActionModal'
-import { CloseIcon, LinkIcon, LabelIcon, CommentIcon, RefreshIcon, ExternalLinkIcon, AssigneeIcon, CopyIcon } from './Icons'
+import { CloseIcon, LinkIcon, LabelIcon, CommentIcon, RefreshIcon, ExternalLinkIcon, AssigneeIcon, CopyIcon, ClaudeWorkflowIcon, ReleasePleaseIcon, CodeRabbitIcon } from './Icons'
 import { api } from '../api'
 import { BranchSilo } from './BranchBuilding'
 import { useAppStore } from '../store'
@@ -310,6 +310,27 @@ export function BaseNode({ entry, position, isRelocateMode, isBeingRelocated, on
             : <IsoBaseBuilding color={repo.color || '#00ff88'} />
           }
         </div>
+
+        {/* Setup indicators — small icons showing which integrations are configured */}
+        {(data.hasClaudeYml || data.hasPleaseRelease || data.hasCodeRabbit) && (
+          <div className="base-setup-indicators">
+            {data.hasClaudeYml && (
+              <span className="setup-indicator si-claude" title="Claude Code Workflow configured">
+                <ClaudeWorkflowIcon size={10} />
+              </span>
+            )}
+            {data.hasPleaseRelease && (
+              <span className="setup-indicator si-release" title="Release Please configured">
+                <ReleasePleaseIcon size={10} />
+              </span>
+            )}
+            {data.hasCodeRabbit && (
+              <span className="setup-indicator si-coderabbit" title="CodeRabbit configured">
+                <CodeRabbitIcon size={10} />
+              </span>
+            )}
+          </div>
+        )}
 
         {/* Floating HUD toolbar — appears on hover */}
         <div className="base-hud">

--- a/gh-ctrl/client/src/components/Icons.tsx
+++ b/gh-ctrl/client/src/components/Icons.tsx
@@ -205,3 +205,40 @@ export function GitLabIcon({ size = 16, className, title }: IconProps) {
     </svg>
   )
 }
+
+export function ClaudeWorkflowIcon({ size = 12, className, title }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden={!title} role={title ? 'img' : undefined}>
+      {title && <title>{title}</title>}
+      <rect x="3" y="5" width="10" height="8" rx="2" stroke="currentColor" strokeWidth="1.5" />
+      <circle cx="6" cy="9" r="1" fill="currentColor" />
+      <circle cx="10" cy="9" r="1" fill="currentColor" />
+      <line x1="6.5" y1="11" x2="9.5" y2="11" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="8" y1="2" x2="8" y2="5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="8" cy="2" r="0.8" fill="currentColor" />
+    </svg>
+  )
+}
+
+export function ReleasePleaseIcon({ size = 12, className, title }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden={!title} role={title ? 'img' : undefined}>
+      {title && <title>{title}</title>}
+      <path d="M2 2h5.5l6.5 6.5-5.5 5.5L2 7.5V2z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+      <circle cx="5.5" cy="5.5" r="1.2" fill="currentColor" />
+    </svg>
+  )
+}
+
+export function CodeRabbitIcon({ size = 12, className, title }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden={!title} role={title ? 'img' : undefined}>
+      {title && <title>{title}</title>}
+      <path d="M5.5 7.5V3.5C5.5 2.5 4 2 4 3.5V6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M10.5 7.5V3.5C10.5 2.5 12 2 12 3.5V6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <ellipse cx="8" cy="10.5" rx="4" ry="3.5" stroke="currentColor" strokeWidth="1.5" />
+      <circle cx="6.5" cy="10" r="0.8" fill="currentColor" />
+      <circle cx="9.5" cy="10" r="0.8" fill="currentColor" />
+    </svg>
+  )
+}

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -1948,6 +1948,45 @@ select.input {
   opacity: 0.7;
 }
 
+/* Setup indicators — small SVG icons below the building showing configured integrations */
+.base-setup-indicators {
+  position: absolute;
+  bottom: -16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 3px;
+  z-index: 3;
+}
+
+.setup-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+  background: rgba(8, 12, 18, 0.75);
+  opacity: 0.85;
+  transition: opacity 0.15s;
+}
+
+.setup-indicator:hover {
+  opacity: 1;
+}
+
+.si-claude {
+  color: var(--purple, #a855f7);
+}
+
+.si-release {
+  color: var(--crt-green, #00ff88);
+}
+
+.si-coderabbit {
+  color: var(--crt-amber, #fbbf24);
+}
+
 /* Building graphic — isometric PNG building */
 .base-building {
   position: relative;

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -122,6 +122,8 @@ export interface RepoData {
   branches: Branch[]
   defaultBranch: string
   hasClaudeYml: boolean
+  hasPleaseRelease: boolean
+  hasCodeRabbit: boolean
   error: string | null
 }
 

--- a/gh-ctrl/src/providers/gitlab.ts
+++ b/gh-ctrl/src/providers/gitlab.ts
@@ -218,6 +218,8 @@ export async function fetchGitLabRepoData(
     branches: [],
     defaultBranch: 'main',
     hasClaudeYml: false,
+    hasPleaseRelease: false,
+    hasCodeRabbit: false,
     error: null,
   }
 
@@ -287,6 +289,8 @@ export async function fetchGitLabRepoData(
     branches,
     defaultBranch,
     hasClaudeYml: false,
+    hasPleaseRelease: false,
+    hasCodeRabbit: false,
     error: null,
   }
 }

--- a/gh-ctrl/src/providers/types.ts
+++ b/gh-ctrl/src/providers/types.ts
@@ -86,7 +86,9 @@ export interface NormalizedRepoData {
   runningWorkflows: NormalizedPipeline[]
   branches: NormalizedBranch[]
   defaultBranch: string
-  hasClaudeYml: false
+  hasClaudeYml: boolean
+  hasPleaseRelease: boolean
+  hasCodeRabbit: boolean
   error: string | null
 }
 

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -259,6 +259,8 @@ async function fetchRepoData(fullName: string) {
       branches: [],
       defaultBranch: 'main',
       hasClaudeYml: false,
+      hasPleaseRelease: false,
+      hasCodeRabbit: false,
       error: prResult.error || issueResult.error,
     }
   }

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -176,6 +176,22 @@ async function checkClaudeYml(fullName: string): Promise<boolean> {
   return result.error === null && result.data !== null
 }
 
+async function checkPleaseRelease(fullName: string): Promise<boolean> {
+  const [config, manifest] = await Promise.all([
+    gh(['api', `repos/${fullName}/contents/release-please-config.json`]),
+    gh(['api', `repos/${fullName}/contents/.release-please-manifest.json`]),
+  ])
+  return (config.error === null && config.data !== null) || (manifest.error === null && manifest.data !== null)
+}
+
+async function checkCodeRabbit(fullName: string): Promise<boolean> {
+  const [yml, yaml] = await Promise.all([
+    gh(['api', `repos/${fullName}/contents/.coderabbit.yaml`]),
+    gh(['api', `repos/${fullName}/contents/.coderabbit.yml`]),
+  ])
+  return (yml.error === null && yml.data !== null) || (yaml.error === null && yaml.data !== null)
+}
+
 async function fetchRepoBranches(fullName: string): Promise<{ branches: { name: string; committedDate: string }[]; defaultBranch: string }> {
   const [owner, name] = fullName.split('/')
   const graphqlQuery = `{
@@ -251,12 +267,14 @@ async function fetchRepoData(fullName: string) {
   const issues = issueResult.data || []
 
   // Netlify URLs depend on prs, but workflows and branches are independent
-  const [previewUrls, { activeClaudeIssues, runningWorkflows }, claudeIssueBranches, { branches, defaultBranch }, hasClaudeYml] = await Promise.all([
+  const [previewUrls, { activeClaudeIssues, runningWorkflows }, claudeIssueBranches, { branches, defaultBranch }, hasClaudeYml, hasPleaseRelease, hasCodeRabbit] = await Promise.all([
     fetchNetlifyUrls(fullName, prs),
     fetchRunningWorkflows(fullName),
     fetchClaudeIssueBranches(fullName),
     fetchRepoBranches(fullName),
     checkClaudeYml(fullName),
+    checkPleaseRelease(fullName),
+    checkCodeRabbit(fullName),
   ])
 
   const enrichedPrs = prs.map((pr: any) => ({
@@ -303,6 +321,8 @@ async function fetchRepoData(fullName: string) {
     branches,
     defaultBranch,
     hasClaudeYml,
+    hasPleaseRelease,
+    hasCodeRabbit,
     error: null,
   }
 }


### PR DESCRIPTION
Replace text symbols with custom SVG icons from Icons.tsx for the three setup indicator badges shown below each repo building: ClaudeWorkflowIcon (purple bot), ReleasePleaseIcon (green tag), CodeRabbitIcon (amber rabbit).

Also adds checkPleaseRelease() and checkCodeRabbit() detection functions and extends the type system throughout.

Closes #320

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visual setup indicators beneath repository bases that show configured integrations (Claude Workflow, Release Please, Code Rabbit). Each integration displays an icon with a descriptive tooltip when its configuration is detected. Icons are styled and positioned for consistent appearance and hover feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->