### PR TITLE
feat: add Authelia, Authentik, and generic OIDC auth providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,48 @@ These workflows are the backbone of **ClawCom** — the dashboard's AI command l
 - Optional auth — disabled by default; enable by setting provider env vars
 - **Keycloak** — full OAuth2 / OpenID Connect (`KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`)
 - **Authentik** — OIDC wrapper (`AUTHENTIK_URL`, `AUTHENTIK_SLUG`)
-- **Generic OIDC** — works with Zitadel, Dex, Logto, Auth0, and others (`OIDC_JWKS_URL`, `OIDC_ISSUER`, `OIDC_AUDIENCE`)
+- **Generic OIDC** — works with Zitadel, Dex, Logto, Auth0, Clerk, and others (`OIDC_JWKS_URL`, `OIDC_ISSUER`, `OIDC_AUDIENCE`)
 - **Authelia** (proxy-level) — zero app changes; forward auth via Caddy; see [`docs/auth/authelia/`](docs/auth/authelia/)
 - User profile display in sidebar
+
+<details>
+<summary><strong>Clerk setup guide</strong></summary>
+
+Clerk uses the built-in generic OIDC provider. No extra dependencies are needed.
+
+**1. Create an OAuth application in the Clerk Dashboard**
+
+- Go to [Clerk Dashboard](https://dashboard.clerk.com) → **Configure** → **OAuth Applications** → **Create application**
+- Add your app URL as an **Allowed redirect URI** (e.g. `https://yourapp.com`)
+- Note the **Client ID** shown after creation
+
+**2. Find your Frontend API URL**
+
+In the Clerk Dashboard, go to **API Keys** and copy the **Frontend API URL**.  
+It looks like `https://your-app-id.clerk.accounts.dev` for development instances, or your custom domain for production.
+
+**3. Set environment variables**
+
+Frontend (`gh-ctrl/client/.env`):
+
+```env
+VITE_OIDC_AUTHORITY=https://your-app-id.clerk.accounts.dev
+VITE_OIDC_CLIENT_ID=<clerk-oauth-client-id>
+VITE_OIDC_REDIRECT_URI=https://yourapp.com
+VITE_OIDC_SCOPE=openid profile email
+```
+
+Backend (`gh-ctrl/.env`):
+
+```env
+OIDC_JWKS_URL=https://your-app-id.clerk.accounts.dev/.well-known/jwks.json
+OIDC_ISSUER=https://your-app-id.clerk.accounts.dev
+OIDC_AUDIENCE=<clerk-oauth-client-id>
+```
+
+Replace `your-app-id.clerk.accounts.dev` with your actual Frontend API URL and `<clerk-oauth-client-id>` with the Client ID from step 1. `VITE_OIDC_AUTHORITY` uses the OIDC discovery document (`/.well-known/openid-configuration`) Clerk exposes automatically — no extra configuration is required.
+
+</details>
 
 ### Other
 - Voice input (browser Speech API) for hands-free issue and PR creation

--- a/README.md
+++ b/README.md
@@ -199,7 +199,11 @@ These workflows are the backbone of **ClawCom** — the dashboard's AI command l
 - Label-trigger automation endpoint
 
 ### Authentication
-- Optional Keycloak (OAuth2 / OpenID Connect) integration
+- Optional auth — disabled by default; enable by setting provider env vars
+- **Keycloak** — full OAuth2 / OpenID Connect (`KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`)
+- **Authentik** — OIDC wrapper (`AUTHENTIK_URL`, `AUTHENTIK_SLUG`)
+- **Generic OIDC** — works with Zitadel, Dex, Logto, Auth0, and others (`OIDC_JWKS_URL`, `OIDC_ISSUER`, `OIDC_AUDIENCE`)
+- **Authelia** (proxy-level) — zero app changes; forward auth via Caddy; see [`docs/auth/authelia/`](docs/auth/authelia/)
 - User profile display in sidebar
 
 ### Other
@@ -223,7 +227,7 @@ These workflows are the backbone of **ClawCom** — the dashboard's AI command l
 | GitHub API | GitHub CLI (`gh`) |
 | GitLab API | REST API (with self-hosted instance support) |
 | State Management | [Zustand](https://github.com/pmndrs/zustand) |
-| Auth (optional) | Keycloak (OAuth2 / OpenID Connect) |
+| Auth (optional) | Keycloak · Authentik · Generic OIDC · Authelia (proxy) |
 
 ## Project Structure
 

--- a/docs/auth/authelia/Caddyfile
+++ b/docs/auth/authelia/Caddyfile
@@ -1,0 +1,42 @@
+# Vibe and Conquer — Caddy + Authelia forward_auth example
+#
+# Authelia acts as a forward auth server in front of the app.
+# Caddy checks every request against Authelia before proxying it to the backend.
+# No changes to the Vibe and Conquer app itself are required.
+#
+# Flow:
+#   Browser → Caddy → Authelia (verify) → Caddy → Vibe and Conquer
+#                          ↓ not authenticated
+#                      Redirect to Authelia login portal
+#
+# Prerequisites:
+#   - Authelia container running (see docker-compose.yml)
+#   - DNS pointing dashboard.example.com and auth.example.com to this host
+#   - Replace example.com with your actual domain
+
+{
+    # Optional: Enable the Caddy admin API (disable in production if not needed)
+    admin off
+}
+
+# Authelia login portal
+auth.example.com {
+    reverse_proxy authelia:9091
+}
+
+# Vibe and Conquer dashboard — protected by Authelia
+dashboard.example.com {
+    # Forward every request to Authelia for verification
+    forward_auth authelia:9091 {
+        uri /api/verify?rd=https://auth.example.com
+
+        # Authelia passes authenticated user info via headers
+        copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+    }
+
+    # Proxy authenticated requests to the Vibe and Conquer backend
+    reverse_proxy vibe-and-conquer:3001
+
+    # Optional: serve the Vite frontend in production (if built into the backend)
+    # If running the dev server separately, add a second reverse_proxy block for port 5173
+}

--- a/docs/auth/authelia/Caddyfile
+++ b/docs/auth/authelia/Caddyfile
@@ -26,6 +26,14 @@ auth.example.com {
 
 # Vibe and Conquer dashboard — protected by Authelia
 dashboard.example.com {
+    # Strip any client-supplied identity headers before the auth check.
+    # Prevents header-injection/spoofing (GHSA-7r4p-gjf4-gxv4) on Caddy < v2.11.2;
+    # acts as defense-in-depth on v2.11.2+ where copy_headers already deletes them.
+    request_header -Remote-User
+    request_header -Remote-Groups
+    request_header -Remote-Name
+    request_header -Remote-Email
+
     # Forward every request to Authelia for verification
     forward_auth authelia:9091 {
         uri /api/verify?rd=https://auth.example.com

--- a/docs/auth/authelia/authelia-config.yml
+++ b/docs/auth/authelia/authelia-config.yml
@@ -1,6 +1,11 @@
 ---
 # Authelia minimal configuration for Vibe and Conquer
 # Full reference: https://www.authelia.com/configuration/prologue/introduction/
+#
+# Secrets are injected via environment variables (see docker-compose.yml).
+# Enable Authelia's built-in env-expansion filter so ${VAR} references work below.
+filters:
+  - expand-env
 
 theme: dark
 
@@ -10,8 +15,9 @@ server:
 log:
   level: info
 
-# JWT secret used to sign internal session tokens (generate with: openssl rand -hex 32)
-jwt_secret: CHANGE_ME_generate_with_openssl_rand_hex_32
+# JWT secret used to sign internal session tokens.
+# Set AUTHELIA_JWT_SECRET in your environment (generate with: openssl rand -hex 32)
+jwt_secret: ${AUTHELIA_JWT_SECRET}
 
 authentication_backend:
   file:
@@ -21,7 +27,7 @@ authentication_backend:
 
 # Where Authelia stores sessions
 session:
-  secret: CHANGE_ME_another_random_secret
+  secret: ${AUTHELIA_SESSION_SECRET}
   cookies:
     - name: authelia_session
       domain: example.com  # Replace with your domain
@@ -30,7 +36,7 @@ session:
       inactivity: 5m
 
 storage:
-  encryption_key: CHANGE_ME_32_char_encryption_key_here
+  encryption_key: ${AUTHELIA_STORAGE_ENCRYPTION_KEY}
   local:
     path: /config/db.sqlite3
 

--- a/docs/auth/authelia/authelia-config.yml
+++ b/docs/auth/authelia/authelia-config.yml
@@ -1,0 +1,55 @@
+---
+# Authelia minimal configuration for Vibe and Conquer
+# Full reference: https://www.authelia.com/configuration/prologue/introduction/
+
+theme: dark
+
+server:
+  address: tcp://0.0.0.0:9091/
+
+log:
+  level: info
+
+# JWT secret used to sign internal session tokens (generate with: openssl rand -hex 32)
+jwt_secret: CHANGE_ME_generate_with_openssl_rand_hex_32
+
+authentication_backend:
+  file:
+    path: /config/users_database.yml
+    password:
+      algorithm: bcrypt
+
+# Where Authelia stores sessions
+session:
+  secret: CHANGE_ME_another_random_secret
+  cookies:
+    - name: authelia_session
+      domain: example.com  # Replace with your domain
+      authelia_url: https://auth.example.com
+      expiration: 1h
+      inactivity: 5m
+
+storage:
+  encryption_key: CHANGE_ME_32_char_encryption_key_here
+  local:
+    path: /config/db.sqlite3
+
+notifier:
+  # For testing; switch to smtp for production
+  filesystem:
+    filename: /config/notification.txt
+
+access_control:
+  default_policy: deny
+  rules:
+    # Allow the Authelia API itself (health, verify, etc.)
+    - domain: auth.example.com
+      policy: bypass
+
+    # Protect the dashboard — require any authenticated user
+    - domain: dashboard.example.com
+      policy: one_factor
+
+    # Optional: require two-factor for extra security
+    # - domain: dashboard.example.com
+    #   policy: two_factor

--- a/docs/auth/authelia/docker-compose.yml
+++ b/docs/auth/authelia/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  vibe-and-conquer:
+    image: ghcr.io/svengraziani/vibe-and-conquer:latest
+    # Or build locally:
+    # build: ../../..
+    environment:
+      - PORT=3001
+      # No KEYCLOAK_* / AUTHENTIK_* / OIDC_* vars needed —
+      # Authelia handles auth at the proxy level, the app itself
+      # does not validate JWTs when using this setup.
+    volumes:
+      - app_data:/app/data
+    restart: unless-stopped
+
+  authelia:
+    image: authelia/authelia:latest
+    volumes:
+      - ./authelia-config.yml:/config/configuration.yml:ro
+      # Authelia needs a users database; for production use LDAP or a proper DB
+      - ./users_database.yml:/config/users_database.yml:ro
+    environment:
+      - TZ=Europe/Berlin
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9091/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  caddy:
+    image: caddy:latest
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"  # HTTP/3
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      authelia:
+        condition: service_healthy
+      vibe-and-conquer:
+        condition: service_started
+    restart: unless-stopped
+
+volumes:
+  app_data:
+  caddy_data:
+  caddy_config:

--- a/docs/auth/authelia/docker-compose.yml
+++ b/docs/auth/authelia/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   vibe-and-conquer:
-    image: ghcr.io/svengraziani/vibe-and-conquer:latest
+    # Pin to a specific release tag — replace with the version you are deploying.
+    image: ghcr.io/svengraziani/vibe-and-conquer:1.2.0
     # Or build locally:
     # build: ../../..
     environment:
@@ -13,13 +14,19 @@ services:
     restart: unless-stopped
 
   authelia:
-    image: authelia/authelia:latest
+    # Pin to a specific minor version for reproducible deployments.
+    image: authelia/authelia:4.38
     volumes:
       - ./authelia-config.yml:/config/configuration.yml:ro
       # Authelia needs a users database; for production use LDAP or a proper DB
       - ./users_database.yml:/config/users_database.yml:ro
     environment:
       - TZ=Europe/Berlin
+      # Secrets — supply via a .env file or your secrets manager.
+      # Generate values with: openssl rand -hex 32
+      - AUTHELIA_JWT_SECRET=${AUTHELIA_JWT_SECRET}
+      - AUTHELIA_SESSION_SECRET=${AUTHELIA_SESSION_SECRET}
+      - AUTHELIA_STORAGE_ENCRYPTION_KEY=${AUTHELIA_STORAGE_ENCRYPTION_KEY}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:9091/api/health"]
@@ -28,7 +35,8 @@ services:
       retries: 5
 
   caddy:
-    image: caddy:latest
+    # v2.11.2+ includes the fix for GHSA-7r4p-gjf4-gxv4 (Remote-* header spoofing).
+    image: caddy:2.11.2
     ports:
       - "80:80"
       - "443:443"

--- a/docs/auth/authelia/users_database.yml
+++ b/docs/auth/authelia/users_database.yml
@@ -1,0 +1,15 @@
+---
+# Authelia local users database
+# Replace with LDAP or a proper user store for production.
+#
+# Generate a bcrypt password hash:
+#   docker run --rm authelia/authelia:latest authelia crypto hash generate bcrypt --password 'your-password'
+
+users:
+  admin:
+    displayname: Admin
+    # Default password: "changeme" — replace before deploying!
+    password: "$2b$12$ygfxwHyTDuHdGJw4.5lBR.0ULe0YTZ8pjlRJhFnEr5O4V5MZyXnYy"
+    email: admin@example.com
+    groups:
+      - admins

--- a/docs/auth/authelia/users_database.yml
+++ b/docs/auth/authelia/users_database.yml
@@ -8,8 +8,10 @@
 users:
   admin:
     displayname: Admin
-    # Default password: "changeme" — replace before deploying!
-    password: "$2b$12$ygfxwHyTDuHdGJw4.5lBR.0ULe0YTZ8pjlRJhFnEr5O4V5MZyXnYy"
+    # Generate a real bcrypt hash before deploying — do NOT use a placeholder here.
+    # Run: docker run --rm authelia/authelia:4.38 authelia crypto hash generate bcrypt --password 'your-password'
+    # Then paste the output below.
+    password: "<REPLACE_WITH_BCRYPT_HASH>"
     email: admin@example.com
     groups:
       - admins

--- a/gh-ctrl/client/package.json
+++ b/gh-ctrl/client/package.json
@@ -16,6 +16,7 @@
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
     "keycloak-js": "^26.1.4",
+    "oidc-client-ts": "^3.1.0",
     "lucide-react": "^0.475.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/gh-ctrl/client/src/auth/AuthContext.ts
+++ b/gh-ctrl/client/src/auth/AuthContext.ts
@@ -1,0 +1,27 @@
+import { createContext, useContext } from 'react'
+
+export interface AuthUser {
+  username?: string
+  email?: string
+  name?: string
+}
+
+export interface AuthContextValue {
+  initialized: boolean
+  token: string | undefined
+  user: AuthUser | null
+  isAuthenticated: boolean
+  logout: () => void
+}
+
+export const AuthContext = createContext<AuthContextValue>({
+  initialized: true,
+  token: undefined,
+  user: null,
+  isAuthenticated: true,
+  logout: () => {},
+})
+
+export function useAuthContext(): AuthContextValue {
+  return useContext(AuthContext)
+}

--- a/gh-ctrl/client/src/auth/AuthentikProvider.tsx
+++ b/gh-ctrl/client/src/auth/AuthentikProvider.tsx
@@ -11,8 +11,11 @@ export const authentikEnabled =
   Boolean(AUTHENTIK_URL) && Boolean(AUTHENTIK_SLUG) && Boolean(AUTHENTIK_CLIENT_ID)
 
 export function AuthentikProvider({ children }: { children: ReactNode }) {
+  // Trim trailing slashes so a user-supplied URL like "https://authentik.example.com/"
+  // doesn't produce double-slash paths in the OIDC discovery / JWKS URLs.
+  const baseUrl = AUTHENTIK_URL!.replace(/\/+$/, '')
   // e.g. "https://authentik.example.com/application/o/vibe-and-conquer/"
-  const authority = `${AUTHENTIK_URL}/application/o/${AUTHENTIK_SLUG}/`
+  const authority = `${baseUrl}/application/o/${AUTHENTIK_SLUG}/`
 
   return (
     <OidcProvider authority={authority} clientId={AUTHENTIK_CLIENT_ID!}>

--- a/gh-ctrl/client/src/auth/AuthentikProvider.tsx
+++ b/gh-ctrl/client/src/auth/AuthentikProvider.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react'
+import { OidcProvider } from './OidcProvider'
+
+// Authentik exposes OIDC at: {AUTHENTIK_URL}/application/o/{AUTHENTIK_SLUG}/
+// The discovery document lives at: {authority}/.well-known/openid-configuration
+const AUTHENTIK_URL = import.meta.env.VITE_AUTHENTIK_URL as string | undefined
+const AUTHENTIK_SLUG = import.meta.env.VITE_AUTHENTIK_SLUG as string | undefined
+const AUTHENTIK_CLIENT_ID = import.meta.env.VITE_AUTHENTIK_CLIENT_ID as string | undefined
+
+export const authentikEnabled =
+  Boolean(AUTHENTIK_URL) && Boolean(AUTHENTIK_SLUG) && Boolean(AUTHENTIK_CLIENT_ID)
+
+export function AuthentikProvider({ children }: { children: ReactNode }) {
+  // e.g. "https://authentik.example.com/application/o/vibe-and-conquer/"
+  const authority = `${AUTHENTIK_URL}/application/o/${AUTHENTIK_SLUG}/`
+
+  return (
+    <OidcProvider authority={authority} clientId={AUTHENTIK_CLIENT_ID!}>
+      {children}
+    </OidcProvider>
+  )
+}

--- a/gh-ctrl/client/src/auth/KeycloakProvider.tsx
+++ b/gh-ctrl/client/src/auth/KeycloakProvider.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import Keycloak from 'keycloak-js'
+import { AuthContext, type AuthContextValue } from './AuthContext'
 
 const KEYCLOAK_URL = import.meta.env.VITE_KEYCLOAK_URL as string | undefined
 const KEYCLOAK_REALM = import.meta.env.VITE_KEYCLOAK_REALM as string | undefined
@@ -7,28 +8,6 @@ const KEYCLOAK_CLIENT_ID = import.meta.env.VITE_KEYCLOAK_CLIENT_ID as string | u
 
 export const keycloakEnabled =
   Boolean(KEYCLOAK_URL) && Boolean(KEYCLOAK_REALM) && Boolean(KEYCLOAK_CLIENT_ID)
-
-interface AuthContextValue {
-  keycloak: Keycloak | null
-  initialized: boolean
-  token: string | undefined
-  user: {
-    username?: string
-    email?: string
-    name?: string
-  } | null
-  isAuthenticated: boolean
-  logout: () => void
-}
-
-const AuthContext = createContext<AuthContextValue>({
-  keycloak: null,
-  initialized: true,
-  token: undefined,
-  user: null,
-  isAuthenticated: true,
-  logout: () => {},
-})
 
 let keycloakInstance: Keycloak | null = null
 
@@ -99,7 +78,6 @@ export function KeycloakProvider({ children }: { children: ReactNode }) {
   return (
     <AuthContext.Provider
       value={{
-        keycloak,
         initialized,
         token,
         user,
@@ -110,8 +88,4 @@ export function KeycloakProvider({ children }: { children: ReactNode }) {
       {children}
     </AuthContext.Provider>
   )
-}
-
-export function useAuthContext() {
-  return useContext(AuthContext)
 }

--- a/gh-ctrl/client/src/auth/OidcProvider.tsx
+++ b/gh-ctrl/client/src/auth/OidcProvider.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { UserManager, WebStorageStateStore, type User } from 'oidc-client-ts'
+import { AuthContext, type AuthContextValue } from './AuthContext'
+
+const OIDC_AUTHORITY = import.meta.env.VITE_OIDC_AUTHORITY as string | undefined
+const OIDC_CLIENT_ID = import.meta.env.VITE_OIDC_CLIENT_ID as string | undefined
+const OIDC_REDIRECT_URI = import.meta.env.VITE_OIDC_REDIRECT_URI as string | undefined
+const OIDC_SCOPE = import.meta.env.VITE_OIDC_SCOPE as string | undefined
+
+export const oidcEnabled = Boolean(OIDC_AUTHORITY) && Boolean(OIDC_CLIENT_ID)
+
+interface OidcProviderProps {
+  children: ReactNode
+  /** Override the OIDC authority URL (defaults to VITE_OIDC_AUTHORITY) */
+  authority?: string
+  /** Override the client ID (defaults to VITE_OIDC_CLIENT_ID) */
+  clientId?: string
+  /** Override the redirect URI (defaults to VITE_OIDC_REDIRECT_URI or window.location.origin) */
+  redirectUri?: string
+  /** Override the scope string (defaults to VITE_OIDC_SCOPE or "openid profile email") */
+  scope?: string
+}
+
+export function OidcProvider({ children, authority, clientId, redirectUri, scope }: OidcProviderProps) {
+  const resolvedAuthority = authority ?? OIDC_AUTHORITY!
+  const resolvedClientId = clientId ?? OIDC_CLIENT_ID!
+  const resolvedRedirectUri = redirectUri ?? OIDC_REDIRECT_URI ?? window.location.origin
+  const resolvedScope = scope ?? OIDC_SCOPE ?? 'openid profile email'
+
+  const [initialized, setInitialized] = useState(false)
+  const [token, setToken] = useState<string | undefined>(undefined)
+  const [user, setUser] = useState<AuthContextValue['user']>(null)
+  const managerRef = useRef<UserManager | null>(null)
+
+  function getManager(): UserManager {
+    if (!managerRef.current) {
+      managerRef.current = new UserManager({
+        authority: resolvedAuthority,
+        client_id: resolvedClientId,
+        redirect_uri: resolvedRedirectUri,
+        post_logout_redirect_uri: resolvedRedirectUri,
+        response_type: 'code',
+        scope: resolvedScope,
+        automaticSilentRenew: true,
+        userStore: new WebStorageStateStore({ store: window.sessionStorage }),
+      })
+    }
+    return managerRef.current
+  }
+
+  useEffect(() => {
+    const manager = getManager()
+
+    const onUserLoaded = (u: User) => {
+      setToken(u.access_token)
+      setUser({
+        username: u.profile.preferred_username,
+        email: u.profile.email,
+        name: u.profile.name,
+      })
+    }
+
+    const onUserUnloaded = () => {
+      setToken(undefined)
+      setUser(null)
+    }
+
+    async function handleAuth() {
+      // Check if we're handling an OIDC authorization code callback
+      const params = new URLSearchParams(window.location.search)
+      if (params.get('code') && params.get('state')) {
+        try {
+          const oidcUser = await manager.signinRedirectCallback()
+          // Clean up the code/state params from the URL
+          window.history.replaceState({}, '', window.location.pathname)
+          onUserLoaded(oidcUser)
+        } catch (err) {
+          console.error('[oidc] callback error', err)
+        }
+        setInitialized(true)
+        return
+      }
+
+      // Try to restore an existing session from storage
+      try {
+        const existingUser = await manager.getUser()
+        if (existingUser && !existingUser.expired) {
+          onUserLoaded(existingUser)
+          setInitialized(true)
+          return
+        }
+      } catch (err) {
+        console.error('[oidc] getUser error', err)
+      }
+
+      // No valid session — redirect to the IdP login page
+      manager.signinRedirect().catch((err) => {
+        console.error('[oidc] signinRedirect error', err)
+        setInitialized(true)
+      })
+    }
+
+    handleAuth()
+
+    manager.events.addUserLoaded(onUserLoaded)
+    manager.events.addUserUnloaded(onUserUnloaded)
+
+    return () => {
+      manager.events.removeUserLoaded(onUserLoaded)
+      manager.events.removeUserUnloaded(onUserUnloaded)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const logout = () => {
+    getManager().signoutRedirect().catch(console.error)
+  }
+
+  if (!initialized) {
+    return (
+      <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg)', color: 'var(--text-2)', fontSize: '0.9rem' }}>
+        Authenticating…
+      </div>
+    )
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        initialized,
+        token,
+        user,
+        isAuthenticated: token !== undefined,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/gh-ctrl/client/src/auth/useAuth.ts
+++ b/gh-ctrl/client/src/auth/useAuth.ts
@@ -1,13 +1,18 @@
-import { useAuthContext, keycloakEnabled } from './KeycloakProvider'
+import { useAuthContext } from './AuthContext'
+import { keycloakEnabled } from './KeycloakProvider'
+import { authentikEnabled } from './AuthentikProvider'
+import { oidcEnabled } from './OidcProvider'
+
+const authEnabled = keycloakEnabled || authentikEnabled || oidcEnabled
 
 export function useAuth() {
   const ctx = useAuthContext()
 
   return {
-    token: keycloakEnabled ? ctx.token : undefined,
+    token: authEnabled ? ctx.token : undefined,
     user: ctx.user,
-    isAuthenticated: keycloakEnabled ? ctx.isAuthenticated : true,
+    isAuthenticated: authEnabled ? ctx.isAuthenticated : true,
     logout: ctx.logout,
-    enabled: keycloakEnabled,
+    enabled: authEnabled,
   }
 }

--- a/gh-ctrl/client/src/main.tsx
+++ b/gh-ctrl/client/src/main.tsx
@@ -1,9 +1,11 @@
-import React from 'react'
+import React, { type ReactNode } from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import './styles.css'
 import { KeycloakProvider, keycloakEnabled } from './auth/KeycloakProvider'
+import { AuthentikProvider, authentikEnabled } from './auth/AuthentikProvider'
+import { OidcProvider, oidcEnabled } from './auth/OidcProvider'
 
 const tree = (
   <React.StrictMode>
@@ -13,6 +15,11 @@ const tree = (
   </React.StrictMode>
 )
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  keycloakEnabled ? <KeycloakProvider>{tree}</KeycloakProvider> : tree
-)
+function wrapWithAuthProvider(children: ReactNode): ReactNode {
+  if (keycloakEnabled) return <KeycloakProvider>{children}</KeycloakProvider>
+  if (authentikEnabled) return <AuthentikProvider>{children}</AuthentikProvider>
+  if (oidcEnabled) return <OidcProvider>{children}</OidcProvider>
+  return children
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(wrapWithAuthProvider(tree))

--- a/gh-ctrl/src/__tests__/test-db.ts
+++ b/gh-ctrl/src/__tests__/test-db.ts
@@ -96,5 +96,13 @@ export function createTestDb() {
     )
   `)
 
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER DEFAULT (unixepoch())
+    )
+  `)
+
   return drizzle(sqlite, { schema })
 }

--- a/gh-ctrl/src/middleware/auth.ts
+++ b/gh-ctrl/src/middleware/auth.ts
@@ -1,19 +1,59 @@
 import type { MiddlewareHandler } from 'hono'
 import { createRemoteJWKSet, jwtVerify } from 'jose'
 
+// --- Keycloak ---
 const KEYCLOAK_URL = process.env.KEYCLOAK_URL
 const KEYCLOAK_INTERNAL_URL = process.env.KEYCLOAK_INTERNAL_URL || KEYCLOAK_URL
 const KEYCLOAK_REALM = process.env.KEYCLOAK_REALM
 const KEYCLOAK_CLIENT_ID = process.env.KEYCLOAK_CLIENT_ID
 
+// --- Authentik (shorthand — derives JWKS URL and issuer automatically) ---
+// AUTHENTIK_URL  = https://authentik.example.com
+// AUTHENTIK_SLUG = vibe-and-conquer  (the application slug in Authentik)
+const AUTHENTIK_URL = process.env.AUTHENTIK_URL
+const AUTHENTIK_SLUG = process.env.AUTHENTIK_SLUG
+
+// --- Generic OIDC (Zitadel, Dex, Logto, Auth0, Authelia OIDC, etc.) ---
+// OIDC_JWKS_URL = https://my-idp.example.com/.well-known/jwks.json
+// OIDC_ISSUER   = https://my-idp.example.com
+const OIDC_JWKS_URL = process.env.OIDC_JWKS_URL
+const OIDC_ISSUER = process.env.OIDC_ISSUER
+
+// --- Resolve active OIDC config (Keycloak > Authentik > Generic OIDC) ---
+interface OidcConfig {
+  jwksUrl: string
+  issuer: string
+}
+
+function resolveOidcConfig(): OidcConfig | null {
+  if (KEYCLOAK_URL && KEYCLOAK_REALM && KEYCLOAK_CLIENT_ID) {
+    return {
+      jwksUrl: `${KEYCLOAK_INTERNAL_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs`,
+      issuer: `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`,
+    }
+  }
+  if (AUTHENTIK_URL && AUTHENTIK_SLUG) {
+    const base = `${AUTHENTIK_URL}/application/o/${AUTHENTIK_SLUG}`
+    return {
+      jwksUrl: `${base}/jwks/`,
+      issuer: `${base}/`,
+    }
+  }
+  if (OIDC_JWKS_URL && OIDC_ISSUER) {
+    return {
+      jwksUrl: OIDC_JWKS_URL,
+      issuer: OIDC_ISSUER,
+    }
+  }
+  return null
+}
+
+const oidcConfig = resolveOidcConfig()
 let jwks: ReturnType<typeof createRemoteJWKSet> | null = null
 
 function getJwks() {
-  if (!jwks && KEYCLOAK_INTERNAL_URL && KEYCLOAK_REALM) {
-    const jwksUrl = new URL(
-      `${KEYCLOAK_INTERNAL_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs`
-    )
-    jwks = createRemoteJWKSet(jwksUrl)
+  if (!jwks && oidcConfig) {
+    jwks = createRemoteJWKSet(new URL(oidcConfig.jwksUrl))
   }
   return jwks
 }
@@ -26,12 +66,12 @@ export const authMiddleware: MiddlewareHandler = async (c, next) => {
     return next()
   }
 
-  // If Keycloak is not configured, skip auth entirely (opt-in)
-  if (!KEYCLOAK_URL || !KEYCLOAK_REALM || !KEYCLOAK_CLIENT_ID) {
+  // No auth provider configured — opt-in, skip entirely
+  if (!oidcConfig) {
     return next()
   }
 
-  // Accept token from Authorization header or query param (for SSE/EventSource which can't set headers)
+  // Accept token from Authorization header or query param (SSE/EventSource can't set headers)
   const authorization = c.req.header('Authorization')
   const token = authorization?.startsWith('Bearer ')
     ? authorization.slice(7)
@@ -44,15 +84,14 @@ export const authMiddleware: MiddlewareHandler = async (c, next) => {
   try {
     const keySet = getJwks()!
     const { payload } = await jwtVerify(token, keySet, {
-      issuer: `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`,
+      issuer: oidcConfig.issuer,
     })
     c.set('user' as never, payload)
     return next()
   } catch (err) {
     console.error('[auth] JWT verification failed:', err instanceof Error ? err.message : err)
-    console.error('[auth] Expected issuer:', `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`)
-    console.error('[auth] Expected audience:', KEYCLOAK_CLIENT_ID)
-    console.error('[auth] JWKS URL:', `${KEYCLOAK_INTERNAL_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs`)
+    console.error('[auth] JWKS URL:', oidcConfig.jwksUrl)
+    console.error('[auth] Expected issuer:', oidcConfig.issuer)
     return c.json({ error: 'Unauthorized' }, 401)
   }
 }

--- a/gh-ctrl/src/middleware/auth.ts
+++ b/gh-ctrl/src/middleware/auth.ts
@@ -16,39 +16,78 @@ const AUTHENTIK_SLUG = process.env.AUTHENTIK_SLUG
 // --- Generic OIDC (Zitadel, Dex, Logto, Auth0, Authelia OIDC, etc.) ---
 // OIDC_JWKS_URL = https://my-idp.example.com/.well-known/jwks.json
 // OIDC_ISSUER   = https://my-idp.example.com
+// OIDC_AUDIENCE = (optional) expected audience claim in the JWT
 const OIDC_JWKS_URL = process.env.OIDC_JWKS_URL
 const OIDC_ISSUER = process.env.OIDC_ISSUER
+const OIDC_AUDIENCE = process.env.OIDC_AUDIENCE
 
 // --- Resolve active OIDC config (Keycloak > Authentik > Generic OIDC) ---
 interface OidcConfig {
   jwksUrl: string
   issuer: string
+  /** Expected audience claim; if set it is validated in jwtVerify. */
+  audience?: string
 }
 
 function resolveOidcConfig(): OidcConfig | null {
-  if (KEYCLOAK_URL && KEYCLOAK_REALM && KEYCLOAK_CLIENT_ID) {
+  const hasKeycloakPartial = Boolean(KEYCLOAK_URL || KEYCLOAK_REALM || KEYCLOAK_CLIENT_ID)
+  if (hasKeycloakPartial) {
+    if (!(KEYCLOAK_URL && KEYCLOAK_REALM && KEYCLOAK_CLIENT_ID)) {
+      throw new Error(
+        '[auth] Incomplete Keycloak config: KEYCLOAK_URL, KEYCLOAK_REALM and KEYCLOAK_CLIENT_ID are all required',
+      )
+    }
     return {
       jwksUrl: `${KEYCLOAK_INTERNAL_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/certs`,
       issuer: `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`,
+      audience: KEYCLOAK_CLIENT_ID,
     }
   }
-  if (AUTHENTIK_URL && AUTHENTIK_SLUG) {
-    const base = `${AUTHENTIK_URL}/application/o/${AUTHENTIK_SLUG}`
+
+  const hasAuthentikPartial = Boolean(AUTHENTIK_URL || AUTHENTIK_SLUG)
+  if (hasAuthentikPartial) {
+    if (!(AUTHENTIK_URL && AUTHENTIK_SLUG)) {
+      throw new Error(
+        '[auth] Incomplete Authentik config: both AUTHENTIK_URL and AUTHENTIK_SLUG are required',
+      )
+    }
+    // Trim trailing slashes so a user-supplied URL like "https://authentik.example.com/"
+    // doesn't produce double-slash paths in the JWKS / issuer URLs.
+    const baseUrl = AUTHENTIK_URL.replace(/\/+$/, '')
+    const base = `${baseUrl}/application/o/${AUTHENTIK_SLUG}`
     return {
       jwksUrl: `${base}/jwks/`,
       issuer: `${base}/`,
+      audience: AUTHENTIK_SLUG,
     }
   }
-  if (OIDC_JWKS_URL && OIDC_ISSUER) {
+
+  const hasOidcPartial = Boolean(OIDC_JWKS_URL || OIDC_ISSUER || OIDC_AUDIENCE)
+  if (hasOidcPartial) {
+    if (!(OIDC_JWKS_URL && OIDC_ISSUER)) {
+      throw new Error(
+        '[auth] Incomplete generic OIDC config: OIDC_JWKS_URL and OIDC_ISSUER are required',
+      )
+    }
     return {
       jwksUrl: OIDC_JWKS_URL,
       issuer: OIDC_ISSUER,
+      ...(OIDC_AUDIENCE ? { audience: OIDC_AUDIENCE } : {}),
     }
   }
+
   return null
 }
 
-const oidcConfig = resolveOidcConfig()
+let oidcConfig: OidcConfig | null = null
+let oidcConfigError: string | null = null
+try {
+  oidcConfig = resolveOidcConfig()
+} catch (err) {
+  oidcConfigError = err instanceof Error ? err.message : String(err)
+  console.error(oidcConfigError)
+}
+
 let jwks: ReturnType<typeof createRemoteJWKSet> | null = null
 
 function getJwks() {
@@ -64,6 +103,12 @@ export const authMiddleware: MiddlewareHandler = async (c, next) => {
   // Skip auth for public endpoints
   if (PUBLIC_PATHS.includes(c.req.path)) {
     return next()
+  }
+
+  // Fail closed: some auth env vars were set but the config is incomplete.
+  if (oidcConfigError) {
+    console.error('[auth] Auth configuration error:', oidcConfigError)
+    return c.json({ error: 'Server auth misconfiguration' }, 500)
   }
 
   // No auth provider configured — opt-in, skip entirely
@@ -85,6 +130,7 @@ export const authMiddleware: MiddlewareHandler = async (c, next) => {
     const keySet = getJwks()!
     const { payload } = await jwtVerify(token, keySet, {
       issuer: oidcConfig.issuer,
+      ...(oidcConfig.audience ? { audience: oidcConfig.audience } : {}),
     })
     c.set('user' as never, payload)
     return next()

--- a/gh-ctrl/src/middleware/auth.ts
+++ b/gh-ctrl/src/middleware/auth.ts
@@ -2,8 +2,11 @@ import type { MiddlewareHandler } from 'hono'
 import { createRemoteJWKSet, jwtVerify } from 'jose'
 
 // --- Keycloak ---
-const KEYCLOAK_URL = process.env.KEYCLOAK_URL
-const KEYCLOAK_INTERNAL_URL = process.env.KEYCLOAK_INTERNAL_URL || KEYCLOAK_URL
+const KEYCLOAK_URL = process.env.KEYCLOAK_URL?.replace(/\/+$/, '')
+const KEYCLOAK_INTERNAL_URL = (process.env.KEYCLOAK_INTERNAL_URL || KEYCLOAK_URL)?.replace(
+  /\/+$/,
+  '',
+)
 const KEYCLOAK_REALM = process.env.KEYCLOAK_REALM
 const KEYCLOAK_CLIENT_ID = process.env.KEYCLOAK_CLIENT_ID
 
@@ -16,7 +19,7 @@ const AUTHENTIK_SLUG = process.env.AUTHENTIK_SLUG
 // --- Generic OIDC (Zitadel, Dex, Logto, Auth0, Authelia OIDC, etc.) ---
 // OIDC_JWKS_URL = https://my-idp.example.com/.well-known/jwks.json
 // OIDC_ISSUER   = https://my-idp.example.com
-// OIDC_AUDIENCE = (optional) expected audience claim in the JWT
+// OIDC_AUDIENCE = expected audience claim in the JWT (required)
 const OIDC_JWKS_URL = process.env.OIDC_JWKS_URL
 const OIDC_ISSUER = process.env.OIDC_ISSUER
 const OIDC_AUDIENCE = process.env.OIDC_AUDIENCE
@@ -64,15 +67,15 @@ function resolveOidcConfig(): OidcConfig | null {
 
   const hasOidcPartial = Boolean(OIDC_JWKS_URL || OIDC_ISSUER || OIDC_AUDIENCE)
   if (hasOidcPartial) {
-    if (!(OIDC_JWKS_URL && OIDC_ISSUER)) {
+    if (!(OIDC_JWKS_URL && OIDC_ISSUER && OIDC_AUDIENCE)) {
       throw new Error(
-        '[auth] Incomplete generic OIDC config: OIDC_JWKS_URL and OIDC_ISSUER are required',
+        '[auth] Incomplete generic OIDC config: OIDC_JWKS_URL, OIDC_ISSUER and OIDC_AUDIENCE are all required',
       )
     }
     return {
       jwksUrl: OIDC_JWKS_URL,
       issuer: OIDC_ISSUER,
-      ...(OIDC_AUDIENCE ? { audience: OIDC_AUDIENCE } : {}),
+      audience: OIDC_AUDIENCE,
     }
   }
 


### PR DESCRIPTION
Implements auth providers 1, 2 and 3 from #337:

- Authelia (proxy-level `forward_auth` via Caddy, zero app changes) with Docker Compose example
- Authentik provider (OIDC wrapper, `VITE_AUTHENTIK_URL` + `VITE_AUTHENTIK_SLUG`)
- Generic OIDC provider via `oidc-client-ts` (works with Zitadel, Dex, Logto, Auth0, etc.)
- Shared `AuthContext.ts` decouples context from Keycloak
- Backend `auth.ts` auto-resolves JWKS/issuer for all three providers

Closes #337

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime selection of auth provider (Keycloak, Authentik, generic OIDC) plus client-side OIDC providers and full sign-in/sign-out/session restore flows.

* **Documentation**
  * End-to-end Authelia examples: proxy config, Authelia config, sample users, and Docker Compose; README updated to list supported auth options.

* **Bug Fixes**
  * Hardening of auth middleware with better config validation and clearer error responses.

* **Tests**
  * Extended test DB schema with a settings table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->