### PR TITLE
feat: version notification + Docker-native update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,33 @@ docker compose --profile dev up --build
 
 The SQLite database is stored in a named Docker volume (`gh-ctrl-data`) and persists across restarts.
 
+### In-App Updates (opt-in)
+
+When a new release is available, a notification banner appears at the top of the UI. Clicking **INSTALL UPDATE** runs `gh-ctrl/scripts/update.sh` inside the container — it pulls the latest code, rebuilds the image, and restarts the services.
+
+This requires the container to reach the host Docker daemon and the project root on disk. Because mounting `/var/run/docker.sock` grants container-level control of the Docker daemon (root-equivalent on the host), **this is opt-in** and disabled by default.
+
+**Enable with the overlay file:**
+
+```bash
+# Start (or restart) with both compose files:
+docker compose -f compose.yml -f compose.update.yml --profile prod up -d
+```
+
+**Or set `COMPOSE_FILE` in your `.env` so it applies automatically:**
+
+```dotenv
+COMPOSE_FILE=compose.yml:compose.update.yml
+```
+
+Then `docker compose --profile prod up -d` picks up the overlay without the extra `-f` flag.
+
+> **Security note:** Only enable the overlay when:
+> - You trust the network exposure of your deployment, **and**
+> - You have configured authentication (`KEYCLOAK_URL` / `KEYCLOAK_REALM` / `KEYCLOAK_CLIENT_ID` in `.env`).
+>
+> Without auth, any user who can reach the UI can trigger a host rebuild. The updater path (`POST /api/version/update`) is excluded from public routes and requires a valid session when Keycloak is configured.
+
 ---
 
 ## GitHub Actions Workflows

--- a/compose.update.yml
+++ b/compose.update.yml
@@ -1,0 +1,21 @@
+# compose.update.yml — Opt-in overlay for the in-app "Install Update" button.
+#
+# Mounts the host Docker socket and project root into the app container so that
+# gh-ctrl/scripts/update.sh can rebuild and restart services via Docker Compose
+# from within the running container.
+#
+# ⚠️  Security note: mounting /var/run/docker.sock grants container-level control
+# of the Docker daemon (equivalent to root on the host). Only enable this if you
+# trust the network exposure of your deployment and have configured auth
+# (KEYCLOAK_URL / KEYCLOAK_REALM / KEYCLOAK_CLIENT_ID in .env).
+#
+# Usage:
+#   docker compose -f compose.yml -f compose.update.yml --profile prod up -d
+#
+# Or set COMPOSE_FILE in your .env:
+#   COMPOSE_FILE=compose.yml:compose.update.yml
+services:
+  app:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - .:/workspace

--- a/compose.yml
+++ b/compose.yml
@@ -18,6 +18,12 @@ services:
     volumes:
       - gh-ctrl-data:/app/data
       - gh-ctrl-uploads:/app/uploads
+      # Mount Docker socket + project root to enable the in-app "Install Update" button.
+      # The update script (gh-ctrl/scripts/update.sh) uses these to rebuild and restart
+      # the container via Docker Compose without leaving the running process.
+      # Remove these two lines if you don't need the in-app update button.
+      - /var/run/docker.sock:/var/run/docker.sock
+      - .:/workspace
     networks:
       - internal
     healthcheck:

--- a/compose.yml
+++ b/compose.yml
@@ -18,12 +18,6 @@ services:
     volumes:
       - gh-ctrl-data:/app/data
       - gh-ctrl-uploads:/app/uploads
-      # Mount Docker socket + project root to enable the in-app "Install Update" button.
-      # The update script (gh-ctrl/scripts/update.sh) uses these to rebuild and restart
-      # the container via Docker Compose without leaving the running process.
-      # Remove these two lines if you don't need the in-app update button.
-      - /var/run/docker.sock:/var/run/docker.sock
-      - .:/workspace
     networks:
       - internal
     healthcheck:

--- a/gh-ctrl/Dockerfile
+++ b/gh-ctrl/Dockerfile
@@ -27,17 +27,23 @@ RUN cd client && bunx vite build
 # ── Stage 2: runtime (production) ────────────────────────────────────────────
 FROM oven/bun AS runtime
 
-# Install gh CLI
+# Install gh CLI + Docker CLI (docker CLI is used by the in-app update script
+# to run `docker compose up -d --build` via the mounted /var/run/docker.sock)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg git && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
       > /etc/apt/sources.list.d/github-cli.list && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg \
+      | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod go+r /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
+      > /etc/apt/sources.list.d/docker.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends gh && \
+    apt-get install -y --no-install-recommends gh docker-ce-cli docker-compose-plugin && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -8,8 +8,10 @@ import { MapEditor } from './components/MapEditor'
 import { ToastArea } from './components/Toast'
 import { SetupScreen } from './components/SetupScreen'
 import { ConnectionSetup } from './components/ConnectionSetup'
+import { UpdateNotificationBanner } from './components/UpdateNotificationBanner'
 import { api, getServerUrl, setAuthTokenProvider } from './api'
 import { useAuth } from './auth/useAuth'
+import { useVersionCheck } from './hooks/useVersionCheck'
 import type { SetupStatus } from './types'
 
 export default function App() {
@@ -28,6 +30,7 @@ export default function App() {
   const [setupChecked, setSetupChecked] = useState(false)
   const [connectionChecked, setConnectionChecked] = useState(false)
   const [serverReachable, setServerReachable] = useState(false)
+  const versionCheck = useVersionCheck()
   const auth = useAuth()
 
   // Register Keycloak token provider so api.ts can attach Bearer tokens
@@ -120,7 +123,17 @@ export default function App() {
   }
 
   return (
-    <div className="app-layout">
+    <div className={`app-layout${versionCheck.updateAvailable ? ' update-banner-visible' : ''}`}>
+      {versionCheck.updateAvailable && (
+        <UpdateNotificationBanner
+          current={versionCheck.current}
+          latest={versionCheck.latest}
+          releaseName={versionCheck.releaseName}
+          releaseUrl={versionCheck.releaseUrl}
+          onDismiss={versionCheck.dismiss}
+        />
+      )}
+
       {/* Mobile: hamburger button to open sidebar drawer */}
       <button
         className="sidebar-hamburger"
@@ -201,7 +214,12 @@ export default function App() {
         </div>
 
         {appVersion && (
-          <div className="sidebar-version">v{appVersion}</div>
+          <div className={`sidebar-version${versionCheck.updateAvailable ? ' sidebar-version--update' : ''}`}>
+            v{appVersion}
+            {versionCheck.updateAvailable && (
+              <span className="sidebar-update-dot" title={`Update available: ${versionCheck.latest}`} />
+            )}
+          </div>
         )}
 
         {auth.enabled && auth.user && (

--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -682,4 +682,18 @@ export const api = {
     request<{ ok: boolean; sessions: string[]; error?: string }>(
       `/buildings/${buildingId}/shell/connections/${connectionId}/tmux-sessions`
     ),
+
+  checkVersion: () =>
+    request<{
+      current: string
+      latest: string | null
+      updateAvailable: boolean
+      releaseUrl: string | null
+      releaseName: string | null
+    }>('/version/check'),
+
+  triggerUpdate: () =>
+    request<{ success: boolean; output: string; exitCode: number }>('/version/update', {
+      method: 'POST',
+    }),
 }

--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -692,8 +692,50 @@ export const api = {
       releaseName: string | null
     }>('/version/check'),
 
-  triggerUpdate: () =>
-    request<{ success: boolean; output: string; exitCode: number }>('/version/update', {
-      method: 'POST',
-    }),
+  triggerUpdate: async (onChunk: (chunk: string) => void): Promise<{ exitCode: number; truncated: boolean; error?: string }> => {
+    const base = getBase()
+    const token = _getToken?.()
+    const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {}
+
+    const res = await fetch(`${base}/version/update`, { method: 'POST', headers })
+    if (!res.body) throw new Error('No response body')
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        const text = decoder.decode(value, { stream: true })
+        buffer += text
+
+        // Flush everything except a potential partial sentinel line at the end
+        const sentinelIdx = buffer.lastIndexOf('\n__META__:')
+        const flushUpTo = sentinelIdx >= 0 ? sentinelIdx : buffer.lastIndexOf('\n')
+        if (flushUpTo > 0) {
+          onChunk(buffer.slice(0, flushUpTo + 1))
+          buffer = buffer.slice(flushUpTo + 1)
+        }
+      }
+    } finally {
+      reader.releaseLock()
+    }
+
+    // Parse the sentinel line from whatever remains in buffer
+    const metaMatch = buffer.match(/__META__:(\{.*\})/)
+    if (metaMatch) {
+      try {
+        return JSON.parse(metaMatch[1]) as { exitCode: number; truncated: boolean; error?: string }
+      } catch {
+        // fall through
+      }
+    }
+    // Flush any remaining non-sentinel output
+    if (buffer.trim() && !buffer.includes('__META__:')) {
+      onChunk(buffer)
+    }
+    return { exitCode: -1, truncated: false, error: 'Could not parse update result' }
+  },
 }

--- a/gh-ctrl/client/src/components/UpdateNotificationBanner.tsx
+++ b/gh-ctrl/client/src/components/UpdateNotificationBanner.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { api } from '../api'
 
 interface UpdateNotificationBannerProps {
@@ -9,7 +9,7 @@ interface UpdateNotificationBannerProps {
   onDismiss: () => void
 }
 
-type InstallState = 'idle' | 'running' | 'success' | 'error'
+type InstallState = 'idle' | 'running' | 'success' | 'error' | 'unknown'
 
 export function UpdateNotificationBanner({
   current,
@@ -21,6 +21,17 @@ export function UpdateNotificationBanner({
   const [showDialog, setShowDialog] = useState(false)
   const [installState, setInstallState] = useState<InstallState>('idle')
   const [installOutput, setInstallOutput] = useState('')
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  // Focus the dialog when it opens, restore focus on close
+  useEffect(() => {
+    if (showDialog && dialogRef.current) {
+      dialogRef.current.focus()
+    } else if (!showDialog && triggerRef.current) {
+      triggerRef.current.focus()
+    }
+  }, [showDialog])
 
   const handleInstall = async () => {
     setInstallState('running')
@@ -28,12 +39,72 @@ export function UpdateNotificationBanner({
     setShowDialog(true)
 
     try {
-      const result = await api.triggerUpdate()
-      setInstallOutput(result.output)
-      setInstallState(result.success ? 'success' : 'error')
+      const result = await api.triggerUpdate((chunk) => {
+        setInstallOutput((prev) => prev + chunk)
+      })
+
+      if (result.error && result.exitCode === -1) {
+        // Check if this looks like a transport/connection error (container restarted)
+        const isTransportError =
+          result.error.includes('fetch') ||
+          result.error.includes('network') ||
+          result.error.includes('connect') ||
+          result.error.includes('Could not parse')
+
+        if (isTransportError) {
+          setInstallOutput((prev) =>
+            prev + '\n[Connection closed — the container may be restarting…]\n'
+          )
+          setInstallState('unknown')
+          // Follow-up check to determine true success
+          try {
+            const check = await api.checkVersion()
+            if (!check.updateAvailable) {
+              setInstallState('success')
+            } else {
+              setInstallState('error')
+            }
+          } catch {
+            setInstallState('unknown')
+          }
+        } else {
+          setInstallOutput((prev) =>
+            prev + `\n[Error: ${result.error}]\n`
+          )
+          setInstallState('error')
+        }
+      } else {
+        setInstallState(result.exitCode === 0 ? 'success' : 'error')
+      }
     } catch (err) {
-      setInstallOutput(err instanceof Error ? err.message : 'Update failed')
-      setInstallState('error')
+      const msg = err instanceof Error ? err.message : String(err)
+      // Network/transport errors are expected when the container restarts
+      const isTransportError =
+        err instanceof TypeError ||
+        msg.toLowerCase().includes('fetch') ||
+        msg.toLowerCase().includes('network') ||
+        msg.toLowerCase().includes('failed to fetch') ||
+        (err instanceof DOMException && err.name === 'AbortError')
+
+      if (isTransportError) {
+        setInstallOutput((prev) =>
+          prev + '\n[Connection closed — the container may be restarting…]\n'
+        )
+        setInstallState('unknown')
+        try {
+          const check = await api.checkVersion()
+          if (!check.updateAvailable) {
+            setInstallState('success')
+          } else {
+            setInstallState('error')
+          }
+        } catch {
+          setInstallState('unknown')
+        }
+      } else {
+        setInstallOutput(msg)
+        setInstallState('error')
+      }
     }
   }
 
@@ -42,7 +113,12 @@ export function UpdateNotificationBanner({
     setShowDialog(false)
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') handleCloseDialog()
+  }
+
   const displayVersion = releaseName ?? latest
+  const titleId = 'update-dialog-title'
 
   return (
     <>
@@ -66,6 +142,7 @@ export function UpdateNotificationBanner({
             </a>
           )}
           <button
+            ref={triggerRef}
             className={`hud-btn update-banner-install-btn${installState === 'running' ? ' active' : ''}`}
             onClick={handleInstall}
             disabled={installState === 'running'}
@@ -95,8 +172,16 @@ export function UpdateNotificationBanner({
           className="modal-overlay"
           onClick={(e) => e.target === e.currentTarget && handleCloseDialog()}
         >
-          <div className="modal update-install-modal">
-            <div className="modal-title">
+          <div
+            ref={dialogRef}
+            className="modal update-install-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            tabIndex={-1}
+            onKeyDown={handleKeyDown}
+          >
+            <div id={titleId} className="modal-title">
               {installState === 'running' && (
                 <>
                   <span className="spinning-process">&#x2699;</span> Running Update…
@@ -104,6 +189,7 @@ export function UpdateNotificationBanner({
               )}
               {installState === 'success' && <>&#x2713; Update Complete</>}
               {installState === 'error' && <>&#x2717; Update Failed</>}
+              {installState === 'unknown' && <>&#x3F; Update Status Unknown</>}
               {installState === 'idle' && <>Install Update</>}
             </div>
 
@@ -118,11 +204,18 @@ export function UpdateNotificationBanner({
                 or refresh manually after a few seconds.
               </div>
             )}
+            {installState === 'unknown' && (
+              <div className="update-install-notice">
+                The connection was interrupted — this is expected when the container
+                restarts during an update. Check the version indicator to confirm
+                the new version is running, or refresh the page.
+              </div>
+            )}
             {installState === 'error' && (
               <div className="update-install-notice update-install-notice--error">
                 Update failed. Check the output above.<br />
                 Ensure <code>/var/run/docker.sock</code> and the project root
-                (<code>.:/workspace</code>) are mounted in <code>compose.yml</code>,
+                (<code>.:/workspace</code>) are mounted via <code>compose.update.yml</code>,
                 then run <code>gh-ctrl/scripts/update.sh</code> manually on the host.
               </div>
             )}

--- a/gh-ctrl/client/src/components/UpdateNotificationBanner.tsx
+++ b/gh-ctrl/client/src/components/UpdateNotificationBanner.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+import { api } from '../api'
+
+interface UpdateNotificationBannerProps {
+  current: string | null
+  latest: string | null
+  releaseName: string | null
+  releaseUrl: string | null
+  onDismiss: () => void
+}
+
+type InstallState = 'idle' | 'running' | 'success' | 'error'
+
+export function UpdateNotificationBanner({
+  current,
+  latest,
+  releaseName,
+  releaseUrl,
+  onDismiss,
+}: UpdateNotificationBannerProps) {
+  const [showDialog, setShowDialog] = useState(false)
+  const [installState, setInstallState] = useState<InstallState>('idle')
+  const [installOutput, setInstallOutput] = useState('')
+
+  const handleInstall = async () => {
+    setInstallState('running')
+    setInstallOutput('')
+    setShowDialog(true)
+
+    try {
+      const result = await api.triggerUpdate()
+      setInstallOutput(result.output)
+      setInstallState(result.success ? 'success' : 'error')
+    } catch (err) {
+      setInstallOutput(err instanceof Error ? err.message : 'Update failed')
+      setInstallState('error')
+    }
+  }
+
+  const handleCloseDialog = () => {
+    if (installState === 'running') return
+    setShowDialog(false)
+  }
+
+  const displayVersion = releaseName ?? latest
+
+  return (
+    <>
+      <div className="update-banner" role="alert" aria-live="polite">
+        <span className="update-banner-dot" />
+        <span className="update-banner-text">
+          <strong>{displayVersion}</strong> is available
+          {current && (
+            <span className="update-banner-current"> — current: v{current}</span>
+          )}
+        </span>
+        <div className="update-banner-actions">
+          {releaseUrl && (
+            <a
+              href={releaseUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="update-banner-link"
+            >
+              RELEASE NOTES
+            </a>
+          )}
+          <button
+            className={`hud-btn update-banner-install-btn${installState === 'running' ? ' active' : ''}`}
+            onClick={handleInstall}
+            disabled={installState === 'running'}
+            title="Run update script on the server (Docker Compose rebuild + restart)"
+          >
+            {installState === 'running' ? (
+              <>
+                <span className="spinning-process">&#x2699;</span> UPDATING…
+              </>
+            ) : (
+              <>&#x2B06; INSTALL UPDATE</>
+            )}
+          </button>
+          <button
+            className="hud-btn hud-btn-icon update-banner-dismiss"
+            onClick={onDismiss}
+            title={`Dismiss — won't show again for ${latest}`}
+            aria-label="Dismiss update notification"
+          >
+            &#x2715;
+          </button>
+        </div>
+      </div>
+
+      {showDialog && (
+        <div
+          className="modal-overlay"
+          onClick={(e) => e.target === e.currentTarget && handleCloseDialog()}
+        >
+          <div className="modal update-install-modal">
+            <div className="modal-title">
+              {installState === 'running' && (
+                <>
+                  <span className="spinning-process">&#x2699;</span> Running Update…
+                </>
+              )}
+              {installState === 'success' && <>&#x2713; Update Complete</>}
+              {installState === 'error' && <>&#x2717; Update Failed</>}
+              {installState === 'idle' && <>Install Update</>}
+            </div>
+
+            <pre className="update-install-output">
+              {installOutput || 'Starting update script…'}
+            </pre>
+
+            {installState === 'success' && (
+              <div className="update-install-notice">
+                Docker Compose is rebuilding and restarting the container.
+                This page will reload automatically once the new version is live —
+                or refresh manually after a few seconds.
+              </div>
+            )}
+            {installState === 'error' && (
+              <div className="update-install-notice update-install-notice--error">
+                Update failed. Check the output above.<br />
+                Ensure <code>/var/run/docker.sock</code> and the project root
+                (<code>.:/workspace</code>) are mounted in <code>compose.yml</code>,
+                then run <code>gh-ctrl/scripts/update.sh</code> manually on the host.
+              </div>
+            )}
+
+            <div className="modal-actions">
+              <button
+                className="hud-btn"
+                onClick={handleCloseDialog}
+                disabled={installState === 'running'}
+              >
+                {installState === 'running' ? 'PLEASE WAIT…' : 'CLOSE'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/gh-ctrl/client/src/hooks/useVersionCheck.ts
+++ b/gh-ctrl/client/src/hooks/useVersionCheck.ts
@@ -1,0 +1,88 @@
+import { useState, useEffect, useCallback } from 'react'
+import { api } from '../api'
+
+interface VersionCheckState {
+  current: string | null
+  latest: string | null
+  updateAvailable: boolean
+  releaseUrl: string | null
+  releaseName: string | null
+}
+
+interface CachedCheck {
+  data: VersionCheckState
+  timestamp: number
+}
+
+const CACHE_KEY = 'versionCheck'
+const DISMISSED_KEY = 'versionCheckDismissed'
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000 // 6 hours
+
+export function useVersionCheck() {
+  const [state, setState] = useState<VersionCheckState | null>(null)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    const dismissedVersion = localStorage.getItem(DISMISSED_KEY)
+
+    // Use cached result if still fresh
+    try {
+      const raw = localStorage.getItem(CACHE_KEY)
+      if (raw) {
+        const cached: CachedCheck = JSON.parse(raw)
+        if (Date.now() - cached.timestamp < CACHE_TTL_MS) {
+          setState(cached.data)
+          if (dismissedVersion && dismissedVersion === cached.data.latest) {
+            setDismissed(true)
+          }
+          return
+        }
+      }
+    } catch {
+      // ignore corrupt cache
+    }
+
+    // Fetch fresh from backend
+    api
+      .checkVersion()
+      .then((result) => {
+        const checkState: VersionCheckState = {
+          current: result.current,
+          latest: result.latest,
+          updateAvailable: result.updateAvailable,
+          releaseUrl: result.releaseUrl,
+          releaseName: result.releaseName,
+        }
+        setState(checkState)
+        localStorage.setItem(
+          CACHE_KEY,
+          JSON.stringify({ data: checkState, timestamp: Date.now() })
+        )
+        if (dismissedVersion && dismissedVersion === result.latest) {
+          setDismissed(true)
+        }
+      })
+      .catch(() => {
+        // silently fail — version check is non-critical
+      })
+  }, [])
+
+  const dismiss = useCallback(() => {
+    setState((prev) => {
+      if (prev?.latest) {
+        localStorage.setItem(DISMISSED_KEY, prev.latest)
+      }
+      return prev
+    })
+    setDismissed(true)
+  }, [])
+
+  return {
+    current: state?.current ?? null,
+    latest: state?.latest ?? null,
+    releaseName: state?.releaseName ?? null,
+    releaseUrl: state?.releaseUrl ?? null,
+    updateAvailable: (state?.updateAvailable && !dismissed) ?? false,
+    dismiss,
+  }
+}

--- a/gh-ctrl/client/src/hooks/useVersionCheck.ts
+++ b/gh-ctrl/client/src/hooks/useVersionCheck.ts
@@ -43,9 +43,11 @@ export function useVersionCheck() {
     }
 
     // Fetch fresh from backend
+    let cancelled = false
     api
       .checkVersion()
       .then((result) => {
+        if (cancelled) return
         const checkState: VersionCheckState = {
           current: result.current,
           latest: result.latest,
@@ -65,6 +67,10 @@ export function useVersionCheck() {
       .catch(() => {
         // silently fail — version check is non-critical
       })
+
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   const dismiss = useCallback(() => {

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -6348,3 +6348,171 @@ select.input {
   }
 }
 
+/* ── Update Notification Banner ─────────────────────────────────── */
+
+.update-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 36px;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px 0 16px;
+  background: rgba(0, 14, 0, 0.96);
+  border-bottom: 1px solid rgba(57, 255, 20, 0.4);
+  backdrop-filter: blur(8px);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--crt-green);
+  letter-spacing: 0.04em;
+}
+
+.update-banner-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--crt-green);
+  box-shadow: 0 0 6px rgba(57, 255, 20, 0.8);
+  flex-shrink: 0;
+  animation: update-dot-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes update-dot-pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 6px rgba(57, 255, 20, 0.8); }
+  50% { opacity: 0.4; box-shadow: 0 0 2px rgba(57, 255, 20, 0.3); }
+}
+
+.update-banner-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.update-banner-current {
+  opacity: 0.55;
+  margin-left: 4px;
+}
+
+.update-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.update-banner-link {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.8px;
+  color: rgba(57, 255, 20, 0.65);
+  text-decoration: none;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border: 1px solid rgba(57, 255, 20, 0.25);
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.update-banner-link:hover {
+  color: var(--crt-green);
+  border-color: rgba(57, 255, 20, 0.6);
+}
+
+.update-banner-install-btn {
+  font-size: 9px !important;
+  padding: 2px 8px !important;
+  background: rgba(57, 255, 20, 0.08) !important;
+  border-color: rgba(57, 255, 20, 0.5) !important;
+}
+
+.update-banner-install-btn:hover:not(:disabled) {
+  background: rgba(57, 255, 20, 0.15) !important;
+  border-color: var(--crt-green) !important;
+  box-shadow: 0 0 8px rgba(57, 255, 20, 0.3) !important;
+}
+
+.update-banner-dismiss {
+  opacity: 0.5;
+  font-size: 10px !important;
+  padding: 2px 5px !important;
+}
+
+.update-banner-dismiss:hover {
+  opacity: 1;
+}
+
+/* Push app content down when banner is visible */
+.app-layout.update-banner-visible {
+  padding-top: 36px;
+}
+
+/* Sidebar update indicator */
+.sidebar-version--update {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+}
+
+.sidebar-update-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--crt-green);
+  box-shadow: 0 0 5px rgba(57, 255, 20, 0.7);
+  animation: update-dot-pulse 1.6s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+/* Update install dialog */
+.update-install-modal {
+  width: 600px;
+  max-width: calc(100vw - 40px);
+}
+
+.update-install-output {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--crt-green);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 360px;
+  overflow-y: auto;
+  margin-bottom: 12px;
+  line-height: 1.6;
+}
+
+.update-install-notice {
+  font-size: 11px;
+  color: var(--text-2);
+  background: rgba(57, 255, 20, 0.05);
+  border: 1px solid rgba(57, 255, 20, 0.15);
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+.update-install-notice code {
+  font-family: var(--font-mono);
+  color: var(--crt-green);
+  font-size: 10px;
+}
+
+.update-install-notice--error {
+  background: rgba(248, 81, 73, 0.06);
+  border-color: rgba(248, 81, 73, 0.2);
+  color: var(--crt-red);
+}
+
+.update-install-notice--error code {
+  color: var(--crt-red);
+}
+

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -6449,6 +6449,11 @@ select.input {
   padding-top: 36px;
 }
 
+/* Keep hamburger above the update banner on mobile */
+.app-layout.update-banner-visible .sidebar-hamburger {
+  top: 44px;
+}
+
 /* Sidebar update indicator */
 .sidebar-version--update {
   display: flex;
@@ -6482,7 +6487,8 @@ select.input {
   font-size: 11px;
   color: var(--crt-green);
   white-space: pre-wrap;
-  word-break: break-word;
+  word-break: normal;
+  overflow-wrap: anywhere;
   max-height: 360px;
   overflow-y: auto;
   margin-bottom: 12px;

--- a/gh-ctrl/scripts/update.sh
+++ b/gh-ctrl/scripts/update.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Vibe & Conquer — Docker Update Script
+#
+# Pulls the latest code from origin/main, rebuilds the Docker image,
+# and restarts services via Docker Compose.
+#
+# ── Usage ──────────────────────────────────────────────────────────────────────
+#
+#   Manual (run on the VPS host):
+#     cd /path/to/vibe-and-conquer && ./gh-ctrl/scripts/update.sh
+#
+#   In-app "Install Update" button (triggered via the backend inside the container):
+#     Requires the following volumes in compose.yml (see compose.yml):
+#       - /var/run/docker.sock:/var/run/docker.sock
+#       - .:/workspace
+#
+# ── Prerequisites ───────────────────────────────────────────────────────────────
+#   docker (compose v2 plugin)  •  git  •  curl (for backup, optional)
+# ───────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+# ── Resolve project root ───────────────────────────────────────────────────────
+# Inside the container the host project root is mounted at /workspace.
+# When run on the host directly, derive the root from this script's location.
+if [ -f "/workspace/compose.yml" ]; then
+  PROJECT_ROOT="/workspace"
+else
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+fi
+
+echo "==> Vibe & Conquer Update Script (Docker)"
+echo "==> Project root: $PROJECT_ROOT"
+echo ""
+
+cd "$PROJECT_ROOT"
+
+# ── 1. Backup database ─────────────────────────────────────────────────────────
+echo "==> Backing up database..."
+BACKUP_DIR="./backups/$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$BACKUP_DIR"
+docker compose cp app:/app/data/. "$BACKUP_DIR/" 2>/dev/null \
+  && echo "  Backed up to $BACKUP_DIR" \
+  || echo "  (skipped — container not running or no data volume yet)"
+echo ""
+
+# ── 2. Pull latest source code ─────────────────────────────────────────────────
+echo "==> Pulling latest code from origin/main..."
+git pull origin main
+echo ""
+
+# ── 3. Rebuild and restart via Docker Compose ──────────────────────────────────
+echo "==> Rebuilding and restarting services (prod profile)..."
+docker compose --profile prod up -d --build
+echo ""
+
+# ── 4. Prune stale images ──────────────────────────────────────────────────────
+echo "==> Cleaning up old images..."
+docker image prune -f
+echo ""
+
+echo "==> Update complete!"
+echo "==> The container is restarting with the latest build."
+echo "==> Monitor logs with: docker compose logs -f app"

--- a/gh-ctrl/scripts/update.sh
+++ b/gh-ctrl/scripts/update.sh
@@ -44,9 +44,11 @@ docker compose cp app:/app/data/. "$BACKUP_DIR/" 2>/dev/null \
   || echo "  (skipped — container not running or no data volume yet)"
 echo ""
 
-# ── 2. Pull latest source code ─────────────────────────────────────────────────
-echo "==> Pulling latest code from origin/main..."
-git pull origin main
+# ── 2. Sync working tree to origin/main ────────────────────────────────────────
+echo "==> Syncing working tree to origin/main..."
+git fetch origin main --tags
+git checkout main
+git reset --hard origin/main
 echo ""
 
 # ── 3. Rebuild and restart via Docker Compose ──────────────────────────────────

--- a/gh-ctrl/src/__tests__/test-db.ts
+++ b/gh-ctrl/src/__tests__/test-db.ts
@@ -72,6 +72,14 @@ export function createTestDb() {
   `)
 
   sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER DEFAULT (unixepoch())
+    )
+  `)
+
+  sqlite.exec(`
     CREATE TABLE IF NOT EXISTS badges (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL,

--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -13,7 +13,7 @@ import timersRouter from './routes/timers'
 import contactsRouter from './routes/contacts'
 import settingsRouter from './routes/settings'
 import shellRouter, { shellWebsocket } from './routes/shell'
-import pkg from '../package.json'
+import versionRouter from './routes/version'
 import { existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { initHealthcheckService } from './healthcheck-service'
@@ -62,9 +62,9 @@ app.route('/api/timers', timersRouter)
 app.route('/api/contacts', contactsRouter)
 app.route('/api/settings', settingsRouter)
 app.route('/api/shell', shellRouter)
+app.route('/api/version', versionRouter)
 
 app.get('/api/health', (c) => c.json({ ok: true }))
-app.get('/api/version', (c) => c.json({ version: pkg.version }))
 
 // Serve uploaded badge images
 app.use('/uploads/*', serveStatic({ root: './' }))

--- a/gh-ctrl/src/middleware/auth.ts
+++ b/gh-ctrl/src/middleware/auth.ts
@@ -18,7 +18,7 @@ function getJwks() {
   return jwks
 }
 
-const PUBLIC_PATHS = ['/api/health', '/api/version']
+const PUBLIC_PATHS = ['/api/health', '/api/version', '/api/version/check']
 
 export const authMiddleware: MiddlewareHandler = async (c, next) => {
   // Skip auth for public endpoints

--- a/gh-ctrl/src/routes/version.ts
+++ b/gh-ctrl/src/routes/version.ts
@@ -1,0 +1,141 @@
+import { Hono } from 'hono'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import pkg from '../../package.json'
+
+const router = new Hono()
+
+interface VersionCheckResult {
+  current: string
+  latest: string | null
+  updateAvailable: boolean
+  releaseUrl: string | null
+  releaseName: string | null
+}
+
+interface CacheEntry {
+  data: VersionCheckResult
+  timestamp: number
+}
+
+const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour server-side cache
+const GITHUB_REPO = 'svengraziani/vibe-and-conquer'
+let releaseCache: CacheEntry | null = null
+
+function semverGt(a: string, b: string): boolean {
+  const parse = (v: string) =>
+    v
+      .replace(/^v/, '')
+      .split('.')
+      .map((n) => parseInt(n, 10) || 0)
+  const [aMajor = 0, aMinor = 0, aPatch = 0] = parse(a)
+  const [bMajor = 0, bMinor = 0, bPatch = 0] = parse(b)
+  if (aMajor !== bMajor) return aMajor > bMajor
+  if (aMinor !== bMinor) return aMinor > bMinor
+  return aPatch > bPatch
+}
+
+// GET / — current version (moved here from index.ts)
+router.get('/', (c) => c.json({ version: pkg.version }))
+
+// GET /check — compare installed version with latest GitHub release
+router.get('/check', async (c) => {
+  const current = pkg.version
+
+  if (releaseCache && Date.now() - releaseCache.timestamp < CACHE_TTL_MS) {
+    return c.json(releaseCache.data)
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
+      {
+        headers: {
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 'vibe-and-conquer-app',
+        },
+        signal: AbortSignal.timeout(5000),
+      }
+    )
+
+    if (!res.ok) {
+      return c.json({
+        current,
+        latest: null,
+        updateAvailable: false,
+        releaseUrl: null,
+        releaseName: null,
+      })
+    }
+
+    const release = (await res.json()) as {
+      tag_name: string
+      html_url: string
+      name: string
+    }
+
+    const latestClean = release.tag_name.replace(/^v/, '')
+    const updateAvailable = semverGt(latestClean, current)
+
+    const result: VersionCheckResult = {
+      current,
+      latest: release.tag_name,
+      updateAvailable,
+      releaseUrl: release.html_url,
+      releaseName: release.name || release.tag_name,
+    }
+
+    releaseCache = { data: result, timestamp: Date.now() }
+    return c.json(result)
+  } catch {
+    return c.json({
+      current,
+      latest: null,
+      updateAvailable: false,
+      releaseUrl: null,
+      releaseName: null,
+    })
+  }
+})
+
+// POST /update — run scripts/update.sh and return full output
+// In Docker deployments, the script is available via the /workspace bind mount.
+// Requires: /var/run/docker.sock and . (project root) mounted in compose.yml.
+router.post('/update', async (c) => {
+  // Prefer the host-mounted path (/workspace) so the script can run
+  // docker compose commands with the correct project context.
+  const inContainerPath = '/workspace/gh-ctrl/scripts/update.sh'
+  const localPath = join(process.cwd(), 'scripts', 'update.sh')
+  const scriptPath = existsSync(inContainerPath) ? inContainerPath : localPath
+
+  const workDir = existsSync('/workspace/compose.yml') ? '/workspace' : process.cwd()
+
+  try {
+    const proc = Bun.spawn(['bash', scriptPath], {
+      cwd: workDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    const output = [stdout, stderr].filter(Boolean).join('\n').trim()
+
+    return c.json({ success: exitCode === 0, output, exitCode })
+  } catch (err) {
+    return c.json(
+      {
+        success: false,
+        output: err instanceof Error ? err.message : String(err),
+        exitCode: -1,
+      },
+      500
+    )
+  }
+})
+
+export default router

--- a/gh-ctrl/src/routes/version.ts
+++ b/gh-ctrl/src/routes/version.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { stream } from 'hono/streaming'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import pkg from '../../package.json'
@@ -20,6 +21,7 @@ interface CacheEntry {
 
 const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour server-side cache
 const GITHUB_REPO = 'svengraziani/vibe-and-conquer'
+const MAX_OUTPUT_BYTES = 512 * 1024 // 512 KB cap on streamed output
 let releaseCache: CacheEntry | null = null
 
 function semverGt(a: string, b: string): boolean {
@@ -98,44 +100,67 @@ router.get('/check', async (c) => {
   }
 })
 
-// POST /update — run scripts/update.sh and return full output
-// In Docker deployments, the script is available via the /workspace bind mount.
-// Requires: /var/run/docker.sock and . (project root) mounted in compose.yml.
-router.post('/update', async (c) => {
-  // Prefer the host-mounted path (/workspace) so the script can run
-  // docker compose commands with the correct project context.
+// POST /update — stream scripts/update.sh output to the client.
+// In Docker deployments, the script is available via the /workspace bind mount
+// (compose.update.yml). Requires: /var/run/docker.sock and . (project root).
+router.post('/update', (c) => {
   const inContainerPath = '/workspace/gh-ctrl/scripts/update.sh'
   const localPath = join(process.cwd(), 'scripts', 'update.sh')
   const scriptPath = existsSync(inContainerPath) ? inContainerPath : localPath
 
   const workDir = existsSync('/workspace/compose.yml') ? '/workspace' : process.cwd()
 
-  try {
-    const proc = Bun.spawn(['bash', scriptPath], {
-      cwd: workDir,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    })
+  return stream(c, async (s) => {
+    const decoder = new TextDecoder()
+    let totalBytes = 0
+    let truncated = false
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ])
+    async function drainStream(readable: ReadableStream<Uint8Array>) {
+      const reader = readable.getReader()
+      try {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          if (!value) continue
+          totalBytes += value.byteLength
+          if (totalBytes > MAX_OUTPUT_BYTES) {
+            if (!truncated) {
+              truncated = true
+              await s.write('\n[output truncated — 512 KB limit reached]\n')
+            }
+            continue
+          }
+          await s.write(decoder.decode(value, { stream: true }))
+        }
+      } finally {
+        reader.releaseLock()
+      }
+    }
 
-    const output = [stdout, stderr].filter(Boolean).join('\n').trim()
+    try {
+      const proc = Bun.spawn(['bash', scriptPath], {
+        cwd: workDir,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
 
-    return c.json({ success: exitCode === 0, output, exitCode })
-  } catch (err) {
-    return c.json(
-      {
-        success: false,
-        output: err instanceof Error ? err.message : String(err),
-        exitCode: -1,
-      },
-      500
-    )
-  }
+      await Promise.all([drainStream(proc.stdout), drainStream(proc.stderr)])
+
+      const exitCode = await proc.exited
+      // Sentinel line so the client can determine success/failure
+      await s.write(
+        `\n__META__:${JSON.stringify({ exitCode, truncated })}\n`
+      )
+    } catch (err) {
+      await s.write(
+        `\n__META__:${JSON.stringify({
+          exitCode: -1,
+          truncated,
+          error: err instanceof Error ? err.message : String(err),
+        })}\n`
+      )
+    }
+  })
 })
 
 export default router


### PR DESCRIPTION
Implements #340: version check & notification with Docker-native install action button.

- Fixed top banner when a new release is available
- Pulsing green dot in sidebar version indicator
- INSTALL UPDATE button runs scripts/update.sh via Docker Compose (git pull + rebuild + restart)
- compose.yml: mounts Docker socket + project root for in-container Docker access
- Dockerfile: adds docker-ce-cli + docker-compose-plugin + git to runtime stage
- Version check cached 6h client-side + 1h server-side
- Dismiss is per-version (re-notifies when next version ships)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now automatically checks for available updates and displays a notification banner when a new version is found
  * Users can install available updates directly from the app with real-time progress feedback and release notes access
  * Update notifications can be dismissed and will reappear after 6 hours

<!-- end of auto-generated comment: release notes by coderabbit.ai -->