### PR TITLE
fix: mobile touch accessibility on battlefield

### DIFF
--- a/gh-ctrl/client/src/components/BaseDialog.tsx
+++ b/gh-ctrl/client/src/components/BaseDialog.tsx
@@ -8,7 +8,7 @@ interface BaseDialogProps {
 
 /**
  * Shared dialog primitive.
- * Handles: Escape key to close, onClick/onMouseDown/wheel stopPropagation.
+ * Handles: Escape key to close, onClick/onMouseDown/wheel/touch stopPropagation.
  */
 export function BaseDialog({ onClose, className, children }: BaseDialogProps) {
   useEffect(() => {

--- a/gh-ctrl/client/src/components/BaseDialog.tsx
+++ b/gh-ctrl/client/src/components/BaseDialog.tsx
@@ -25,6 +25,9 @@ export function BaseDialog({ onClose, className, children }: BaseDialogProps) {
       onWheel={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
       onClick={(e) => e.stopPropagation()}
+      onTouchStart={(e) => e.stopPropagation()}
+      onTouchMove={(e) => e.stopPropagation()}
+      onTouchEnd={(e) => e.stopPropagation()}
     >
       {children}
     </div>

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -110,13 +110,16 @@ export function BattlefieldView() {
       }
     }
     // orientationchange fires on mobile before resize and provides more reliable detection
+    let orientationTimeout: ReturnType<typeof setTimeout> | null = null
     const onOrientationChange = () => {
       // Small delay so innerWidth/innerHeight reflect the new orientation
-      setTimeout(closePanelsIfLandscape, 100)
+      if (orientationTimeout !== null) clearTimeout(orientationTimeout)
+      orientationTimeout = setTimeout(closePanelsIfLandscape, 100)
     }
     window.addEventListener('resize', closePanelsIfLandscape)
     window.addEventListener('orientationchange', onOrientationChange)
     return () => {
+      if (orientationTimeout !== null) clearTimeout(orientationTimeout)
       window.removeEventListener('resize', closePanelsIfLandscape)
       window.removeEventListener('orientationchange', onOrientationChange)
     }

--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -98,7 +98,7 @@ export function BattlefieldView() {
   const autoScanTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
-    const onResize = () => {
+    const closePanelsIfLandscape = () => {
       setIsPortrait(window.innerWidth < window.innerHeight && window.innerWidth <= 768)
       // Close side panels when entering mobile landscape to free up space
       if (window.innerWidth > window.innerHeight && window.innerWidth <= 768) {
@@ -106,10 +106,20 @@ export function BattlefieldView() {
         setShowTimers(false)
         setBranchSiloEntry(null)
         setDetailEntry(null)
+        setConstructTarget(null)
       }
     }
-    window.addEventListener('resize', onResize)
-    return () => window.removeEventListener('resize', onResize)
+    // orientationchange fires on mobile before resize and provides more reliable detection
+    const onOrientationChange = () => {
+      // Small delay so innerWidth/innerHeight reflect the new orientation
+      setTimeout(closePanelsIfLandscape, 100)
+    }
+    window.addEventListener('resize', closePanelsIfLandscape)
+    window.addEventListener('orientationchange', onOrientationChange)
+    return () => {
+      window.removeEventListener('resize', closePanelsIfLandscape)
+      window.removeEventListener('orientationchange', onOrientationChange)
+    }
   }, [])
 
   const { play } = useSound()

--- a/gh-ctrl/client/src/components/Icons.tsx
+++ b/gh-ctrl/client/src/components/Icons.tsx
@@ -242,3 +242,16 @@ export function CodeRabbitIcon({ size = 12, className, title }: IconProps) {
     </svg>
   )
 }
+
+export function TimerIcon({ size = 12, className, title }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} aria-hidden={!title} role={title ? 'img' : undefined}>
+      {title && <title>{title}</title>}
+      <circle cx="8" cy="9.5" r="5.5" stroke="currentColor" strokeWidth="1.5" />
+      <line x1="8" y1="9.5" x2="8" y2="6.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <line x1="8" y1="9.5" x2="10.2" y2="9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <line x1="6" y1="1.5" x2="10" y2="1.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <line x1="8" y1="1.5" x2="8" y2="4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}

--- a/gh-ctrl/client/src/components/SidePanel.tsx
+++ b/gh-ctrl/client/src/components/SidePanel.tsx
@@ -8,7 +8,7 @@ interface SidePanelProps {
 
 /**
  * Shared side panel primitive.
- * Handles: Escape key to close, onClick/onMouseDown/wheel stopPropagation.
+ * Handles: Escape key to close, onClick/onMouseDown/wheel/touch stopPropagation.
  */
 export function SidePanel({ onClose, className, children }: SidePanelProps) {
   const panelRef = useRef<HTMLDivElement>(null)

--- a/gh-ctrl/client/src/components/SidePanel.tsx
+++ b/gh-ctrl/client/src/components/SidePanel.tsx
@@ -35,6 +35,9 @@ export function SidePanel({ onClose, className, children }: SidePanelProps) {
       className={className}
       onClick={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
+      onTouchStart={(e) => e.stopPropagation()}
+      onTouchMove={(e) => e.stopPropagation()}
+      onTouchEnd={(e) => e.stopPropagation()}
     >
       {children}
     </div>

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import type { DashboardEntry, GameMap } from '../../types'
-import { CloseIcon, RelocateIcon, ScanIcon, BuildIcon, MapIcon, FeedIcon } from '../Icons'
+import { CloseIcon, RelocateIcon, ScanIcon, BuildIcon, MapIcon, FeedIcon, TimerIcon } from '../Icons'
 import { ZOOM_MIN, ZOOM_MAX } from './battlefieldConstants'
 
 interface BattlefieldHUDProps {
@@ -165,7 +165,7 @@ export function BattlefieldHUD({
           aria-label="Toggle mission timers"
           aria-pressed={showTimers}
         >
-          ⏱<span className="hud-label"> TIMERS</span>
+          <TimerIcon size={11} /><span className="hud-label"> TIMERS</span>
         </button>
         <span className="hud-zoom-sep" />
         <button className="hud-btn hud-zoom-btn" onClick={onZoomOut} disabled={zoom <= ZOOM_MIN} title="Zoom out [−]" aria-label="Zoom out">−</button>
@@ -224,7 +224,7 @@ export function BattlefieldHUD({
                 <FeedIcon size={11} /> FEED
               </button>
               <button className={`hud-btn hud-overflow-item${showTimers ? ' active' : ''}`} onClick={() => { setShowOverflow(false); onToggleTimers() }}>
-                ⏱ TIMERS
+                <TimerIcon size={11} /> TIMERS
               </button>
             </div>
           )}

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -6338,12 +6338,22 @@ select.input {
   }
 }
 
+/* Construct dialog full-width on mobile */
+@media (max-width: 600px) {
+  .construct-dialog {
+    width: 100vw;
+    left: 0;
+    right: 0;
+  }
+}
+
 /* Hide side panels in mobile landscape — they eat the entire viewport */
 @media (max-width: 768px) and (orientation: landscape) {
   .feed-panel,
   .silo-panel,
   .dt-panel,
-  .base-detail-side-panel {
+  .base-detail-side-panel,
+  .construct-dialog {
     display: none !important;
   }
 }


### PR DESCRIPTION
Fixes mobile touch issues reported in #348:

- Build Dialog touch interactions (open, use, close) fixed via touch stopPropagation in BaseDialog
- SidePanel touch interactions fixed via touch stopPropagation
- Timer Sound button now uses TimerIcon SVG instead of ⏱ emoji
- Side Panel now reliably closes in mobile landscape mode via orientationchange listener
- ConstructDialog full-width on small screens and hidden in landscape

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a timer icon to HUD controls

* **Bug Fixes**
  * Improved touch event handling in dialogs and side panels
  * Enhanced mobile landscape detection and panel-closing behavior
  * Ensured construct dialog is positioned and hidden correctly on narrow screens

* **Style**
  * Added responsive CSS rules for mobile layouts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->