### PR TITLE
feat: Database Export / Import (Backup & Restore)

### DIFF
--- a/gh-ctrl/bun.lock
+++ b/gh-ctrl/bun.lock
@@ -11,6 +11,7 @@
         "hono": "^4.4.0",
         "imapflow": "^1.2.18",
         "jose": "^5.9.6",
+        "jszip": "^3.10.1",
         "lucide-react": "^0.577.0",
         "nodemailer": "^8.0.4",
         "react-router-dom": "^7.13.1",

--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -683,3 +683,48 @@ export const api = {
       `/buildings/${buildingId}/shell/connections/${connectionId}/tmux-sessions`
     ),
 }
+
+export async function exportBackup(): Promise<Blob> {
+  const token = _getToken?.()
+  const authHeader: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {}
+  const res = await fetch(`${getBase()}/backup/export`, { headers: authHeader })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error((err as any).error || res.statusText)
+  }
+  return res.blob()
+}
+
+export async function importBackup(file: File): Promise<{ success: boolean; stats: Record<string, number>; badgeFileErrors?: string[] }> {
+  const token = _getToken?.()
+  const authHeader: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {}
+  const form = new FormData()
+  form.append('file', file)
+  const res = await fetch(`${getBase()}/backup/import`, {
+    method: 'POST',
+    headers: authHeader,
+    body: form,
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error((err as any).error || res.statusText)
+  }
+  return res.json()
+}
+
+export async function previewBackup(file: File): Promise<{ version: number; appVersion: string; exportedAt: string; tables: Record<string, number> }> {
+  const token = _getToken?.()
+  const authHeader: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {}
+  const form = new FormData()
+  form.append('file', file)
+  const res = await fetch(`${getBase()}/backup/preview`, {
+    method: 'POST',
+    headers: authHeader,
+    body: form,
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error((err as any).error || res.statusText)
+  }
+  return res.json()
+}

--- a/gh-ctrl/client/src/components/BackupPanel.tsx
+++ b/gh-ctrl/client/src/components/BackupPanel.tsx
@@ -1,0 +1,279 @@
+import { useState, useRef } from 'react'
+import { exportBackup, importBackup, previewBackup } from '../api'
+import { useAppStore } from '../store'
+
+interface BackupManifest {
+  version: number
+  appVersion: string
+  exportedAt: string
+  tables: Record<string, number>
+}
+
+export function BackupPanel() {
+  const addToast = useAppStore((s) => s.addToast)
+
+  // Export state
+  const [exporting, setExporting] = useState(false)
+
+  // Import state
+  const [importFile, setImportFile] = useState<File | null>(null)
+  const [manifest, setManifest] = useState<BackupManifest | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [previewError, setPreviewError] = useState('')
+  const [importing, setImporting] = useState(false)
+  const [dragOver, setDragOver] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleExport = async () => {
+    setExporting(true)
+    try {
+      const blob = await exportBackup()
+      const isoDate = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `ghctrl-backup-${isoDate}.zip`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+      addToast('Backup downloaded successfully', 'success')
+    } catch (err: any) {
+      addToast(`Export failed: ${err.message}`, 'error')
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  const handleFileSelect = async (file: File) => {
+    if (!file.name.endsWith('.zip')) {
+      setPreviewError('Please select a .zip backup file')
+      setImportFile(null)
+      setManifest(null)
+      return
+    }
+
+    setImportFile(file)
+    setManifest(null)
+    setPreviewError('')
+    setPreviewLoading(true)
+
+    try {
+      const meta = await previewBackup(file)
+      setManifest(meta)
+    } catch (err: any) {
+      setPreviewError(`Could not read backup: ${err.message}`)
+    } finally {
+      setPreviewLoading(false)
+    }
+  }
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) handleFileSelect(file)
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setDragOver(false)
+    const file = e.dataTransfer.files?.[0]
+    if (file) handleFileSelect(file)
+  }
+
+  const handleImport = async () => {
+    if (!importFile || !manifest) return
+    setImporting(true)
+    try {
+      const result = await importBackup(importFile)
+      const totalRows = Object.values(result.stats).reduce((a, b) => a + b, 0)
+      addToast(`Restore complete — ${totalRows} records restored`, 'success')
+      if (result.badgeFileErrors?.length) {
+        addToast(`Some badge files could not be restored: ${result.badgeFileErrors.join(', ')}`, 'error')
+      }
+      setImportFile(null)
+      setManifest(null)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    } catch (err: any) {
+      addToast(`Restore failed: ${err.message}`, 'error')
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  const handleClearFile = () => {
+    setImportFile(null)
+    setManifest(null)
+    setPreviewError('')
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const formatDate = (iso: string) => {
+    try {
+      return new Date(iso).toLocaleString()
+    } catch {
+      return iso
+    }
+  }
+
+  return (
+    <div className="settings-section">
+      <h2>Backup &amp; Restore</h2>
+
+      {/* Export */}
+      <div style={{ marginBottom: '1.5rem' }}>
+        <h3 style={{ fontSize: '0.95rem', fontWeight: 600, marginBottom: '0.5rem', color: 'var(--text)' }}>
+          Export
+        </h3>
+        <p style={{ fontSize: '0.82rem', color: 'var(--text-2)', marginBottom: '0.75rem' }}>
+          Download a full backup ZIP containing all your data (repos, maps, buildings, messages, timers, etc.) and badge image files.
+        </p>
+        <div
+          style={{
+            padding: '0.6rem 0.75rem',
+            background: 'rgba(255, 200, 0, 0.08)',
+            border: '1px solid rgba(255, 200, 0, 0.25)',
+            borderRadius: '6px',
+            fontSize: '0.78rem',
+            color: 'var(--text-2)',
+            marginBottom: '0.75rem',
+          }}
+        >
+          &#9888;&#65039; The backup includes sensitive tokens and credentials (GitLab tokens, SSH keys). Store it securely.
+        </div>
+        <button
+          className="btn btn-primary"
+          onClick={handleExport}
+          disabled={exporting}
+        >
+          {exporting ? 'Building backup…' : 'Download Backup'}
+        </button>
+      </div>
+
+      {/* Divider */}
+      <div style={{ borderTop: '1px solid var(--border)', marginBottom: '1.5rem' }} />
+
+      {/* Import */}
+      <div>
+        <h3 style={{ fontSize: '0.95rem', fontWeight: 600, marginBottom: '0.5rem', color: 'var(--text)' }}>
+          Restore
+        </h3>
+        <p style={{ fontSize: '0.82rem', color: 'var(--text-2)', marginBottom: '0.75rem' }}>
+          Restore from a previously exported backup. <strong style={{ color: 'var(--red, #f85149)' }}>This will overwrite all current data.</strong>
+        </p>
+
+        {/* Drag-and-drop zone */}
+        <div
+          onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={handleDrop}
+          onClick={() => !importFile && fileInputRef.current?.click()}
+          style={{
+            border: `2px dashed ${dragOver ? 'var(--green-neon, #00ff88)' : 'var(--border)'}`,
+            borderRadius: '8px',
+            padding: '1.5rem',
+            textAlign: 'center',
+            cursor: importFile ? 'default' : 'pointer',
+            background: dragOver ? 'rgba(0,255,136,0.05)' : 'transparent',
+            transition: 'border-color 0.15s, background 0.15s',
+            marginBottom: '0.75rem',
+          }}
+        >
+          {!importFile ? (
+            <>
+              <div style={{ fontSize: '1.5rem', marginBottom: '0.4rem' }}>&#128230;</div>
+              <div style={{ fontSize: '0.85rem', color: 'var(--text-2)' }}>
+                Drag &amp; drop a <code>.zip</code> backup here, or <span style={{ color: 'var(--green-neon, #00ff88)' }}>click to browse</span>
+              </div>
+            </>
+          ) : (
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem' }}>
+              <span style={{ fontSize: '0.88rem', color: 'var(--text)' }}>&#128196; {importFile.name}</span>
+              <button
+                className="btn btn-ghost btn-sm"
+                onClick={(e) => { e.stopPropagation(); handleClearFile() }}
+                style={{ padding: '1px 6px', fontSize: '0.78rem' }}
+              >
+                &times;
+              </button>
+            </div>
+          )}
+        </div>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".zip"
+          style={{ display: 'none' }}
+          onChange={handleFileInputChange}
+        />
+
+        {previewLoading && (
+          <div style={{ fontSize: '0.82rem', color: 'var(--text-2)', marginBottom: '0.5rem' }}>
+            Reading backup…
+          </div>
+        )}
+
+        {previewError && (
+          <div style={{ fontSize: '0.82rem', color: 'var(--red, #f85149)', marginBottom: '0.5rem' }}>
+            {previewError}
+          </div>
+        )}
+
+        {manifest && (
+          <div
+            style={{
+              padding: '0.75rem',
+              background: 'var(--surface)',
+              border: '1px solid var(--border)',
+              borderRadius: '6px',
+              marginBottom: '0.75rem',
+              fontSize: '0.82rem',
+            }}
+          >
+            <div style={{ fontWeight: 600, marginBottom: '0.4rem', color: 'var(--text)' }}>
+              Backup Preview
+            </div>
+            <div style={{ color: 'var(--text-2)', marginBottom: '0.25rem' }}>
+              Exported: {formatDate(manifest.exportedAt)}
+            </div>
+            {manifest.appVersion && (
+              <div style={{ color: 'var(--text-2)', marginBottom: '0.5rem' }}>
+                App version: {manifest.appVersion}
+              </div>
+            )}
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+              {Object.entries(manifest.tables)
+                .filter(([, count]) => count > 0)
+                .map(([table, count]) => (
+                  <span
+                    key={table}
+                    style={{
+                      background: 'rgba(0,255,136,0.08)',
+                      border: '1px solid rgba(0,255,136,0.2)',
+                      borderRadius: '4px',
+                      padding: '1px 7px',
+                      color: 'var(--green-neon, #00ff88)',
+                      fontSize: '0.75rem',
+                    }}
+                  >
+                    {table}: {count}
+                  </span>
+                ))}
+            </div>
+          </div>
+        )}
+
+        {manifest && (
+          <button
+            className="btn btn-danger"
+            onClick={handleImport}
+            disabled={importing}
+            style={{ width: '100%' }}
+          >
+            {importing ? 'Restoring…' : 'Restore — this will overwrite all current data'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/components/BackupPanel.tsx
+++ b/gh-ctrl/client/src/components/BackupPanel.tsx
@@ -86,13 +86,14 @@ export function BackupPanel() {
     try {
       const result = await importBackup(importFile)
       const totalRows = Object.values(result.stats).reduce((a, b) => a + b, 0)
-      addToast(`Restore complete — ${totalRows} records restored`, 'success')
+      addToast(`Restore complete — ${totalRows} records restored. Reloading…`, 'success')
       if (result.badgeFileErrors?.length) {
         addToast(`Some badge files could not be restored: ${result.badgeFileErrors.join(', ')}`, 'error')
       }
       setImportFile(null)
       setManifest(null)
       if (fileInputRef.current) fileInputRef.current.value = ''
+      setTimeout(() => window.location.reload(), 300)
     } catch (err: any) {
       addToast(`Restore failed: ${err.message}`, 'error')
     } finally {
@@ -163,10 +164,14 @@ export function BackupPanel() {
 
         {/* Drag-and-drop zone */}
         <div
+          role="button"
+          tabIndex={0}
+          aria-label="Drop a .zip backup file here, or press Enter to browse"
           onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
           onDragLeave={() => setDragOver(false)}
           onDrop={handleDrop}
           onClick={() => !importFile && fileInputRef.current?.click()}
+          onKeyDown={(e) => { if ((e.key === 'Enter' || e.key === ' ') && !importFile) fileInputRef.current?.click() }}
           style={{
             border: `2px dashed ${dragOver ? 'var(--green-neon, #00ff88)' : 'var(--border)'}`,
             borderRadius: '8px',
@@ -203,8 +208,10 @@ export function BackupPanel() {
           ref={fileInputRef}
           type="file"
           accept=".zip"
-          style={{ display: 'none' }}
+          style={{ position: 'absolute', width: 0, height: 0, opacity: 0, overflow: 'hidden' }}
           onChange={handleFileInputChange}
+          tabIndex={-1}
+          aria-hidden="true"
         />
 
         {previewLoading && (

--- a/gh-ctrl/client/src/components/Settings.tsx
+++ b/gh-ctrl/client/src/components/Settings.tsx
@@ -4,6 +4,7 @@ import { api, getServerUrl, setServerUrl } from '../api'
 import { useAppStore } from '../store'
 import type { GameMap } from '../types'
 import { GitHubIcon, GitLabIcon } from './Icons'
+import { BackupPanel } from './BackupPanel'
 
 const COLORS = ['#39d353', '#58a6ff', '#f0883e', '#f85149', '#bc8cff', '#ffa657', '#ff7b72', '#79c0ff']
 
@@ -890,6 +891,8 @@ export function Settings() {
           </div>
         )}
       </div>
+
+      <BackupPanel />
     </div>
   )
 }

--- a/gh-ctrl/package.json
+++ b/gh-ctrl/package.json
@@ -23,6 +23,7 @@
     "hono": "^4.4.0",
     "imapflow": "^1.2.18",
     "jose": "^5.9.6",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.577.0",
     "nodemailer": "^8.0.4",
     "react-router-dom": "^7.13.1",

--- a/gh-ctrl/src/__tests__/test-db.ts
+++ b/gh-ctrl/src/__tests__/test-db.ts
@@ -96,5 +96,13 @@ export function createTestDb() {
     )
   `)
 
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER DEFAULT (unixepoch())
+    )
+  `)
+
   return drizzle(sqlite, { schema })
 }

--- a/gh-ctrl/src/db/index.ts
+++ b/gh-ctrl/src/db/index.ts
@@ -220,3 +220,4 @@ sqlite.exec(`
 `)
 
 export const db = drizzle(sqlite, { schema })
+export const sqliteDb = sqlite

--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -13,6 +13,7 @@ import timersRouter from './routes/timers'
 import contactsRouter from './routes/contacts'
 import settingsRouter from './routes/settings'
 import shellRouter, { shellWebsocket } from './routes/shell'
+import backupRouter from './routes/backup'
 import pkg from '../package.json'
 import { existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
@@ -62,6 +63,7 @@ app.route('/api/timers', timersRouter)
 app.route('/api/contacts', contactsRouter)
 app.route('/api/settings', settingsRouter)
 app.route('/api/shell', shellRouter)
+app.route('/api/backup', backupRouter)
 
 app.get('/api/health', (c) => c.json({ ok: true }))
 app.get('/api/version', (c) => c.json({ version: pkg.version }))

--- a/gh-ctrl/src/routes/backup.ts
+++ b/gh-ctrl/src/routes/backup.ts
@@ -1,11 +1,22 @@
 import { Hono } from 'hono'
 import { sqliteDb } from '../db'
-import { join } from 'node:path'
-import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join, resolve, sep } from 'node:path'
+import { existsSync, readFileSync, mkdirSync, writeFileSync, renameSync, rmSync } from 'node:fs'
 import JSZip from 'jszip'
 import pkg from '../../package.json'
 
 const UPLOAD_DIR = join(process.cwd(), 'uploads', 'badges')
+const BACKUP_VERSION = 1
+
+// Validate that a filename resolves safely within a given base directory
+function resolveBadgePath(baseDir: string, filename: string): string {
+  const resolvedRoot = resolve(baseDir)
+  const resolvedPath = resolve(baseDir, filename)
+  if (!resolvedPath.startsWith(resolvedRoot + sep)) {
+    throw new Error('Invalid badge filename')
+  }
+  return resolvedPath
+}
 
 const router = new Hono()
 
@@ -34,11 +45,14 @@ const TABLE_DELETE_ORDER = [...TABLE_INSERT_ORDER].reverse()
 // GET /export — download a full backup as ZIP
 router.get('/export', async (c) => {
   try {
-    // 1. Read all table data using raw SQL (preserves integer timestamps as-is)
-    const data: Record<string, unknown[]> = {}
-    for (const table of TABLE_INSERT_ORDER) {
-      data[table] = sqliteDb.query(`SELECT * FROM ${table}`).all()
-    }
+    // 1. Read all table data in a single transaction snapshot to avoid inconsistent state
+    const data = sqliteDb.transaction(() => {
+      const snapshot: Record<string, unknown[]> = {}
+      for (const table of TABLE_INSERT_ORDER) {
+        snapshot[table] = sqliteDb.query(`SELECT * FROM ${table}`).all()
+      }
+      return snapshot
+    })()
 
     // 2. Build manifest
     const manifest = {
@@ -59,9 +73,13 @@ router.get('/export', async (c) => {
     const badgesFolder = zip.folder('badges')!
     const badgeRows = data['badges'] as Array<{ filename: string }>
     for (const badge of badgeRows) {
-      const filepath = join(UPLOAD_DIR, badge.filename)
-      if (existsSync(filepath)) {
-        badgesFolder.file(badge.filename, readFileSync(filepath))
+      try {
+        const filepath = resolveBadgePath(UPLOAD_DIR, badge.filename)
+        if (existsSync(filepath)) {
+          badgesFolder.file(badge.filename, readFileSync(filepath))
+        }
+      } catch {
+        // Skip badges with invalid filenames
       }
     }
 
@@ -143,8 +161,8 @@ router.post('/import', async (c) => {
     return c.json({ error: 'Invalid manifest.json' }, 400)
   }
 
-  if (typeof manifest.version !== 'number' || manifest.version < 1) {
-    return c.json({ error: `Unsupported backup version: ${manifest.version}` }, 400)
+  if (manifest.version !== BACKUP_VERSION) {
+    return c.json({ error: `Unsupported backup version: ${manifest.version}. Expected: ${BACKUP_VERSION}` }, 400)
   }
 
   // 4. Parse data
@@ -158,7 +176,33 @@ router.post('/import', async (c) => {
     return c.json({ error: 'Invalid data.json' }, 400)
   }
 
-  // 5. Restore DB in a single transaction
+  // 5. Stage badge files BEFORE the DB transaction so failures are atomic
+  const badgesInZip = Object.keys(zip.files)
+    .filter((p) => p.startsWith('badges/') && !p.endsWith('/'))
+  const stagingDir = UPLOAD_DIR + '.staging'
+  const badgeFileErrors: string[] = []
+
+  if (badgesInZip.length > 0) {
+    mkdirSync(stagingDir, { recursive: true })
+
+    for (const zipPath of badgesInZip) {
+      const filename = zipPath.slice('badges/'.length)
+      try {
+        const safeTarget = resolveBadgePath(stagingDir, filename)
+        const fileBuffer = await zip.files[zipPath].async('nodebuffer')
+        writeFileSync(safeTarget, fileBuffer)
+      } catch (err: any) {
+        badgeFileErrors.push(`${filename}: ${err.message}`)
+      }
+    }
+
+    if (badgeFileErrors.length > 0) {
+      try { rmSync(stagingDir, { recursive: true, force: true }) } catch {}
+      return c.json({ error: `Badge file staging failed: ${badgeFileErrors.join(', ')}` }, 400)
+    }
+  }
+
+  // 6. Restore DB in a single transaction
   try {
     const restore = sqliteDb.transaction(() => {
       // Disable FK constraints so we can delete/insert in bulk without ordering issues
@@ -196,26 +240,29 @@ router.post('/import', async (c) => {
   } catch (err: any) {
     // Ensure FK constraints are re-enabled even on error
     try { sqliteDb.exec('PRAGMA foreign_keys = ON') } catch {}
+    if (badgesInZip.length > 0) {
+      try { rmSync(stagingDir, { recursive: true, force: true }) } catch {}
+    }
     return c.json({ error: `Restore failed: ${err.message}` }, 400)
   }
 
-  // 6. Restore badge image files (outside transaction — best effort)
-  const badgeFileErrors: string[] = []
-  if (!existsSync(UPLOAD_DIR)) {
+  // 7. Move staged badge files into the final location (atomic per-file rename)
+  if (badgesInZip.length > 0) {
     mkdirSync(UPLOAD_DIR, { recursive: true })
-  }
 
-  const badgesInZip = Object.keys(zip.files)
-    .filter((p) => p.startsWith('badges/') && !p.endsWith('/'))
-
-  for (const zipPath of badgesInZip) {
-    const filename = zipPath.slice('badges/'.length)
-    try {
-      const fileBuffer = await zip.files[zipPath].async('nodebuffer')
-      writeFileSync(join(UPLOAD_DIR, filename), fileBuffer)
-    } catch (err: any) {
-      badgeFileErrors.push(`${filename}: ${err.message}`)
+    for (const zipPath of badgesInZip) {
+      const filename = zipPath.slice('badges/'.length)
+      try {
+        renameSync(
+          resolveBadgePath(stagingDir, filename),
+          resolveBadgePath(UPLOAD_DIR, filename)
+        )
+      } catch (err: any) {
+        badgeFileErrors.push(`${filename}: ${err.message}`)
+      }
     }
+
+    try { rmSync(stagingDir, { recursive: true, force: true }) } catch {}
   }
 
   // Build stats from restored data

--- a/gh-ctrl/src/routes/backup.ts
+++ b/gh-ctrl/src/routes/backup.ts
@@ -1,0 +1,233 @@
+import { Hono } from 'hono'
+import { sqliteDb } from '../db'
+import { join } from 'node:path'
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import JSZip from 'jszip'
+import pkg from '../../package.json'
+
+const UPLOAD_DIR = join(process.cwd(), 'uploads', 'badges')
+
+const router = new Hono()
+
+// All table names in export/import order (FK dependency order for inserts)
+const TABLE_INSERT_ORDER = [
+  'repos',
+  'maps',
+  'buildings',
+  'badges',
+  'deadline_timers',
+  'contacts',
+  'settings',
+  'map_repos',
+  'clawcom_messages',
+  'healthcheck_results',
+  'mail_folders',
+  'mail_messages',
+  'placed_badges',
+  'ssh_connections',
+  'ssh_session_log',
+]
+
+// Reverse order for deletes
+const TABLE_DELETE_ORDER = [...TABLE_INSERT_ORDER].reverse()
+
+// GET /export — download a full backup as ZIP
+router.get('/export', async (c) => {
+  try {
+    // 1. Read all table data using raw SQL (preserves integer timestamps as-is)
+    const data: Record<string, unknown[]> = {}
+    for (const table of TABLE_INSERT_ORDER) {
+      data[table] = sqliteDb.query(`SELECT * FROM ${table}`).all()
+    }
+
+    // 2. Build manifest
+    const manifest = {
+      version: 1,
+      appVersion: pkg.version,
+      exportedAt: new Date().toISOString(),
+      tables: Object.fromEntries(
+        Object.entries(data).map(([t, rows]) => [t, rows.length])
+      ),
+    }
+
+    // 3. Build ZIP
+    const zip = new JSZip()
+    zip.file('manifest.json', JSON.stringify(manifest, null, 2))
+    zip.file('data.json', JSON.stringify(data, null, 2))
+
+    // 4. Add badge image files
+    const badgesFolder = zip.folder('badges')!
+    const badgeRows = data['badges'] as Array<{ filename: string }>
+    for (const badge of badgeRows) {
+      const filepath = join(UPLOAD_DIR, badge.filename)
+      if (existsSync(filepath)) {
+        badgesFolder.file(badge.filename, readFileSync(filepath))
+      }
+    }
+
+    // 5. Generate ZIP buffer
+    const buffer = await zip.generateAsync({ type: 'nodebuffer' })
+
+    const isoDate = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+    return new Response(buffer, {
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': `attachment; filename="ghctrl-backup-${isoDate}.zip"`,
+        'Content-Length': String(buffer.length),
+      },
+    })
+  } catch (err: any) {
+    return c.json({ error: `Export failed: ${err.message}` }, 500)
+  }
+})
+
+// POST /preview — return manifest metadata from a ZIP without restoring
+router.post('/preview', async (c) => {
+  let formData: FormData
+  try {
+    formData = await c.req.formData()
+  } catch {
+    return c.json({ error: 'Invalid multipart request' }, 400)
+  }
+
+  const file = formData.get('file') as File | null
+  if (!file) return c.json({ error: 'No file provided' }, 400)
+
+  let zip: JSZip
+  try {
+    zip = await JSZip.loadAsync(await file.arrayBuffer())
+  } catch {
+    return c.json({ error: 'Could not parse ZIP file' }, 400)
+  }
+
+  const manifestFile = zip.file('manifest.json')
+  if (!manifestFile) return c.json({ error: 'Missing manifest.json in backup' }, 400)
+
+  try {
+    const manifest = JSON.parse(await manifestFile.async('string'))
+    return c.json(manifest)
+  } catch {
+    return c.json({ error: 'Invalid manifest.json' }, 400)
+  }
+})
+
+// POST /import — restore from a ZIP backup
+router.post('/import', async (c) => {
+  // 1. Parse multipart form
+  let formData: FormData
+  try {
+    formData = await c.req.formData()
+  } catch {
+    return c.json({ error: 'Invalid multipart request' }, 400)
+  }
+
+  const file = formData.get('file') as File | null
+  if (!file) return c.json({ error: 'No file provided' }, 400)
+
+  // 2. Parse ZIP
+  let zip: JSZip
+  try {
+    zip = await JSZip.loadAsync(await file.arrayBuffer())
+  } catch {
+    return c.json({ error: 'Could not parse ZIP file' }, 400)
+  }
+
+  // 3. Validate manifest
+  const manifestFile = zip.file('manifest.json')
+  if (!manifestFile) return c.json({ error: 'Missing manifest.json in backup' }, 400)
+
+  let manifest: any
+  try {
+    manifest = JSON.parse(await manifestFile.async('string'))
+  } catch {
+    return c.json({ error: 'Invalid manifest.json' }, 400)
+  }
+
+  if (typeof manifest.version !== 'number' || manifest.version < 1) {
+    return c.json({ error: `Unsupported backup version: ${manifest.version}` }, 400)
+  }
+
+  // 4. Parse data
+  const dataFile = zip.file('data.json')
+  if (!dataFile) return c.json({ error: 'Missing data.json in backup' }, 400)
+
+  let data: Record<string, unknown[]>
+  try {
+    data = JSON.parse(await dataFile.async('string'))
+  } catch {
+    return c.json({ error: 'Invalid data.json' }, 400)
+  }
+
+  // 5. Restore DB in a single transaction
+  try {
+    const restore = sqliteDb.transaction(() => {
+      // Disable FK constraints so we can delete/insert in bulk without ordering issues
+      sqliteDb.exec('PRAGMA foreign_keys = OFF')
+
+      // Delete all tables (reverse order is a safety net; FK is OFF anyway)
+      for (const table of TABLE_DELETE_ORDER) {
+        sqliteDb.exec(`DELETE FROM ${table}`)
+      }
+
+      // Re-insert each table using parameterized bulk inserts
+      for (const table of TABLE_INSERT_ORDER) {
+        const rows = data[table] ?? []
+        if (rows.length === 0) continue
+
+        const columns = Object.keys(rows[0] as object)
+        const placeholders = columns.map(() => '?').join(', ')
+        const sql = `INSERT INTO ${table} (${columns.join(', ')}) VALUES (${placeholders})`
+        const stmt = sqliteDb.prepare(sql)
+
+        for (const row of rows) {
+          const values = columns.map((col) => {
+            const v = (row as Record<string, unknown>)[col]
+            // JSON serializes undefined as null; pass null-ish as null
+            return v === undefined ? null : v
+          })
+          stmt.run(...values)
+        }
+      }
+
+      sqliteDb.exec('PRAGMA foreign_keys = ON')
+    })
+
+    restore()
+  } catch (err: any) {
+    // Ensure FK constraints are re-enabled even on error
+    try { sqliteDb.exec('PRAGMA foreign_keys = ON') } catch {}
+    return c.json({ error: `Restore failed: ${err.message}` }, 400)
+  }
+
+  // 6. Restore badge image files (outside transaction — best effort)
+  const badgeFileErrors: string[] = []
+  if (!existsSync(UPLOAD_DIR)) {
+    mkdirSync(UPLOAD_DIR, { recursive: true })
+  }
+
+  const badgesInZip = Object.keys(zip.files)
+    .filter((p) => p.startsWith('badges/') && !p.endsWith('/'))
+
+  for (const zipPath of badgesInZip) {
+    const filename = zipPath.slice('badges/'.length)
+    try {
+      const fileBuffer = await zip.files[zipPath].async('nodebuffer')
+      writeFileSync(join(UPLOAD_DIR, filename), fileBuffer)
+    } catch (err: any) {
+      badgeFileErrors.push(`${filename}: ${err.message}`)
+    }
+  }
+
+  // Build stats from restored data
+  const stats = Object.fromEntries(
+    TABLE_INSERT_ORDER.map((t) => [t, (data[t] ?? []).length])
+  )
+
+  return c.json({
+    success: true,
+    stats,
+    ...(badgeFileErrors.length > 0 ? { badgeFileErrors } : {}),
+  })
+})
+
+export default router


### PR DESCRIPTION
Implements the full ZIP-based backup & restore feature from #343.

## Changes

**Backend (`src/routes/backup.ts`)**
- `GET /api/backup/export` — full DB dump + badge images as ZIP
- `POST /api/backup/preview` — returns manifest metadata without restoring
- `POST /api/backup/import` — atomic restore in SQLite transaction

**Frontend**
- `BackupPanel.tsx` — export + import UI with drag-and-drop, preview, and confirm
- `api.ts` — `exportBackup`, `importBackup`, `previewBackup`
- `Settings.tsx` — BackupPanel wired in at the bottom

Closes #343

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export application data as timestamped backup files for safekeeping.
  * Import and restore data from backup files with preview functionality to verify contents before restoration.
  * New Backup management panel integrated into Settings with drag-and-drop file upload support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->