### PR TITLE
feat: allow GitHub and GitLab PAT configuration in application settings

### DIFF
--- a/gh-ctrl/client/src/components/Settings.tsx
+++ b/gh-ctrl/client/src/components/Settings.tsx
@@ -36,6 +36,73 @@ export function Settings() {
   const [connStatus, setConnStatus] = useState<'idle' | 'ok' | 'error'>('idle')
   const [connError, setConnError] = useState('')
 
+  // API Credentials state
+  const [githubTokenInput, setGithubTokenInput] = useState('')
+  const [gitlabTokenInput, setGitlabTokenInput] = useState('')
+  const [githubTokenSet, setGithubTokenSet] = useState(false)
+  const [gitlabTokenSet, setGitlabTokenSet] = useState(false)
+  const [savingGithubToken, setSavingGithubToken] = useState(false)
+  const [savingGitlabToken, setSavingGitlabToken] = useState(false)
+
+  useEffect(() => {
+    api.getAllSettings().then((s) => {
+      setGithubTokenSet(!!s['GITHUB_TOKEN'])
+      setGitlabTokenSet(!!s['GITLAB_TOKEN'])
+    }).catch(() => {})
+  }, [])
+
+  const handleSaveGithubToken = async () => {
+    if (!githubTokenInput.trim()) return
+    setSavingGithubToken(true)
+    try {
+      await api.putSetting('GITHUB_TOKEN', githubTokenInput.trim())
+      setGithubTokenSet(true)
+      setGithubTokenInput('')
+      addToast('GitHub token saved', 'success')
+    } catch (err: any) {
+      addToast(`Failed to save GitHub token: ${err.message}`, 'error')
+    } finally {
+      setSavingGithubToken(false)
+    }
+  }
+
+  const handleClearGithubToken = async () => {
+    try {
+      await api.deleteSetting('GITHUB_TOKEN')
+      setGithubTokenSet(false)
+      setGithubTokenInput('')
+      addToast('GitHub token cleared', 'info')
+    } catch (err: any) {
+      addToast(`Failed to clear GitHub token: ${err.message}`, 'error')
+    }
+  }
+
+  const handleSaveGitlabToken = async () => {
+    if (!gitlabTokenInput.trim()) return
+    setSavingGitlabToken(true)
+    try {
+      await api.putSetting('GITLAB_TOKEN', gitlabTokenInput.trim())
+      setGitlabTokenSet(true)
+      setGitlabTokenInput('')
+      addToast('GitLab token saved', 'success')
+    } catch (err: any) {
+      addToast(`Failed to save GitLab token: ${err.message}`, 'error')
+    } finally {
+      setSavingGitlabToken(false)
+    }
+  }
+
+  const handleClearGitlabToken = async () => {
+    try {
+      await api.deleteSetting('GITLAB_TOKEN')
+      setGitlabTokenSet(false)
+      setGitlabTokenInput('')
+      addToast('GitLab token cleared', 'info')
+    } catch (err: any) {
+      addToast(`Failed to clear GitLab token: ${err.message}`, 'error')
+    }
+  }
+
   const handleSaveServerUrl = async () => {
     setTestingConn(true)
     setConnStatus('idle')
@@ -344,6 +411,105 @@ export function Settings() {
           {connStatus === 'error' && (
             <span className="form-error">{connError}</span>
           )}
+        </div>
+      </div>
+
+      <div className="settings-section">
+        <h2>API Credentials</h2>
+        <p style={{ color: 'var(--text-2)', fontSize: '0.85rem', margin: '0 0 1rem' }}>
+          Store your Personal Access Tokens securely in the database. These override environment variables.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          {/* GitHub PAT */}
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.4rem' }}>
+              <GitHubIcon size={14} />
+              <span style={{ fontSize: '0.88rem', fontWeight: 600 }}>GitHub Personal Access Token</span>
+              {githubTokenSet && (
+                <span style={{ fontSize: '0.75rem', color: 'var(--green)', background: 'rgba(0,255,136,0.1)', padding: '1px 7px', borderRadius: '10px' }}>
+                  configured
+                </span>
+              )}
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <input
+                className="input"
+                type="password"
+                placeholder={githubTokenSet ? '●●●●●●●●●●●● (token stored — enter new to replace)' : 'ghp_xxxxxxxxxxxxxxxxxxxx'}
+                value={githubTokenInput}
+                onChange={(e) => setGithubTokenInput(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleSaveGithubToken()}
+                style={{ flex: 1 }}
+                autoComplete="off"
+              />
+              <button
+                className="btn btn-primary"
+                onClick={handleSaveGithubToken}
+                disabled={savingGithubToken || !githubTokenInput.trim()}
+                style={{ whiteSpace: 'nowrap' }}
+              >
+                {savingGithubToken ? 'Saving…' : 'Save'}
+              </button>
+              {githubTokenSet && (
+                <button
+                  className="btn btn-danger"
+                  onClick={handleClearGithubToken}
+                  style={{ whiteSpace: 'nowrap' }}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            <p style={{ fontSize: '0.75rem', color: 'var(--text-2)', margin: '0.3rem 0 0' }}>
+              Used by the <code>gh</code> CLI for GitHub API calls. Requires <code>repo</code> scope.
+            </p>
+          </div>
+
+          {/* GitLab PAT */}
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.4rem' }}>
+              <GitLabIcon size={14} />
+              <span style={{ fontSize: '0.88rem', fontWeight: 600 }}>GitLab Personal Access Token</span>
+              {gitlabTokenSet && (
+                <span style={{ fontSize: '0.75rem', color: 'var(--green)', background: 'rgba(0,255,136,0.1)', padding: '1px 7px', borderRadius: '10px' }}>
+                  configured
+                </span>
+              )}
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <input
+                className="input"
+                type="password"
+                placeholder={gitlabTokenSet ? '●●●●●●●●●●●● (token stored — enter new to replace)' : 'glpat-xxxxxxxxxxxxxxxxxxxx'}
+                value={gitlabTokenInput}
+                onChange={(e) => setGitlabTokenInput(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleSaveGitlabToken()}
+                style={{ flex: 1 }}
+                autoComplete="off"
+              />
+              <button
+                className="btn btn-primary"
+                onClick={handleSaveGitlabToken}
+                disabled={savingGitlabToken || !gitlabTokenInput.trim()}
+                style={{ whiteSpace: 'nowrap' }}
+              >
+                {savingGitlabToken ? 'Saving…' : 'Save'}
+              </button>
+              {gitlabTokenSet && (
+                <button
+                  className="btn btn-danger"
+                  onClick={handleClearGitlabToken}
+                  style={{ whiteSpace: 'nowrap' }}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            <p style={{ fontSize: '0.75rem', color: 'var(--text-2)', margin: '0.3rem 0 0' }}>
+              Global GitLab token — used when no per-repository token is set. Requires <code>read_api</code> scope.
+            </p>
+          </div>
         </div>
       </div>
 

--- a/gh-ctrl/src/routes/github.ts
+++ b/gh-ctrl/src/routes/github.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import { db } from '../db'
-import { repos } from '../db/schema'
+import { repos, settings } from '../db/schema'
+import { eq } from 'drizzle-orm'
 import { fetchGitLabRepoData } from '../providers/gitlab'
 
 interface GHResult {
@@ -9,8 +10,28 @@ interface GHResult {
   error: string | null
 }
 
+// Cache the GitHub token from DB with a 60-second TTL to avoid hitting SQLite on every `gh` call
+let _ghTokenCache: { value: string | null; expiry: number } | null = null
+
+async function getGithubTokenFromSettings(): Promise<string | null> {
+  const now = Date.now()
+  if (_ghTokenCache && now < _ghTokenCache.expiry) return _ghTokenCache.value
+  const row = await db.select().from(settings).where(eq(settings.key, 'GITHUB_TOKEN')).get()
+  const value = row?.value ?? null
+  _ghTokenCache = { value, expiry: now + 60_000 }
+  return value
+}
+
+/** Invalidate the cached GitHub token (called when the setting is updated). */
+export function invalidateGithubTokenCache() {
+  _ghTokenCache = null
+}
+
 async function gh(args: string[]): Promise<GHResult> {
-  const proc = Bun.spawn(['gh', ...args], { env: { ...process.env } })
+  const dbToken = await getGithubTokenFromSettings()
+  const env: Record<string, string | undefined> = { ...process.env }
+  if (dbToken) env['GH_TOKEN'] = dbToken
+  const proc = Bun.spawn(['gh', ...args], { env })
   const stdout = await new Response(proc.stdout).text()
   const exitCode = await proc.exited
   if (exitCode !== 0) {

--- a/gh-ctrl/src/routes/gitlab.ts
+++ b/gh-ctrl/src/routes/gitlab.ts
@@ -12,7 +12,7 @@
 
 import { Hono } from 'hono'
 import { db } from '../db'
-import { repos } from '../db/schema'
+import { repos, settings } from '../db/schema'
 import { eq } from 'drizzle-orm'
 import {
   glabApi,
@@ -45,8 +45,12 @@ async function resolveProject(
     .where(eq(repos.fullName, projectPath))
     .get()
 
+  // Check settings table for a global GitLab token configured via the UI
+  const settingsRow = await db.select().from(settings).where(eq(settings.key, 'GITLAB_TOKEN')).get()
+  const globalToken = settingsRow?.value ?? process.env.GITLAB_TOKEN ?? null
+
   const instanceUrl = row?.instanceUrl ?? process.env.GITLAB_INSTANCE_URL ?? null
-  const gitlabToken = row?.gitlabToken ?? process.env.GITLAB_TOKEN ?? null
+  const gitlabToken = row?.gitlabToken ?? globalToken
 
   return { projectPath, instanceUrl, gitlabToken }
 }

--- a/gh-ctrl/src/routes/setup.ts
+++ b/gh-ctrl/src/routes/setup.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { db } from '../db'
-import { repos } from '../db/schema'
+import { repos, settings } from '../db/schema'
+import { eq } from 'drizzle-orm'
 import fs from 'fs'
 
 const app = new Hono()
@@ -46,8 +47,9 @@ app.get('/status', async (c) => {
     dbDetail = err instanceof Error ? err.message : 'Unknown error'
   }
 
-  // Check 4: GitLab token (optional)
-  const gitlabToken = !!process.env.GITLAB_TOKEN
+  // Check 4: GitLab token (optional) — from env var or app settings
+  const gitlabSettingsRow = await db.select().from(settings).where(eq(settings.key, 'GITLAB_TOKEN')).get()
+  const gitlabToken = !!process.env.GITLAB_TOKEN || !!gitlabSettingsRow?.value
 
   const checks = [
     {
@@ -79,9 +81,7 @@ app.get('/status', async (c) => {
       detail: gitlabToken ? 'GitLab token configured' : 'No GitLab token found',
       fix: gitlabToken
         ? null
-        : mode === 'docker'
-        ? 'Add GITLAB_TOKEN=<your_token> to your .env file and restart the container'
-        : 'Set GITLAB_TOKEN env var to enable GitLab repository support',
+        : 'Set a GitLab Personal Access Token in Settings → API Credentials, or via the GITLAB_TOKEN environment variable',
     },
   ]
 


### PR DESCRIPTION
Resolves #338

Allows users to configure GitHub and GitLab Personal Access Tokens directly in the application Settings UI instead of relying solely on environment variables.

## Changes

- New "API Credentials" section in Settings with masked PAT inputs for GitHub and GitLab
- GitHub token stored as `GITHUB_TOKEN` in settings table, injected as `GH_TOKEN` env var for `gh` CLI
- GitLab token stored as `GITLAB_TOKEN` in settings table, checked before env var fallback
- Setup status screen now reflects tokens configured via UI

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "API Credentials" section to Settings page for managing GitHub and GitLab authentication tokens
  * Users can now save, view configured status, and clear API credentials securely within the app interface
  * Stored tokens are automatically used by the application for API requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->