### PR TITLE
feat: finish Terminal UX/UI

### DIFF
--- a/gh-ctrl/client/src/components/RemoteShellSetupDialog.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellSetupDialog.tsx
@@ -66,6 +66,7 @@ export function RemoteShellSetupDialog({ building, onClose, onConfigured, onOpen
   const [fontSize, setFontSize]             = useState(String(existingConfig.fontSize ?? 14))
   const [fontFamily, setFontFamily]         = useState(existingConfig.fontFamily ?? 'monospace')
   const [theme, setTheme]                   = useState<RemoteShellConfig['theme']>(existingConfig.theme ?? 'dark')
+  const [defaultConnectionId, setDefaultConnectionId] = useState<number | undefined>(existingConfig.defaultConnectionId)
 
   // Test state
   const [testState, setTestState]           = useState<'idle' | 'testing' | 'ok' | 'error'>('idle')
@@ -212,8 +213,30 @@ export function RemoteShellSetupDialog({ building, onClose, onConfigured, onOpen
         fontSize: Number(fontSize) || 14,
         fontFamily: fontFamily.trim() || 'monospace',
         theme,
+        ...(defaultConnectionId !== undefined ? { defaultConnectionId } : {}),
       }
       await api.updateBuilding(building.id, { config: newConfig })
+      await loadBuildings()
+    } catch (err: any) {
+      onError(err.message)
+    }
+  }
+
+  async function handleSetDefault(id: number) {
+    try {
+      const existing: Record<string, unknown> = (() => {
+        try { return JSON.parse(building.config) } catch { return {} }
+      })()
+      const newConfig: RemoteShellConfig = {
+        ...existing,
+        configured: connections.length > 0,
+        fontSize: Number(fontSize) || 14,
+        fontFamily: fontFamily.trim() || 'monospace',
+        theme,
+        defaultConnectionId: id,
+      }
+      await api.updateBuilding(building.id, { config: newConfig })
+      setDefaultConnectionId(id)
       await loadBuildings()
     } catch (err: any) {
       onError(err.message)
@@ -286,7 +309,15 @@ export function RemoteShellSetupDialog({ building, onClose, onConfigured, onOpen
                 }}
               >
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ color: '#00ff88', fontSize: 12, fontWeight: 700 }}>{conn.label}</div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ color: '#00ff88', fontSize: 12, fontWeight: 700 }}>{conn.label}</span>
+                    {defaultConnectionId === conn.id && (
+                      <span style={{
+                        fontSize: 9, color: '#ffcc00', background: '#ffcc0022',
+                        border: '1px solid #ffcc0044', borderRadius: 2, padding: '0 4px',
+                      }}>DEFAULT</span>
+                    )}
+                  </div>
                   <div style={{ color: 'var(--text-dim)', fontSize: 10 }}>
                     {conn.username}@{conn.host}:{conn.port ?? 22}
                     {conn.authType && <> · {conn.authType}</>}
@@ -294,6 +325,16 @@ export function RemoteShellSetupDialog({ building, onClose, onConfigured, onOpen
                     {!conn.hasCredentials && <span style={{ color: '#ff4444' }}> · no creds</span>}
                   </div>
                 </div>
+                <button
+                  className="hud-btn"
+                  style={{
+                    fontSize: 11,
+                    padding: '1px 5px',
+                    color: defaultConnectionId === conn.id ? '#ffcc00' : '#555',
+                  }}
+                  title={defaultConnectionId === conn.id ? 'Default connection' : 'Set as default'}
+                  onClick={() => handleSetDefault(conn.id)}
+                >★</button>
                 <button
                   className="hud-btn"
                   style={{ fontSize: 9 }}

--- a/gh-ctrl/client/src/components/RemoteShellTerminalDialog.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellTerminalDialog.tsx
@@ -21,10 +21,11 @@ export function RemoteShellTerminalDialog({
   onReconfigure,
   addToast,
 }: RemoteShellTerminalDialogProps) {
-  const [connections, setConnections] = useState<SshConnection[]>([])
-  const [tabs, setTabs]               = useState<TabSession[]>([])
-  const [activeTabId, setActiveTabId] = useState<string>('')
-  const [loading, setLoading]         = useState(true)
+  const [connections, setConnections]     = useState<SshConnection[]>([])
+  const [tabs, setTabs]                   = useState<TabSession[]>([])
+  const [activeTabId, setActiveTabId]     = useState<string>('')
+  const [loading, setLoading]             = useState(true)
+  const [showNewTabMenu, setShowNewTabMenu] = useState(false)
 
   const config: Partial<RemoteShellConfig> = (() => {
     try { return JSON.parse(building.config) } catch { return {} }
@@ -46,6 +47,14 @@ export function RemoteShellTerminalDialog({
       .finally(() => setLoading(false))
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [building.id])
+
+  // Close the new-tab dropdown when clicking outside
+  useEffect(() => {
+    if (!showNewTabMenu) return
+    const handler = () => setShowNewTabMenu(false)
+    window.addEventListener('click', handler)
+    return () => window.removeEventListener('click', handler)
+  }, [showNewTabMenu])
 
   function openNewTab(connection: SshConnection) {
     const newTab: TabSession = { id: `tab-${Date.now()}`, connection }
@@ -133,26 +142,44 @@ export function RemoteShellTerminalDialog({
 
         {/* Add tab button */}
         {connections.length > 0 && (
-          <div style={{ position: 'relative' }}>
-            <select
-              style={{
-                background: 'transparent', border: '1px solid #333',
-                color: '#888', fontSize: 11, cursor: 'pointer', borderRadius: 3,
-                padding: '2px 6px', marginLeft: 4,
-              }}
-              value=""
-              onChange={(e) => {
-                const conn = connections.find((c) => String(c.id) === e.target.value)
-                if (conn) openNewTab(conn)
-                e.target.value = ''
-              }}
-              title="Open new tab"
-            >
-              <option value="" disabled>+ New Tab</option>
-              {connections.map((c) => (
-                <option key={c.id} value={String(c.id)}>{c.label}</option>
-              ))}
-            </select>
+          <div style={{ position: 'relative', marginLeft: 4 }}>
+            {connections.length === 1 ? (
+              <button
+                className="hud-btn"
+                style={{ fontSize: 11, padding: '2px 8px' }}
+                onClick={() => openNewTab(connections[0])}
+                title={`New tab: ${connections[0].label}`}
+              >+ TAB</button>
+            ) : (
+              <>
+                <button
+                  className="hud-btn"
+                  style={{ fontSize: 11, padding: '2px 8px', color: showNewTabMenu ? '#00ff88' : '#888' }}
+                  title="Open new tab"
+                  onClick={(e) => { e.stopPropagation(); setShowNewTabMenu((v) => !v) }}
+                >+ TAB ▾</button>
+                {showNewTabMenu && (
+                  <div style={{
+                    position: 'absolute', top: '100%', left: 0, marginTop: 2,
+                    background: '#111', border: '1px solid #333', borderRadius: 3,
+                    zIndex: 200, minWidth: 160,
+                  }}>
+                    {connections.map((c) => (
+                      <div
+                        key={c.id}
+                        style={{
+                          padding: '5px 10px', cursor: 'pointer',
+                          fontSize: 11, color: '#aaa', whiteSpace: 'nowrap',
+                        }}
+                        onMouseEnter={(e) => { e.currentTarget.style.background = '#222'; e.currentTarget.style.color = '#00ff88' }}
+                        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = '#aaa' }}
+                        onClick={() => { openNewTab(c); setShowNewTabMenu(false) }}
+                      >▸ {c.label}</div>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
           </div>
         )}
       </div>

--- a/gh-ctrl/client/src/components/RemoteShellTerminalTab.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellTerminalTab.tsx
@@ -110,6 +110,10 @@ export function RemoteShellTerminalTab({
   const [status, setStatus] = useState<ShellStatus>('connecting')
   const [statusMsg, setStatusMsg] = useState('')
 
+  // Local font size override (per-tab, starts from prop, changed via +/- buttons)
+  const [localFontSize, setLocalFontSize] = useState(fontSize)
+  const isFontSizeInit = useRef(true)
+
   // Search bar state
   const [searchVisible, setSearchVisible] = useState(false)
   const [searchQuery, setSearchQuery]     = useState('')
@@ -307,6 +311,23 @@ export function RemoteShellTerminalTab({
     }
   }, [searchVisible])
 
+  // Sync localFontSize when the prop changes (e.g. user saved new value in setup dialog)
+  useEffect(() => {
+    setLocalFontSize(fontSize)
+  }, [fontSize])
+
+  // Dynamically update terminal font size without recreating it
+  useEffect(() => {
+    if (isFontSizeInit.current) {
+      isFontSizeInit.current = false
+      return
+    }
+    const term = termRef.current
+    if (!term) return
+    term.options.fontSize = localFontSize
+    setTimeout(() => fitAddonRef.current?.fit(), 50)
+  }, [localFontSize])
+
   function handleSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Escape') {
       setSearchVisible(false)
@@ -324,6 +345,12 @@ export function RemoteShellTerminalTab({
     wsRef.current?.close()
     wsRef.current = null
     connectWS()
+  }
+
+  // ── Clear terminal buffer ──────────────────────────────────────────────────
+  function handleClear() {
+    termRef.current?.clear()
+    termRef.current?.focus()
   }
 
   // ── Send tmux sequence ─────────────────────────────────────────────────────
@@ -394,6 +421,27 @@ export function RemoteShellTerminalTab({
             title="Reconnect"
           >⟳ RECONNECT</button>
         )}
+        {/* Font size controls */}
+        <button
+          className="hud-btn"
+          style={{ fontSize: 9, padding: '0 5px' }}
+          onClick={() => setLocalFontSize((s) => Math.max(8, s - 1))}
+          title="Decrease font size"
+        >A−</button>
+        <span style={{ fontSize: 9, color: '#555', minWidth: 18, textAlign: 'center' }}>{localFontSize}</span>
+        <button
+          className="hud-btn"
+          style={{ fontSize: 9, padding: '0 5px' }}
+          onClick={() => setLocalFontSize((s) => Math.min(32, s + 1))}
+          title="Increase font size"
+        >A+</button>
+        {/* Clear buffer */}
+        <button
+          className="hud-btn"
+          style={{ fontSize: 9, padding: '1px 6px', color: '#666' }}
+          onClick={handleClear}
+          title="Clear terminal buffer"
+        >⌫</button>
         {/* Search toggle */}
         <button
           className="hud-btn"


### PR DESCRIPTION
Finishes the UX and UI for the RemotePost / Terminal building:

- Set as Default connection with star button ★ and DEFAULT badge
- Font size +/- controls in terminal status bar (per-tab, live update)
- Clear buffer button ⌫ in status bar
- + TAB button with dropdown replacing <select>

Closes #329

Generated with [Claude Code](https://claude.ai/code)