### PR TITLE
fix: show logout screen after logging out

### DIFF
--- a/gh-ctrl/client/src/auth/KeycloakProvider.tsx
+++ b/gh-ctrl/client/src/auth/KeycloakProvider.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import Keycloak from 'keycloak-js'
 import { AuthContext, type AuthContextValue } from './AuthContext'
+import { LoggedOutScreen } from './LoggedOutScreen'
+
+const LOGGED_OUT_KEY = 'gh_ctrl_logged_out'
 
 const KEYCLOAK_URL = import.meta.env.VITE_KEYCLOAK_URL as string | undefined
 const KEYCLOAK_REALM = import.meta.env.VITE_KEYCLOAK_REALM as string | undefined
@@ -24,11 +27,20 @@ function getKeycloakInstance(): Keycloak {
 
 export function KeycloakProvider({ children }: { children: ReactNode }) {
   const [initialized, setInitialized] = useState(false)
+  const [loggedOut, setLoggedOut] = useState(false)
   const [token, setToken] = useState<string | undefined>(undefined)
   const [user, setUser] = useState<AuthContextValue['user']>(null)
   const [keycloak] = useState<Keycloak>(() => getKeycloakInstance())
 
   useEffect(() => {
+    // If the user just logged out, show the logout screen instead of re-initiating login
+    if (sessionStorage.getItem(LOGGED_OUT_KEY) === 'true') {
+      sessionStorage.removeItem(LOGGED_OUT_KEY)
+      setLoggedOut(true)
+      setInitialized(true)
+      return
+    }
+
     keycloak
       .init({
         onLoad: 'login-required',
@@ -64,7 +76,8 @@ export function KeycloakProvider({ children }: { children: ReactNode }) {
   }, [keycloak])
 
   const logout = () => {
-    keycloak.logout()
+    sessionStorage.setItem(LOGGED_OUT_KEY, 'true')
+    keycloak.logout({ redirectUri: window.location.origin })
   }
 
   if (!initialized) {
@@ -73,6 +86,10 @@ export function KeycloakProvider({ children }: { children: ReactNode }) {
         Authenticating…
       </div>
     )
+  }
+
+  if (loggedOut) {
+    return <LoggedOutScreen onLogin={() => window.location.reload()} />
   }
 
   return (

--- a/gh-ctrl/client/src/auth/LoggedOutScreen.tsx
+++ b/gh-ctrl/client/src/auth/LoggedOutScreen.tsx
@@ -1,0 +1,48 @@
+interface LoggedOutScreenProps {
+  onLogin: () => void
+}
+
+export function LoggedOutScreen({ onLogin }: LoggedOutScreenProps) {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--bg)',
+        color: 'var(--text)',
+        gap: '1rem',
+      }}
+    >
+      <img
+        src="/logo-transparent.png"
+        alt="V&C Command Center"
+        style={{ width: '80px', opacity: 0.7 }}
+      />
+      <h2 style={{ margin: 0, fontSize: '1.4rem', color: 'var(--text)' }}>
+        You have been logged out
+      </h2>
+      <p style={{ margin: 0, color: 'var(--text-2)', fontSize: '0.9rem' }}>
+        Your session has ended.
+      </p>
+      <button
+        onClick={onLogin}
+        style={{
+          marginTop: '0.5rem',
+          background: 'var(--green-neon)',
+          color: '#000',
+          border: 'none',
+          borderRadius: '6px',
+          padding: '0.5rem 1.5rem',
+          fontSize: '0.9rem',
+          cursor: 'pointer',
+          fontWeight: 600,
+        }}
+      >
+        Login again
+      </button>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/auth/OidcProvider.tsx
+++ b/gh-ctrl/client/src/auth/OidcProvider.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { UserManager, WebStorageStateStore, type User } from 'oidc-client-ts'
 import { AuthContext, type AuthContextValue } from './AuthContext'
+import { LoggedOutScreen } from './LoggedOutScreen'
+
+const LOGGED_OUT_KEY = 'gh_ctrl_logged_out'
 
 const OIDC_AUTHORITY = import.meta.env.VITE_OIDC_AUTHORITY as string | undefined
 const OIDC_CLIENT_ID = import.meta.env.VITE_OIDC_CLIENT_ID as string | undefined
@@ -28,6 +31,7 @@ export function OidcProvider({ children, authority, clientId, redirectUri, scope
   const resolvedScope = scope ?? OIDC_SCOPE ?? 'openid profile email'
 
   const [initialized, setInitialized] = useState(false)
+  const [loggedOut, setLoggedOut] = useState(false)
   const [token, setToken] = useState<string | undefined>(undefined)
   const [user, setUser] = useState<AuthContextValue['user']>(null)
   const managerRef = useRef<UserManager | null>(null)
@@ -66,6 +70,14 @@ export function OidcProvider({ children, authority, clientId, redirectUri, scope
     }
 
     async function handleAuth() {
+      // If the user just logged out, show the logout screen instead of re-initiating login
+      if (sessionStorage.getItem(LOGGED_OUT_KEY) === 'true') {
+        sessionStorage.removeItem(LOGGED_OUT_KEY)
+        setLoggedOut(true)
+        setInitialized(true)
+        return
+      }
+
       // Check if we're handling an OIDC authorization code callback
       const params = new URLSearchParams(window.location.search)
       if (params.get('code') && params.get('state')) {
@@ -112,6 +124,7 @@ export function OidcProvider({ children, authority, clientId, redirectUri, scope
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const logout = () => {
+    sessionStorage.setItem(LOGGED_OUT_KEY, 'true')
     getManager().signoutRedirect().catch(console.error)
   }
 
@@ -121,6 +134,10 @@ export function OidcProvider({ children, authority, clientId, redirectUri, scope
         Authenticating…
       </div>
     )
+  }
+
+  if (loggedOut) {
+    return <LoggedOutScreen onLogin={() => window.location.reload()} />
   }
 
   return (


### PR DESCRIPTION
Fixes #353

After clicking logout, a `sessionStorage` flag is set before redirecting to the IdP logout endpoint. On return, the flag is detected and a dedicated "You have been logged out" screen is shown instead of immediately re-initiating the login flow. Covers both Keycloak and OIDC/Authentik providers.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated logged-out screen that displays after logout, providing clear visual confirmation with an option to log back in.
  * Enhanced logout state handling to properly preserve session state across page reloads and browser sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->