### PR TITLE
 chore: add Caddy reverse proxy and consolidate deployment config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,30 @@
+# ── Deployment ────────────────────────────────────────────────────────────────
+
+# Required — domain for Caddy (TLS cert will be issued for this)
+DOMAIN=yourdomain.com
+
+# ── GitHub ────────────────────────────────────────────────────────────────────
+
 # Required — all GitHub API calls will fail without this
 GH_TOKEN=your_github_token_here
-GITLAB_TOKEN=your_gitlab_token_here
+
+# ── GitLab (optional) ─────────────────────────────────────────────────────────
+
+# GITLAB_TOKEN=your_gitlab_token_here
+# GITLAB_INSTANCE_URL=https://gitlab.example.com
+
+# ── Keycloak auth (optional) ──────────────────────────────────────────────────
+# Leave all three unset to run without authentication.
+# Backend (JWT validation) and frontend (OIDC login) must match.
+
+# KEYCLOAK_URL=https://keycloak.example.com
+# KEYCLOAK_REALM=myrealm
+# KEYCLOAK_CLIENT_ID=vibe-and-conquer
+
+# Frontend — baked into the JS bundle at Docker build time (VITE_ prefix required)
+# VITE_KEYCLOAK_URL=https://keycloak.example.com
+# VITE_KEYCLOAK_REALM=myrealm
+# VITE_KEYCLOAK_CLIENT_ID=vibe-and-conquer
+
+# ── CORS ──────────────────────────────────────────────────────────────────────
+# ALLOWED_ORIGINS=https://yourdomain.com

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,25 @@
+# Domain is read from the DOMAIN env var (set in .env)
+{env.DOMAIN} {
+
+    # SSE + WebSocket: disable buffering and extend timeouts
+    @streaming {
+        path /api/github/stream* /api/gitlab/stream* /api/buildings/*/clawcom/stream*
+    }
+    reverse_proxy @streaming app:3001 {
+        flush_interval -1
+        transport http {
+            read_timeout 1h
+        }
+    }
+
+    # WebSocket for the shell route
+    @websocket {
+        path /api/shell*
+        header Connection *Upgrade*
+        header Upgrade websocket
+    }
+    reverse_proxy @websocket app:3001
+
+    # Everything else
+    reverse_proxy app:3001
+}

--- a/compose.yml
+++ b/compose.yml
@@ -4,12 +4,49 @@ services:
     build:
       context: ./gh-ctrl
       target: runtime
-    ports:
-      - "3001:3001"
-    environment:
-      - GH_TOKEN=${GH_TOKEN}
+      args:
+        VITE_KEYCLOAK_URL: ${VITE_KEYCLOAK_URL:-}
+        VITE_KEYCLOAK_REALM: ${VITE_KEYCLOAK_REALM:-}
+        VITE_KEYCLOAK_CLIENT_ID: ${VITE_KEYCLOAK_CLIENT_ID:-}
+    image: gh-ctrl:latest
+    container_name: gh-ctrl
+    restart: unless-stopped
+    expose:
+      - "3001"
+    env_file:
+      - .env
     volumes:
       - gh-ctrl-data:/app/data
+      - gh-ctrl-uploads:/app/uploads
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  caddy:
+    profiles: [prod]
+    image: caddy:2-alpine
+    container_name: gh-ctrl-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    env_file:
+      - .env
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    networks:
+      - internal
+    depends_on:
+      app:
+        condition: service_healthy
 
   app-dev:
     profiles: [dev]
@@ -19,12 +56,19 @@ services:
     ports:
       - "3001:3001"
       - "5173:5173"
-    environment:
-      - GH_TOKEN=${GH_TOKEN}
+    env_file:
+      - .env
     volumes:
       - ./gh-ctrl/src:/app/src
       - ./gh-ctrl/client/src:/app/client/src
       - gh-ctrl-data:/app/data
+      - gh-ctrl-uploads:/app/uploads
+
+networks:
+  internal:
 
 volumes:
   gh-ctrl-data:
+  gh-ctrl-uploads:
+  caddy-data:
+  caddy-config:

--- a/gh-ctrl/.env.example
+++ b/gh-ctrl/.env.example
@@ -1,3 +1,6 @@
+# Required — domain for the Caddy reverse proxy (TLS cert will be issued for this)
+DOMAIN=yourdomain.com
+
 # Required — all GitHub API calls will fail without this
 GH_TOKEN=your_github_token_here
 

--- a/gh-ctrl/Dockerfile
+++ b/gh-ctrl/Dockerfile
@@ -13,6 +13,15 @@ RUN cd client && bun install
 
 # Copy source and build frontend
 COPY . .
+
+# Keycloak OIDC vars are baked into the JS bundle at build time
+ARG VITE_KEYCLOAK_URL=""
+ARG VITE_KEYCLOAK_REALM=""
+ARG VITE_KEYCLOAK_CLIENT_ID=""
+ENV VITE_KEYCLOAK_URL=$VITE_KEYCLOAK_URL
+ENV VITE_KEYCLOAK_REALM=$VITE_KEYCLOAK_REALM
+ENV VITE_KEYCLOAK_CLIENT_ID=$VITE_KEYCLOAK_CLIENT_ID
+
 RUN cd client && bunx vite build
 
 # ── Stage 2: runtime (production) ────────────────────────────────────────────


### PR DESCRIPTION
  - Add Caddy service to compose.yml with automatic TLS, SSE flush, and WebSocket support; domain read from DOMAIN env var to avoid Caddyfile conflicts on git pull
  - Add Caddyfile with matchers for SSE streaming and WebSocket routes
  - Pass VITE_KEYCLOAK_* as Docker build args so they are baked into the JS bundle at build time
  - Merge all env vars into a single root .env.example (backend, frontend, Keycloak, GitLab, CORS, DOMAIN)
  - Add uploads volume, restart policy, healthcheck, and internal network to prod services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Caddy reverse proxy support with custom domain configuration for TLS
  * Added optional Keycloak OIDC authentication support
  * Added optional GitLab integration configuration options
  * Added CORS configuration support

* **Chores**
  * Updated Docker compose services and networking infrastructure
  * Enhanced environment variable configuration structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->