### PR TITLE
fix: close side panels in mobile landscape view

### DIFF
--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -98,7 +98,16 @@ export function BattlefieldView() {
   const autoScanTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
-    const onResize = () => setIsPortrait(window.innerWidth < window.innerHeight && window.innerWidth <= 768)
+    const onResize = () => {
+      setIsPortrait(window.innerWidth < window.innerHeight && window.innerWidth <= 768)
+      // Close side panels when entering mobile landscape to free up space
+      if (window.innerWidth > window.innerHeight && window.innerWidth <= 768) {
+        setShowFeedPanel(false)
+        setShowTimers(false)
+        setBranchSiloEntry(null)
+        setDetailEntry(null)
+      }
+    }
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
   }, [])

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -6338,3 +6338,13 @@ select.input {
   }
 }
 
+/* Hide side panels in mobile landscape — they eat the entire viewport */
+@media (max-width: 768px) and (orientation: landscape) {
+  .feed-panel,
+  .silo-panel,
+  .dt-panel,
+  .base-detail-side-panel {
+    display: none !important;
+  }
+}
+


### PR DESCRIPTION
Fixes #336

In mobile landscape mode, open side panels were staying visible and blocking the battlefield canvas.

**Changes:**
- Auto-close all side panels when rotating to mobile landscape (resize handler in `BattlefieldView.tsx`)
- CSS fallback to hide panels in `@media (max-width: 768px) and (orientation: landscape)`

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced mobile landscape experience with automatic closure of UI panels and responsive hiding of side panels when viewing on mobile devices in landscape orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->