### PR TITLE
feat: Source Relay building for AI context bundles

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData, SetupStatus, Building, ClawComMessage, Badge, PlacedBadge, HealthcheckResult, DeadlineTimer, ChannelEvent, MailMessage, ResearchJob, Contact, SshConnection, SshSessionLog } from './types'
+import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData, SetupStatus, Building, ClawComMessage, Badge, PlacedBadge, HealthcheckResult, DeadlineTimer, ChannelEvent, MailMessage, ResearchJob, Contact, SshConnection, SshSessionLog, SourceRelayConnector, SourceRelayFetcher, SourceRelayGitFile } from './types'
 
 export function getServerUrl(): string {
   return localStorage.getItem('serverUrl')?.replace(/\/$/, '') ?? ''
@@ -37,6 +37,12 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     throw new Error(err.error || res.statusText)
   }
   return res.json()
+}
+
+export function getSourceRelayFetchUrl(uniqueToken: string): string {
+  const serverUrl = getServerUrl()
+  if (serverUrl) return `${serverUrl}/source-relay/fetch/${uniqueToken}`
+  return `${window.location.origin}/source-relay/fetch/${uniqueToken}`
 }
 
 export function getShellWsUrl(buildingId: number, connectionId: number): string {
@@ -682,4 +688,79 @@ export const api = {
     request<{ ok: boolean; sessions: string[]; error?: string }>(
       `/buildings/${buildingId}/shell/connections/${connectionId}/tmux-sessions`
     ),
+
+  // ── Source Relay ──────────────────────────────────────────────────────────
+
+  listSourceRelayConnectors: (buildingId: number) =>
+    request<SourceRelayConnector[]>(`/source-relay/${buildingId}/connectors`),
+
+  createSourceRelayConnector: (
+    buildingId: number,
+    params: { name: string; type: string; configuration: object },
+  ) =>
+    request<SourceRelayConnector>(`/source-relay/${buildingId}/connectors`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    }),
+
+  updateSourceRelayConnector: (
+    buildingId: number,
+    connectorId: number,
+    updates: { name?: string; type?: string; configuration?: object },
+  ) =>
+    request<SourceRelayConnector>(`/source-relay/${buildingId}/connectors/${connectorId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(updates),
+    }),
+
+  deleteSourceRelayConnector: (buildingId: number, connectorId: number) =>
+    request<{ ok: boolean }>(`/source-relay/${buildingId}/connectors/${connectorId}`, {
+      method: 'DELETE',
+    }),
+
+  getSourceRelayGitTree: (buildingId: number, connectorId: number, branch?: string) => {
+    const qs = new URLSearchParams({ connectorId: String(connectorId) })
+    if (branch) qs.set('branch', branch)
+    return request<{ files: SourceRelayGitFile[] }>(`/source-relay/${buildingId}/git-tree?${qs}`)
+  },
+
+  listSourceRelayFetchers: (buildingId: number) =>
+    request<SourceRelayFetcher[]>(`/source-relay/${buildingId}/fetchers`),
+
+  createSourceRelayFetcher: (buildingId: number, name: string) =>
+    request<SourceRelayFetcher>(`/source-relay/${buildingId}/fetchers`, {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    }),
+
+  updateSourceRelayFetcher: (buildingId: number, fetcherId: number, name: string) =>
+    request<SourceRelayFetcher>(`/source-relay/${buildingId}/fetchers/${fetcherId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ name }),
+    }),
+
+  deleteSourceRelayFetcher: (buildingId: number, fetcherId: number) =>
+    request<{ ok: boolean }>(`/source-relay/${buildingId}/fetchers/${fetcherId}`, {
+      method: 'DELETE',
+    }),
+
+  setSourceRelayConnectorFiles: (
+    buildingId: number,
+    fetcherId: number,
+    connectorId: number,
+    filePaths: string[],
+  ) =>
+    request<{ ok: boolean }>(`/source-relay/${buildingId}/fetchers/${fetcherId}/connectors/${connectorId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ filePaths }),
+    }),
+
+  removeSourceRelayConnectorFromFetcher: (
+    buildingId: number,
+    fetcherId: number,
+    connectorId: number,
+  ) =>
+    request<{ ok: boolean }>(`/source-relay/${buildingId}/fetchers/${fetcherId}/connectors/${connectorId}`, {
+      method: 'DELETE',
+    }),
 }

--- a/gh-ctrl/client/src/components/BuildOptionsMenu.tsx
+++ b/gh-ctrl/client/src/components/BuildOptionsMenu.tsx
@@ -52,6 +52,14 @@ const AVAILABLE_BUILDINGS: BuildingDef[] = [
     defaultColor: '#00aaff',
   },
   {
+    type: 'sourceRelay',
+    name: 'Source Relay',
+    description:
+      'Aggregate content from GitHub repositories and websites into shareable plain-text endpoints. Create context bundles for AI assistants — each fetcher generates a unique public URL that returns all your configured sources combined.',
+    buildImage: '/buildings/healthcheck.png',
+    defaultColor: '#ff8800',
+  },
+  {
     type: 'new-base',
     name: 'Repository',
     description:

--- a/gh-ctrl/client/src/components/SourceRelayBuilding.tsx
+++ b/gh-ctrl/client/src/components/SourceRelayBuilding.tsx
@@ -1,0 +1,1036 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { api, getSourceRelayFetchUrl } from '../api'
+import { useAppStore } from '../store'
+import type {
+  Building,
+  SourceRelayConnector,
+  SourceRelayConnectorType,
+  SourceRelayFetcher,
+  SourceRelayGitFile,
+} from '../types'
+
+interface Position {
+  x: number
+  y: number
+}
+
+interface SourceRelayBuildingProps {
+  building: Building
+  position: Position
+  isRelocateMode: boolean
+  isBeingRelocated: boolean
+  onStartRelocate: (mouseX: number, mouseY: number) => void
+  addToast: (msg: string, type?: 'success' | 'error' | 'info') => void
+  isSelected?: boolean
+  onSelect?: () => void
+  onDeselect?: () => void
+}
+
+// Chroma-key: replace green pixels with the building color
+function useColorizedImage(src: string, color: string): string | null {
+  const [dataUrl, setDataUrl] = useState<string | null>(null)
+  useEffect(() => {
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    img.onload = () => {
+      const canvas = document.createElement('canvas')
+      canvas.width = img.width
+      canvas.height = img.height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      ctx.drawImage(img, 0, 0)
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+      const data = imageData.data
+      const hex = color.replace('#', '')
+      const tr = parseInt(hex.slice(0, 2), 16)
+      const tg = parseInt(hex.slice(2, 4), 16)
+      const tb = parseInt(hex.slice(4, 6), 16)
+      for (let i = 0; i < data.length; i += 4) {
+        const r = data[i], g = data[i + 1], b = data[i + 2]
+        if (g > r * 1.3 && g > b * 1.3 && g > 80) {
+          const ratio = g / 255
+          data[i] = Math.round(tr * ratio)
+          data[i + 1] = Math.round(tg * ratio)
+          data[i + 2] = Math.round(tb * ratio)
+        }
+      }
+      ctx.putImageData(imageData, 0, 0)
+      setDataUrl(canvas.toDataURL())
+    }
+    img.src = src
+  }, [src, color])
+  return dataUrl
+}
+
+// ── File tree browser modal ────────────────────────────────────────────────
+
+interface FileTreeModalProps {
+  buildingId: number
+  connector: SourceRelayConnector
+  selectedPaths: string[]
+  onSave: (paths: string[]) => void
+  onClose: () => void
+}
+
+function FileTreeModal({ buildingId, connector, selectedPaths, onSave, onClose }: FileTreeModalProps) {
+  const [files, setFiles] = useState<SourceRelayGitFile[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [checked, setChecked] = useState<Set<string>>(new Set(selectedPaths))
+  const [search, setSearch] = useState('')
+
+  let cfg: { branch?: string } = {}
+  try { cfg = JSON.parse(connector.configuration) } catch { /* empty */ }
+
+  useEffect(() => {
+    setLoading(true)
+    api.getSourceRelayGitTree(buildingId, connector.id, cfg.branch)
+      .then((data) => { setFiles(data.files); setLoading(false) })
+      .catch((err: Error) => { setError(err.message); setLoading(false) })
+  }, [buildingId, connector.id, cfg.branch])
+
+  const filtered = search
+    ? files.filter((f) => f.path.toLowerCase().includes(search.toLowerCase()))
+    : files
+
+  function toggleAll() {
+    if (checked.size === 0) {
+      setChecked(new Set(files.map((f) => f.path)))
+    } else {
+      setChecked(new Set())
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 3000,
+        background: 'rgba(0,0,0,0.75)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div style={{
+        background: 'var(--bg-panel)', border: '1px solid var(--border)',
+        borderRadius: 4, width: 480, maxHeight: '80vh',
+        display: 'flex', flexDirection: 'column', overflow: 'hidden',
+      }}>
+        <div style={{ padding: '10px 14px', borderBottom: '1px solid var(--border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-dim)' }}>
+            SELECT FILES — {connector.name}
+          </span>
+          <button className="hud-btn" style={{ fontSize: 9 }} onClick={onClose}>✕</button>
+        </div>
+
+        {loading && (
+          <div style={{ padding: 20, textAlign: 'center', color: 'var(--text-dim)', fontSize: 11 }}>
+            Loading file tree…
+          </div>
+        )}
+        {error && (
+          <div style={{ padding: 14, color: '#ff6b6b', fontSize: 11 }}>{error}</div>
+        )}
+        {!loading && !error && (
+          <>
+            <div style={{ padding: '8px 14px', borderBottom: '1px solid var(--border)', display: 'flex', gap: 8, alignItems: 'center' }}>
+              <input
+                className="hud-input"
+                style={{ flex: 1, fontSize: 10 }}
+                placeholder="Filter files…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+              <button className="hud-btn" style={{ fontSize: 9 }} onClick={toggleAll}>
+                {checked.size === 0 ? 'All' : 'None'}
+              </button>
+              <span style={{ fontSize: 9, color: 'var(--text-dim)' }}>
+                {checked.size === 0 ? 'All files' : `${checked.size} selected`}
+              </span>
+            </div>
+            <div style={{ flex: 1, overflowY: 'auto', padding: '6px 0' }}>
+              {filtered.map((f) => (
+                <label
+                  key={f.path}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 8,
+                    padding: '3px 14px', cursor: 'pointer',
+                    fontSize: 10, color: 'var(--text)',
+                    background: checked.has(f.path) ? 'rgba(255,136,0,0.08)' : 'transparent',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked.has(f.path)}
+                    onChange={(e) => {
+                      const next = new Set(checked)
+                      if (e.target.checked) next.add(f.path)
+                      else next.delete(f.path)
+                      setChecked(next)
+                    }}
+                    style={{ accentColor: '#ff8800' }}
+                  />
+                  <span style={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>{f.path}</span>
+                  {f.size !== undefined && (
+                    <span style={{ marginLeft: 'auto', color: 'var(--text-dim)', flexShrink: 0 }}>
+                      {f.size < 1024 ? `${f.size}B` : `${(f.size / 1024).toFixed(1)}KB`}
+                    </span>
+                  )}
+                </label>
+              ))}
+            </div>
+          </>
+        )}
+
+        <div style={{ padding: '8px 14px', borderTop: '1px solid var(--border)', display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+          <button className="hud-btn" style={{ fontSize: 9 }} onClick={onClose}>CANCEL</button>
+          <button
+            className="hud-btn"
+            style={{ fontSize: 9, color: '#ff8800' }}
+            onClick={() => onSave(checked.size === 0 ? [] : Array.from(checked))}
+            disabled={loading}
+          >
+            SAVE SELECTION
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Main dialog ─────────────────────────────────────────────────────────────
+
+type DialogTab = 'connectors' | 'fetchers'
+
+interface ConnectorFormState {
+  name: string
+  type: SourceRelayConnectorType
+  url: string
+  branch: string
+  token: string
+}
+
+function emptyConnectorForm(): ConnectorFormState {
+  return { name: '', type: 'git', url: '', branch: 'main', token: '' }
+}
+
+interface SourceRelayDialogProps {
+  building: Building
+  onClose: () => void
+  addToast: (msg: string, type?: 'success' | 'error' | 'info') => void
+}
+
+function SourceRelayDialog({ building, onClose, addToast }: SourceRelayDialogProps) {
+  const [tab, setTab] = useState<DialogTab>('connectors')
+  const [connectors, setConnectors] = useState<SourceRelayConnector[]>([])
+  const [fetchers, setFetchers] = useState<SourceRelayFetcher[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // Connector form
+  const [showConnectorForm, setShowConnectorForm] = useState(false)
+  const [connectorForm, setConnectorForm] = useState<ConnectorFormState>(emptyConnectorForm())
+  const [editingConnectorId, setEditingConnectorId] = useState<number | null>(null)
+  const [savingConnector, setSavingConnector] = useState(false)
+
+  // Fetcher creation
+  const [newFetcherName, setNewFetcherName] = useState('')
+  const [showNewFetcher, setShowNewFetcher] = useState(false)
+  const [creatingFetcher, setCreatingFetcher] = useState(false)
+
+  // Link connector to fetcher
+  const [linkingFetcherId, setLinkingFetcherId] = useState<number | null>(null)
+  const [linkConnectorId, setLinkConnectorId] = useState<string>('')
+  const [savingLink, setSavingLink] = useState(false)
+
+  // File tree browser
+  const [fileTreeFor, setFileTreeFor] = useState<{
+    fetcherId: number
+    connector: SourceRelayConnector
+    currentPaths: string[]
+  } | null>(null)
+
+  const loadData = useCallback(async () => {
+    try {
+      const [cs, fs] = await Promise.all([
+        api.listSourceRelayConnectors(building.id),
+        api.listSourceRelayFetchers(building.id),
+      ])
+      setConnectors(cs)
+      setFetchers(fs)
+    } catch { /* ignore */ } finally {
+      setLoading(false)
+    }
+  }, [building.id])
+
+  useEffect(() => { loadData() }, [loadData])
+
+  // ── Connector actions ────────────────────────────────────────────────────
+
+  function startEditConnector(c: SourceRelayConnector) {
+    let cfg: { url?: string; branch?: string } = {}
+    try { cfg = JSON.parse(c.configuration) } catch { /* empty */ }
+    setConnectorForm({
+      name: c.name,
+      type: c.type,
+      url: cfg.url ?? '',
+      branch: cfg.branch ?? 'main',
+      token: '', // never pre-fill token
+    })
+    setEditingConnectorId(c.id)
+    setShowConnectorForm(true)
+  }
+
+  async function handleSaveConnector() {
+    if (!connectorForm.name.trim() || !connectorForm.url.trim()) return
+    setSavingConnector(true)
+    try {
+      const configuration: Record<string, string> = { url: connectorForm.url.trim() }
+      if (connectorForm.type !== 'website') {
+        configuration.branch = connectorForm.branch.trim() || 'main'
+      }
+      if (connectorForm.token.trim()) {
+        configuration.token = connectorForm.token.trim()
+      }
+      if (editingConnectorId !== null) {
+        const updated = await api.updateSourceRelayConnector(building.id, editingConnectorId, {
+          name: connectorForm.name.trim(),
+          type: connectorForm.type,
+          configuration,
+        })
+        setConnectors((prev) => prev.map((c) => (c.id === editingConnectorId ? updated : c)))
+        addToast('Connector updated', 'success')
+      } else {
+        const created = await api.createSourceRelayConnector(building.id, {
+          name: connectorForm.name.trim(),
+          type: connectorForm.type,
+          configuration,
+        })
+        setConnectors((prev) => [...prev, created])
+        addToast('Connector created', 'success')
+      }
+      setShowConnectorForm(false)
+      setEditingConnectorId(null)
+      setConnectorForm(emptyConnectorForm())
+    } catch (err: unknown) {
+      addToast(`Error: ${(err as Error).message}`, 'error')
+    } finally {
+      setSavingConnector(false)
+    }
+  }
+
+  async function handleDeleteConnector(id: number) {
+    if (!confirm('Delete this connector? Any fetchers using it will lose access to this source.')) return
+    try {
+      await api.deleteSourceRelayConnector(building.id, id)
+      setConnectors((prev) => prev.filter((c) => c.id !== id))
+      addToast('Connector deleted', 'info')
+    } catch (err: unknown) {
+      addToast(`Error: ${(err as Error).message}`, 'error')
+    }
+  }
+
+  // ── Fetcher actions ──────────────────────────────────────────────────────
+
+  async function handleCreateFetcher() {
+    if (!newFetcherName.trim()) return
+    setCreatingFetcher(true)
+    try {
+      const fetcher = await api.createSourceRelayFetcher(building.id, newFetcherName.trim())
+      setFetchers((prev) => [...prev, fetcher])
+      setNewFetcherName('')
+      setShowNewFetcher(false)
+      addToast('Fetcher created', 'success')
+    } catch (err: unknown) {
+      addToast(`Error: ${(err as Error).message}`, 'error')
+    } finally {
+      setCreatingFetcher(false)
+    }
+  }
+
+  async function handleDeleteFetcher(id: number) {
+    if (!confirm('Delete this fetcher? The public URL will stop working.')) return
+    try {
+      await api.deleteSourceRelayFetcher(building.id, id)
+      setFetchers((prev) => prev.filter((f) => f.id !== id))
+      addToast('Fetcher deleted', 'info')
+    } catch (err: unknown) {
+      addToast(`Error: ${(err as Error).message}`, 'error')
+    }
+  }
+
+  async function handleLinkConnector(fetcherId: number) {
+    const connectorId = Number(linkConnectorId)
+    if (!connectorId) return
+    setSavingLink(true)
+    try {
+      await api.setSourceRelayConnectorFiles(building.id, fetcherId, connectorId, [])
+      await loadData()
+      setLinkingFetcherId(null)
+      setLinkConnectorId('')
+      addToast('Connector linked', 'success')
+    } catch (err: unknown) {
+      addToast(`Error: ${(err as Error).message}`, 'error')
+    } finally {
+      setSavingLink(false)
+    }
+  }
+
+  async function handleUnlinkConnector(fetcherId: number, connectorId: number) {
+    try {
+      await api.removeSourceRelayConnectorFromFetcher(building.id, fetcherId, connectorId)
+      setFetchers((prev) =>
+        prev.map((f) =>
+          f.id === fetcherId
+            ? { ...f, connectorFiles: f.connectorFiles.filter((cf) => cf.connectorId !== connectorId) }
+            : f,
+        ),
+      )
+    } catch (err: unknown) {
+      addToast(`Error: ${(err as Error).message}`, 'error')
+    }
+  }
+
+  async function handleSaveFilePaths(fetcherId: number, connectorId: number, paths: string[]) {
+    try {
+      await api.setSourceRelayConnectorFiles(building.id, fetcherId, connectorId, paths)
+      await loadData()
+      setFileTreeFor(null)
+      addToast('File selection saved', 'success')
+    } catch (err: unknown) {
+      addToast(`Error: ${(err as Error).message}`, 'error')
+    }
+  }
+
+  function copyUrl(url: string) {
+    navigator.clipboard.writeText(url).then(
+      () => addToast('URL copied to clipboard', 'success'),
+      () => addToast('Copy failed', 'error'),
+    )
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  const typeLabel: Record<SourceRelayConnectorType, string> = {
+    git: 'Git Repo',
+    private_git: 'Private Git',
+    website: 'Website',
+  }
+
+  return (
+    <>
+      <div
+        style={{
+          position: 'fixed', inset: 0, zIndex: 2000,
+          background: 'rgba(0,0,0,0.6)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}
+        onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+      >
+        <div style={{
+          background: 'var(--bg-panel)', border: '1px solid var(--border)',
+          borderRadius: 4, width: 560, maxHeight: '82vh',
+          display: 'flex', flexDirection: 'column', overflow: 'hidden',
+        }}>
+          {/* Header */}
+          <div style={{
+            padding: '10px 14px', borderBottom: '1px solid var(--border)',
+            display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          }}>
+            <span style={{ fontSize: 12, fontWeight: 700, color: '#ff8800' }}>
+              &#x25a0; SOURCE RELAY — {building.name}
+            </span>
+            <button className="hud-btn" style={{ fontSize: 9 }} onClick={onClose}>✕ CLOSE</button>
+          </div>
+
+          {/* Tabs */}
+          <div style={{ display: 'flex', borderBottom: '1px solid var(--border)' }}>
+            {(['connectors', 'fetchers'] as DialogTab[]).map((t) => (
+              <button
+                key={t}
+                className="hud-btn"
+                style={{
+                  borderRadius: 0, borderBottom: 'none',
+                  borderRight: '1px solid var(--border)',
+                  fontSize: 10, padding: '6px 16px',
+                  color: tab === t ? '#ff8800' : 'var(--text-dim)',
+                  background: tab === t ? 'rgba(255,136,0,0.08)' : 'transparent',
+                }}
+                onClick={() => setTab(t)}
+              >
+                {t.toUpperCase()}
+              </button>
+            ))}
+          </div>
+
+          {/* Body */}
+          <div style={{ flex: 1, overflowY: 'auto', padding: 14 }}>
+            {loading && (
+              <div style={{ textAlign: 'center', color: 'var(--text-dim)', fontSize: 11, paddingTop: 20 }}>
+                Loading…
+              </div>
+            )}
+
+            {/* ── Connectors Tab ── */}
+            {!loading && tab === 'connectors' && (
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+                  <span style={{ fontSize: 10, color: 'var(--text-dim)' }}>
+                    Connectors are content sources (GitHub repos or websites).
+                  </span>
+                  <button
+                    className="hud-btn"
+                    style={{ fontSize: 9, color: '#ff8800' }}
+                    onClick={() => {
+                      setConnectorForm(emptyConnectorForm())
+                      setEditingConnectorId(null)
+                      setShowConnectorForm(true)
+                    }}
+                  >
+                    + NEW CONNECTOR
+                  </button>
+                </div>
+
+                {showConnectorForm && (
+                  <div style={{
+                    background: 'var(--bg-darker)', border: '1px solid #ff8800',
+                    borderRadius: 4, padding: 12, marginBottom: 12,
+                  }}>
+                    <div style={{ fontSize: 10, color: '#ff8800', marginBottom: 8, fontWeight: 700 }}>
+                      {editingConnectorId !== null ? 'EDIT CONNECTOR' : 'NEW CONNECTOR'}
+                    </div>
+
+                    <div style={{ display: 'grid', gap: 6 }}>
+                      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                        <label style={{ fontSize: 9, color: 'var(--text-dim)', width: 55 }}>NAME</label>
+                        <input
+                          className="hud-input"
+                          style={{ flex: 1, fontSize: 10 }}
+                          value={connectorForm.name}
+                          onChange={(e) => setConnectorForm((f) => ({ ...f, name: e.target.value }))}
+                          placeholder="My Docs"
+                        />
+                      </div>
+                      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                        <label style={{ fontSize: 9, color: 'var(--text-dim)', width: 55 }}>TYPE</label>
+                        <select
+                          className="hud-input"
+                          style={{ flex: 1, fontSize: 10 }}
+                          value={connectorForm.type}
+                          onChange={(e) => setConnectorForm((f) => ({ ...f, type: e.target.value as SourceRelayConnectorType }))}
+                        >
+                          <option value="git">Git Repository (public)</option>
+                          <option value="private_git">Git Repository (private)</option>
+                          <option value="website">Website / URL</option>
+                        </select>
+                      </div>
+                      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                        <label style={{ fontSize: 9, color: 'var(--text-dim)', width: 55 }}>URL</label>
+                        <input
+                          className="hud-input"
+                          style={{ flex: 1, fontSize: 10 }}
+                          value={connectorForm.url}
+                          onChange={(e) => setConnectorForm((f) => ({ ...f, url: e.target.value }))}
+                          placeholder={connectorForm.type === 'website' ? 'https://docs.example.com' : 'https://github.com/user/repo'}
+                        />
+                      </div>
+                      {connectorForm.type !== 'website' && (
+                        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                          <label style={{ fontSize: 9, color: 'var(--text-dim)', width: 55 }}>BRANCH</label>
+                          <input
+                            className="hud-input"
+                            style={{ flex: 1, fontSize: 10 }}
+                            value={connectorForm.branch}
+                            onChange={(e) => setConnectorForm((f) => ({ ...f, branch: e.target.value }))}
+                            placeholder="main"
+                          />
+                        </div>
+                      )}
+                      {connectorForm.type === 'private_git' && (
+                        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                          <label style={{ fontSize: 9, color: 'var(--text-dim)', width: 55 }}>TOKEN</label>
+                          <input
+                            className="hud-input"
+                            style={{ flex: 1, fontSize: 10 }}
+                            type="password"
+                            value={connectorForm.token}
+                            onChange={(e) => setConnectorForm((f) => ({ ...f, token: e.target.value }))}
+                            placeholder={editingConnectorId !== null ? '(leave blank to keep existing)' : 'ghp_...'}
+                          />
+                        </div>
+                      )}
+                    </div>
+
+                    <div style={{ display: 'flex', gap: 8, marginTop: 10, justifyContent: 'flex-end' }}>
+                      <button
+                        className="hud-btn"
+                        style={{ fontSize: 9 }}
+                        onClick={() => { setShowConnectorForm(false); setEditingConnectorId(null) }}
+                      >
+                        CANCEL
+                      </button>
+                      <button
+                        className="hud-btn"
+                        style={{ fontSize: 9, color: '#ff8800' }}
+                        onClick={handleSaveConnector}
+                        disabled={savingConnector || !connectorForm.name.trim() || !connectorForm.url.trim()}
+                      >
+                        {savingConnector ? 'SAVING…' : 'SAVE'}
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {connectors.length === 0 && !showConnectorForm && (
+                  <div style={{ color: 'var(--text-dim)', fontSize: 10, textAlign: 'center', paddingTop: 16 }}>
+                    No connectors yet. Add a GitHub repository or website as a source.
+                  </div>
+                )}
+
+                {connectors.map((c) => {
+                  let cfg: { url?: string; branch?: string } = {}
+                  try { cfg = JSON.parse(c.configuration) } catch { /* empty */ }
+                  return (
+                    <div
+                      key={c.id}
+                      style={{
+                        background: 'var(--bg-darker)', borderRadius: 4,
+                        padding: '8px 10px', marginBottom: 6,
+                        display: 'flex', alignItems: 'center', gap: 8,
+                      }}
+                    >
+                      <div style={{
+                        fontSize: 9, padding: '1px 5px', borderRadius: 2,
+                        background: c.type === 'website' ? '#2244aa' : '#223300',
+                        color: c.type === 'website' ? '#88aaff' : '#88ff44',
+                        flexShrink: 0,
+                      }}>
+                        {typeLabel[c.type]}
+                      </div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 10, fontWeight: 700, color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {c.name}
+                        </div>
+                        <div style={{ fontSize: 9, color: 'var(--text-dim)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {cfg.url ?? '—'}
+                          {cfg.branch && c.type !== 'website' ? ` @ ${cfg.branch}` : ''}
+                          {c.hasToken ? ' 🔑' : ''}
+                        </div>
+                      </div>
+                      <button
+                        className="hud-btn"
+                        style={{ fontSize: 9 }}
+                        onClick={() => startEditConnector(c)}
+                        title="Edit"
+                      >✎</button>
+                      <button
+                        className="hud-btn"
+                        style={{ fontSize: 9, color: '#ff6b6b' }}
+                        onClick={() => handleDeleteConnector(c.id)}
+                        title="Delete"
+                      >✕</button>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+
+            {/* ── Fetchers Tab ── */}
+            {!loading && tab === 'fetchers' && (
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+                  <span style={{ fontSize: 10, color: 'var(--text-dim)' }}>
+                    Each fetcher aggregates connectors into a single shareable URL.
+                  </span>
+                  <button
+                    className="hud-btn"
+                    style={{ fontSize: 9, color: '#ff8800' }}
+                    onClick={() => setShowNewFetcher(true)}
+                  >
+                    + NEW FETCHER
+                  </button>
+                </div>
+
+                {showNewFetcher && (
+                  <div style={{
+                    background: 'var(--bg-darker)', border: '1px solid #ff8800',
+                    borderRadius: 4, padding: 12, marginBottom: 12,
+                    display: 'flex', gap: 8, alignItems: 'center',
+                  }}>
+                    <input
+                      className="hud-input"
+                      style={{ flex: 1, fontSize: 10 }}
+                      placeholder="Fetcher name…"
+                      value={newFetcherName}
+                      onChange={(e) => setNewFetcherName(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') handleCreateFetcher() }}
+                      autoFocus
+                    />
+                    <button
+                      className="hud-btn"
+                      style={{ fontSize: 9 }}
+                      onClick={() => { setShowNewFetcher(false); setNewFetcherName('') }}
+                    >CANCEL</button>
+                    <button
+                      className="hud-btn"
+                      style={{ fontSize: 9, color: '#ff8800' }}
+                      onClick={handleCreateFetcher}
+                      disabled={creatingFetcher || !newFetcherName.trim()}
+                    >
+                      {creatingFetcher ? 'CREATING…' : 'CREATE'}
+                    </button>
+                  </div>
+                )}
+
+                {fetchers.length === 0 && !showNewFetcher && (
+                  <div style={{ color: 'var(--text-dim)', fontSize: 10, textAlign: 'center', paddingTop: 16 }}>
+                    No fetchers yet. Create one to generate a shareable URL.
+                  </div>
+                )}
+
+                {fetchers.map((f) => {
+                  const fetchUrl = getSourceRelayFetchUrl(f.uniqueToken)
+                  const linkedConnectors = f.connectorFiles.map((cf) =>
+                    connectors.find((c) => c.id === cf.connectorId),
+                  ).filter(Boolean) as SourceRelayConnector[]
+                  const unlinkedConnectors = connectors.filter(
+                    (c) => !f.connectorFiles.some((cf) => cf.connectorId === c.id),
+                  )
+
+                  return (
+                    <div
+                      key={f.id}
+                      style={{
+                        background: 'var(--bg-darker)', borderRadius: 4,
+                        padding: 10, marginBottom: 10,
+                        border: '1px solid var(--border)',
+                      }}
+                    >
+                      {/* Fetcher header */}
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                        <span style={{ fontSize: 11, fontWeight: 700, color: '#ff8800', flex: 1 }}>{f.name}</span>
+                        <button
+                          className="hud-btn"
+                          style={{ fontSize: 9, color: '#ff6b6b' }}
+                          onClick={() => handleDeleteFetcher(f.id)}
+                          title="Delete fetcher"
+                        >✕</button>
+                      </div>
+
+                      {/* Public URL */}
+                      <div style={{
+                        background: 'rgba(0,0,0,0.3)', borderRadius: 3, padding: '4px 8px',
+                        display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8,
+                      }}>
+                        <span style={{ fontSize: 9, fontFamily: 'monospace', color: '#88ff44', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {fetchUrl}
+                        </span>
+                        <button
+                          className="hud-btn"
+                          style={{ fontSize: 9, flexShrink: 0 }}
+                          onClick={() => copyUrl(fetchUrl)}
+                          title="Copy URL"
+                        >⧉ COPY</button>
+                      </div>
+
+                      {/* Linked connectors */}
+                      <div style={{ fontSize: 9, color: 'var(--text-dim)', marginBottom: 4 }}>
+                        SOURCES ({linkedConnectors.length})
+                      </div>
+                      {linkedConnectors.length === 0 && (
+                        <div style={{ fontSize: 9, color: 'var(--text-dim)', marginBottom: 6, fontStyle: 'italic' }}>
+                          No sources linked yet.
+                        </div>
+                      )}
+                      {linkedConnectors.map((c) => {
+                        const cf = f.connectorFiles.find((x) => x.connectorId === c.id)
+                        let selectedPaths: string[] = []
+                        try { selectedPaths = JSON.parse(cf?.filePaths ?? '[]') } catch { /* empty */ }
+                        const isGit = c.type !== 'website'
+                        return (
+                          <div
+                            key={c.id}
+                            style={{
+                              display: 'flex', alignItems: 'center', gap: 6,
+                              padding: '3px 0', fontSize: 10,
+                            }}
+                          >
+                            <span style={{ color: 'var(--text)', flex: 1 }}>{c.name}</span>
+                            {isGit && (
+                              <span style={{ fontSize: 9, color: 'var(--text-dim)' }}>
+                                {selectedPaths.length === 0 ? 'all files' : `${selectedPaths.length} file${selectedPaths.length !== 1 ? 's' : ''}`}
+                              </span>
+                            )}
+                            {isGit && (
+                              <button
+                                className="hud-btn"
+                                style={{ fontSize: 9 }}
+                                onClick={() =>
+                                  setFileTreeFor({
+                                    fetcherId: f.id,
+                                    connector: c,
+                                    currentPaths: selectedPaths,
+                                  })
+                                }
+                                title="Select files"
+                              >FILES</button>
+                            )}
+                            <button
+                              className="hud-btn"
+                              style={{ fontSize: 9, color: '#ff6b6b' }}
+                              onClick={() => handleUnlinkConnector(f.id, c.id)}
+                              title="Remove source"
+                            >✕</button>
+                          </div>
+                        )
+                      })}
+
+                      {/* Link new connector */}
+                      {unlinkedConnectors.length > 0 && (
+                        <div style={{ marginTop: 6 }}>
+                          {linkingFetcherId === f.id ? (
+                            <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                              <select
+                                className="hud-input"
+                                style={{ flex: 1, fontSize: 9 }}
+                                value={linkConnectorId}
+                                onChange={(e) => setLinkConnectorId(e.target.value)}
+                              >
+                                <option value="">Select connector…</option>
+                                {unlinkedConnectors.map((c) => (
+                                  <option key={c.id} value={String(c.id)}>{c.name}</option>
+                                ))}
+                              </select>
+                              <button
+                                className="hud-btn"
+                                style={{ fontSize: 9 }}
+                                onClick={() => { setLinkingFetcherId(null); setLinkConnectorId('') }}
+                              >CANCEL</button>
+                              <button
+                                className="hud-btn"
+                                style={{ fontSize: 9, color: '#ff8800' }}
+                                onClick={() => handleLinkConnector(f.id)}
+                                disabled={savingLink || !linkConnectorId}
+                              >
+                                {savingLink ? '…' : 'ADD'}
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              className="hud-btn"
+                              style={{ fontSize: 9 }}
+                              onClick={() => { setLinkingFetcherId(f.id); setLinkConnectorId('') }}
+                            >
+                              + ADD SOURCE
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* File tree modal — portaled separately so it appears above the dialog */}
+      {fileTreeFor && createPortal(
+        <FileTreeModal
+          buildingId={building.id}
+          connector={fileTreeFor.connector}
+          selectedPaths={fileTreeFor.currentPaths}
+          onSave={(paths) =>
+            handleSaveFilePaths(fileTreeFor.fetcherId, fileTreeFor.connector.id, paths)
+          }
+          onClose={() => setFileTreeFor(null)}
+        />,
+        document.body,
+      )}
+    </>
+  )
+}
+
+// ── Building visual on the battlefield ──────────────────────────────────────
+
+export function SourceRelayBuilding({
+  building,
+  position,
+  isRelocateMode,
+  isBeingRelocated,
+  onStartRelocate,
+  addToast,
+  isSelected = false,
+  onSelect,
+  onDeselect,
+}: SourceRelayBuildingProps) {
+  const deleteBuilding = useAppStore((s) => s.deleteBuilding)
+  const updateBuildingColor = useAppStore((s) => s.updateBuildingColor)
+
+  const [currentBuilding, setCurrentBuilding] = useState(building)
+  const [fetcherCount, setFetcherCount] = useState(0)
+  const [showDialog, setShowDialog] = useState(false)
+  const colorInputRef = useRef<HTMLInputElement>(null)
+
+  const colorizedSrc = useColorizedImage('/buildings/healthcheck.png', currentBuilding.color ?? '#ff8800')
+
+  useEffect(() => { setCurrentBuilding(building) }, [building])
+
+  // Load fetcher count for badge
+  useEffect(() => {
+    api.listSourceRelayFetchers(building.id)
+      .then((fs) => setFetcherCount(fs.length))
+      .catch(() => { /* ignore */ })
+  }, [building.id])
+
+  useEffect(() => {
+    if (isSelected) setShowDialog(true)
+    else setShowDialog(false)
+  }, [isSelected])
+
+  function handleClick() {
+    if (isRelocateMode) return
+    onSelect?.()
+  }
+
+  function handleMouseDown(e: React.MouseEvent) {
+    if (isRelocateMode) {
+      e.stopPropagation()
+      onStartRelocate(e.clientX, e.clientY)
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm(`Demolish "${currentBuilding.name}"? All connectors and fetchers will be deleted.`)) return
+    try {
+      await deleteBuilding(currentBuilding.id)
+    } catch { /* toast shown by store */ }
+  }
+
+  async function handleColorChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const newColor = e.target.value
+    setCurrentBuilding((b) => ({ ...b, color: newColor }))
+    await updateBuildingColor(currentBuilding.id, newColor)
+  }
+
+  return (
+    <>
+      <div
+        className={`base-node clawcom-building${isSelected ? ' clawcom-selected' : ''}`}
+        style={{
+          position: 'absolute',
+          left: position.x,
+          top: position.y,
+          transform: 'translate(-50%, -50%)',
+          cursor: isRelocateMode ? 'grab' : 'pointer',
+          userSelect: 'none',
+          width: 140,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 4,
+          zIndex: isBeingRelocated ? 100 : 1,
+          opacity: isBeingRelocated ? 0.75 : 1,
+        }}
+        onMouseDown={handleMouseDown}
+        onClick={handleClick}
+      >
+        <div className="clawcom-img-wrap" style={{ position: 'relative' }}>
+          {colorizedSrc ? (
+            <img
+              src={colorizedSrc}
+              alt={currentBuilding.name}
+              style={{
+                width: 100, height: 100,
+                objectFit: 'contain',
+                imageRendering: 'auto',
+                filter: isBeingRelocated ? 'brightness(1.5)' : undefined,
+              }}
+              draggable={false}
+            />
+          ) : (
+            <div style={{ width: 100, height: 100, background: 'var(--bg-panel)', borderRadius: 4 }} />
+          )}
+
+          {/* Fetcher count badge */}
+          {fetcherCount > 0 && (
+            <div style={{
+              position: 'absolute', top: 2, right: 2,
+              background: '#ff8800', color: '#000',
+              borderRadius: '50%', width: 16, height: 16,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: 9, fontWeight: 700,
+            }}>
+              {fetcherCount}
+            </div>
+          )}
+
+          {/* Status dot */}
+          <div style={{
+            position: 'absolute', bottom: 2, right: 2,
+            width: 8, height: 8, borderRadius: '50%',
+            background: fetcherCount > 0 ? '#ff8800' : '#888',
+            border: '1px solid var(--bg-darker)',
+            boxShadow: fetcherCount > 0 ? '0 0 6px #ff8800' : undefined,
+          }} title={`${fetcherCount} active fetcher${fetcherCount !== 1 ? 's' : ''}`} />
+        </div>
+
+        {/* Name */}
+        <div style={{
+          fontSize: 11, fontWeight: 700,
+          color: currentBuilding.color ?? '#ff8800',
+          textAlign: 'center',
+          textShadow: `0 0 8px ${currentBuilding.color ?? '#ff8800'}44`,
+          maxWidth: 130, overflow: 'hidden',
+          textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>
+          {currentBuilding.name}
+        </div>
+
+        <div style={{ fontSize: 9, color: 'var(--text-dim)', textAlign: 'center' }}>
+          {fetcherCount > 0
+            ? `${fetcherCount} RELAY${fetcherCount !== 1 ? 'S' : ''} ACTIVE`
+            : '◌ NO RELAYS'}
+        </div>
+
+        {/* Action bar */}
+        {!isRelocateMode && (
+          <div
+            className="clawcom-actions"
+            style={{ display: 'flex', gap: 4, marginTop: 2 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className="hud-btn"
+              style={{ fontSize: 9, padding: '1px 5px' }}
+              onClick={() => colorInputRef.current?.click()}
+              title="Change color"
+            >◈</button>
+            <input
+              ref={colorInputRef}
+              type="color"
+              value={currentBuilding.color ?? '#ff8800'}
+              onChange={handleColorChange}
+              style={{ width: 0, height: 0, opacity: 0, position: 'absolute', pointerEvents: 'none' }}
+            />
+            <button
+              className="hud-btn"
+              style={{ fontSize: 9, padding: '1px 5px', color: '#ff6b6b' }}
+              onClick={handleDelete}
+              title="Demolish building"
+            >✕</button>
+          </div>
+        )}
+      </div>
+
+      {showDialog && createPortal(
+        <SourceRelayDialog
+          building={currentBuilding}
+          onClose={() => onDeselect?.()}
+          addToast={addToast}
+        />,
+        document.body,
+      )}
+    </>
+  )
+}

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldMapLayer.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldMapLayer.tsx
@@ -11,6 +11,7 @@ import { HealthcheckBuilding } from '../HealthcheckBuilding'
 import { MailboxBuilding } from '../MailboxBuilding'
 import { ResearchCenterBuilding } from '../ResearchCenterBuilding'
 import { RemoteShellBuilding } from '../RemoteShellBuilding'
+import { SourceRelayBuilding } from '../SourceRelayBuilding'
 import { BadgeMarker } from '../BadgeMarker'
 import { UserUnit } from './UserUnit'
 import type { Repo } from '../../types'
@@ -181,7 +182,9 @@ export function BattlefieldMapLayer({
               ? '/buildings/construction_4s_snailbox.gif'
               : building.type === 'research'
                 ? '/buildings/construct_4s_healthcheck.gif'
-                : '/buildings/construct_3s_clawcom.gif'
+                : building.type === 'sourceRelay'
+                  ? '/buildings/construct_4s_healthcheck.gif'
+                  : '/buildings/construct_3s_clawcom.gif'
           return (
             <div
               key={`building-${building.id}`}
@@ -215,6 +218,9 @@ export function BattlefieldMapLayer({
         }
         if (building.type === 'remoteShell') {
           return <RemoteShellBuilding {...commonProps} />
+        }
+        if (building.type === 'sourceRelay') {
+          return <SourceRelayBuilding {...commonProps} />
         }
         return <ClawComBuilding {...commonProps} />
       })}

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -442,3 +442,47 @@ export interface SshSessionLog {
 }
 
 export type ShellStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error'
+
+export interface SourceRelayConfig {
+  configured: boolean
+}
+
+export type SourceRelayConnectorType = 'git' | 'private_git' | 'website'
+
+export interface SourceRelayConnectorConfig {
+  url: string
+  branch?: string
+  token?: string | true // true = token exists but is redacted by API
+}
+
+export interface SourceRelayConnector {
+  id: number
+  buildingId: number
+  name: string
+  type: SourceRelayConnectorType
+  configuration: string // JSON-encoded SourceRelayConnectorConfig (token redacted)
+  hasToken: boolean
+  createdAt: string | number | null
+}
+
+export interface SourceRelayConnectorFile {
+  id: number
+  connectorId: number
+  fetcherId: number
+  filePaths: string // JSON array of selected file paths (empty = all files)
+  createdAt: string | number | null
+}
+
+export interface SourceRelayFetcher {
+  id: number
+  buildingId: number
+  name: string
+  uniqueToken: string
+  createdAt: string | number | null
+  connectorFiles: SourceRelayConnectorFile[]
+}
+
+export interface SourceRelayGitFile {
+  path: string
+  size?: number
+}

--- a/gh-ctrl/src/db/index.ts
+++ b/gh-ctrl/src/db/index.ts
@@ -219,4 +219,35 @@ sqlite.exec(`
   )
 `)
 
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS source_relay_connectors (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    building_id INTEGER NOT NULL REFERENCES buildings(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL DEFAULT 'git',
+    configuration TEXT NOT NULL DEFAULT '{}',
+    created_at INTEGER DEFAULT (unixepoch())
+  )
+`)
+
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS source_relay_fetchers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    building_id INTEGER NOT NULL REFERENCES buildings(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    unique_token TEXT NOT NULL UNIQUE,
+    created_at INTEGER DEFAULT (unixepoch())
+  )
+`)
+
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS source_relay_connector_files (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    connector_id INTEGER NOT NULL REFERENCES source_relay_connectors(id) ON DELETE CASCADE,
+    fetcher_id INTEGER NOT NULL REFERENCES source_relay_fetchers(id) ON DELETE CASCADE,
+    file_paths TEXT NOT NULL DEFAULT '[]',
+    created_at INTEGER DEFAULT (unixepoch())
+  )
+`)
+
 export const db = drizzle(sqlite, { schema })

--- a/gh-ctrl/src/db/schema.ts
+++ b/gh-ctrl/src/db/schema.ts
@@ -164,3 +164,31 @@ export const sshSessionLog = sqliteTable('ssh_session_log', {
   disconnectedAt:  integer('disconnected_at', { mode: 'timestamp' }),
   durationMs:      integer('duration_ms'),
 })
+
+// Source Relay: connectors (git repos and websites used as content sources)
+export const sourceRelayConnectors = sqliteTable('source_relay_connectors', {
+  id:            integer('id').primaryKey({ autoIncrement: true }),
+  buildingId:    integer('building_id').notNull().references(() => buildings.id, { onDelete: 'cascade' }),
+  name:          text('name').notNull(),
+  type:          text('type').notNull().default('git'), // 'git' | 'private_git' | 'website'
+  configuration: text('configuration').notNull().default('{}'), // JSON: {url, branch?, token?} or {url}
+  createdAt:     integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+})
+
+// Source Relay: fetchers — each fetcher aggregates multiple connectors into a single public URL
+export const sourceRelayFetchers = sqliteTable('source_relay_fetchers', {
+  id:          integer('id').primaryKey({ autoIncrement: true }),
+  buildingId:  integer('building_id').notNull().references(() => buildings.id, { onDelete: 'cascade' }),
+  name:        text('name').notNull(),
+  uniqueToken: text('unique_token').notNull().unique(),
+  createdAt:   integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+})
+
+// Source Relay: links a connector to a fetcher, optionally with a list of selected file paths
+export const sourceRelayConnectorFiles = sqliteTable('source_relay_connector_files', {
+  id:          integer('id').primaryKey({ autoIncrement: true }),
+  connectorId: integer('connector_id').notNull().references(() => sourceRelayConnectors.id, { onDelete: 'cascade' }),
+  fetcherId:   integer('fetcher_id').notNull().references(() => sourceRelayFetchers.id, { onDelete: 'cascade' }),
+  filePaths:   text('file_paths').notNull().default('[]'), // JSON array; empty = include all files
+  createdAt:   integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+})

--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -13,6 +13,7 @@ import timersRouter from './routes/timers'
 import contactsRouter from './routes/contacts'
 import settingsRouter from './routes/settings'
 import shellRouter, { shellWebsocket } from './routes/shell'
+import sourceRelayRouter, { sourceRelayPublicRouter } from './routes/source-relay'
 import pkg from '../package.json'
 import { existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
@@ -62,6 +63,10 @@ app.route('/api/timers', timersRouter)
 app.route('/api/contacts', contactsRouter)
 app.route('/api/settings', settingsRouter)
 app.route('/api/shell', shellRouter)
+app.route('/api/source-relay', sourceRelayRouter)
+
+// Public source-relay fetch endpoint — no auth required
+app.route('/source-relay', sourceRelayPublicRouter)
 
 app.get('/api/health', (c) => c.json({ ok: true }))
 app.get('/api/version', (c) => c.json({ version: pkg.version }))

--- a/gh-ctrl/src/routes/source-relay.ts
+++ b/gh-ctrl/src/routes/source-relay.ts
@@ -1,0 +1,458 @@
+import { Hono } from 'hono'
+import { db } from '../db'
+import {
+  sourceRelayConnectors,
+  sourceRelayFetchers,
+  sourceRelayConnectorFiles,
+} from '../db/schema'
+import { eq, and } from 'drizzle-orm'
+
+// Authenticated management router — mounted at /api/source-relay
+const app = new Hono()
+
+// Public router — mounted at /source-relay (outside auth middleware)
+export const sourceRelayPublicRouter = new Hono()
+
+// ---------------------------------------------------------------------------
+// Connectors
+// ---------------------------------------------------------------------------
+
+// GET /:buildingId/connectors — list connectors (tokens redacted)
+app.get('/:buildingId/connectors', async (c) => {
+  const buildingId = Number(c.req.param('buildingId'))
+  const rows = await db
+    .select()
+    .from(sourceRelayConnectors)
+    .where(eq(sourceRelayConnectors.buildingId, buildingId))
+  return c.json(
+    rows.map((r) => {
+      let cfg: Record<string, unknown> = {}
+      try { cfg = JSON.parse(r.configuration) } catch { /* empty */ }
+      return { ...r, configuration: JSON.stringify({ ...cfg, token: cfg.token ? true : undefined }), hasToken: !!cfg.token }
+    }),
+  )
+})
+
+// POST /:buildingId/connectors — create connector
+app.post('/:buildingId/connectors', async (c) => {
+  const buildingId = Number(c.req.param('buildingId'))
+  const body = await c.req.json()
+  const { name, type = 'git', configuration = {} } = body
+  if (!name?.trim()) return c.json({ error: 'Name required' }, 400)
+  const result = await db
+    .insert(sourceRelayConnectors)
+    .values({
+      buildingId,
+      name: String(name).trim(),
+      type: String(type),
+      configuration:
+        typeof configuration === 'string' ? configuration : JSON.stringify(configuration),
+    })
+    .returning()
+  const r = result[0]
+  let cfg: Record<string, unknown> = {}
+  try { cfg = JSON.parse(r.configuration) } catch { /* empty */ }
+  return c.json({ ...r, configuration: JSON.stringify({ ...cfg, token: cfg.token ? true : undefined }), hasToken: !!cfg.token }, 201)
+})
+
+// PATCH /:buildingId/connectors/:connectorId — update connector (token preserved if not supplied)
+app.patch('/:buildingId/connectors/:connectorId', async (c) => {
+  const buildingId = Number(c.req.param('buildingId'))
+  const connectorId = Number(c.req.param('connectorId'))
+  const body = await c.req.json()
+
+  const existing = await db
+    .select()
+    .from(sourceRelayConnectors)
+    .where(
+      and(
+        eq(sourceRelayConnectors.id, connectorId),
+        eq(sourceRelayConnectors.buildingId, buildingId),
+      ),
+    )
+  if (existing.length === 0) return c.json({ error: 'Connector not found' }, 404)
+
+  const updates: Record<string, string> = {}
+  if (body.name !== undefined) updates.name = String(body.name).trim()
+  if (body.type !== undefined) updates.type = String(body.type)
+  if (body.configuration !== undefined) {
+    const existingCfg: Record<string, unknown> = {}
+    try { Object.assign(existingCfg, JSON.parse(existing[0].configuration)) } catch { /* empty */ }
+    const newCfg: Record<string, unknown> =
+      typeof body.configuration === 'string'
+        ? JSON.parse(body.configuration)
+        : { ...body.configuration }
+    // Preserve existing token if the incoming value is falsy or the sentinel `true`
+    if (!newCfg.token || newCfg.token === true) {
+      newCfg.token = existingCfg.token
+    }
+    updates.configuration = JSON.stringify(newCfg)
+  }
+
+  const result = await db
+    .update(sourceRelayConnectors)
+    .set(updates)
+    .where(
+      and(
+        eq(sourceRelayConnectors.id, connectorId),
+        eq(sourceRelayConnectors.buildingId, buildingId),
+      ),
+    )
+    .returning()
+  if (result.length === 0) return c.json({ error: 'Connector not found' }, 404)
+  const r = result[0]
+  let cfg: Record<string, unknown> = {}
+  try { cfg = JSON.parse(r.configuration) } catch { /* empty */ }
+  return c.json({ ...r, configuration: JSON.stringify({ ...cfg, token: cfg.token ? true : undefined }), hasToken: !!cfg.token })
+})
+
+// DELETE /:buildingId/connectors/:connectorId
+app.delete('/:buildingId/connectors/:connectorId', async (c) => {
+  const buildingId = Number(c.req.param('buildingId'))
+  const connectorId = Number(c.req.param('connectorId'))
+  await db
+    .delete(sourceRelayConnectors)
+    .where(
+      and(
+        eq(sourceRelayConnectors.id, connectorId),
+        eq(sourceRelayConnectors.buildingId, buildingId),
+      ),
+    )
+  return c.json({ ok: true })
+})
+
+// GET /:buildingId/git-tree?connectorId=X — browse git repo file tree via stored connector
+app.get('/:buildingId/git-tree', async (c) => {
+  const buildingId = Number(c.req.param('buildingId'))
+  const connectorId = Number(c.req.query('connectorId') ?? '0')
+  const branch = c.req.query('branch')
+
+  const [connector] = await db
+    .select()
+    .from(sourceRelayConnectors)
+    .where(
+      and(
+        eq(sourceRelayConnectors.id, connectorId),
+        eq(sourceRelayConnectors.buildingId, buildingId),
+      ),
+    )
+  if (!connector) return c.json({ error: 'Connector not found' }, 404)
+
+  let cfg: Record<string, unknown> = {}
+  try { cfg = JSON.parse(connector.configuration) } catch { /* empty */ }
+
+  const repoUrl = cfg.url as string | undefined
+  const repoBranch = branch ?? (cfg.branch as string | undefined) ?? 'main'
+  const repoToken = cfg.token as string | undefined
+
+  if (!repoUrl) return c.json({ error: 'Connector has no URL configured' }, 400)
+
+  const match = repoUrl.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/?$)/)
+  if (!match) return c.json({ error: 'Only GitHub repository URLs are supported for file browsing' }, 400)
+
+  const [, owner, repo] = match
+  const apiUrl = `https://api.github.com/repos/${owner}/${repo}/git/trees/${repoBranch}?recursive=1`
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github.v3+json',
+    'User-Agent': 'vibe-and-conquer',
+  }
+  if (repoToken) headers['Authorization'] = `Bearer ${repoToken}`
+
+  const res = await fetch(apiUrl, { headers })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ message: res.statusText }))
+    return c.json({ error: (err as { message?: string }).message ?? res.statusText }, res.status as 400 | 404 | 422 | 500)
+  }
+
+  const data = (await res.json()) as {
+    tree: Array<{ path: string; type: string; size?: number }>
+  }
+  const files = data.tree.filter((item) => item.type === 'blob')
+  return c.json({ files: files.map((f) => ({ path: f.path, size: f.size })) })
+})
+
+// ---------------------------------------------------------------------------
+// Fetchers
+// ---------------------------------------------------------------------------
+
+// GET /:buildingId/fetchers — list fetchers with their connector assignments
+app.get('/:buildingId/fetchers', async (c) => {
+  const buildingId = Number(c.req.param('buildingId'))
+  const fetchers = await db
+    .select()
+    .from(sourceRelayFetchers)
+    .where(eq(sourceRelayFetchers.buildingId, buildingId))
+
+  const result = await Promise.all(
+    fetchers.map(async (f) => {
+      const connFiles = await db
+        .select()
+        .from(sourceRelayConnectorFiles)
+        .where(eq(sourceRelayConnectorFiles.fetcherId, f.id))
+      return { ...f, connectorFiles: connFiles }
+    }),
+  )
+  return c.json(result)
+})
+
+// POST /:buildingId/fetchers — create fetcher with a random unique token
+app.post('/:buildingId/fetchers', async (c) => {
+  const buildingId = Number(c.req.param('buildingId'))
+  const body = await c.req.json()
+  const { name } = body
+  if (!name?.trim()) return c.json({ error: 'Name required' }, 400)
+
+  const uniqueToken = crypto.randomUUID().replace(/-/g, '')
+  const result = await db
+    .insert(sourceRelayFetchers)
+    .values({ buildingId, name: String(name).trim(), uniqueToken })
+    .returning()
+  return c.json({ ...result[0], connectorFiles: [] }, 201)
+})
+
+// PATCH /:buildingId/fetchers/:fetcherId — rename fetcher
+app.patch('/:buildingId/fetchers/:fetcherId', async (c) => {
+  const buildingId = Number(c.req.param('buildingId'))
+  const fetcherId = Number(c.req.param('fetcherId'))
+  const body = await c.req.json()
+  const updates: Record<string, string> = {}
+  if (body.name !== undefined) updates.name = String(body.name).trim()
+  const result = await db
+    .update(sourceRelayFetchers)
+    .set(updates)
+    .where(
+      and(
+        eq(sourceRelayFetchers.id, fetcherId),
+        eq(sourceRelayFetchers.buildingId, buildingId),
+      ),
+    )
+    .returning()
+  if (result.length === 0) return c.json({ error: 'Fetcher not found' }, 404)
+  return c.json(result[0])
+})
+
+// DELETE /:buildingId/fetchers/:fetcherId
+app.delete('/:buildingId/fetchers/:fetcherId', async (c) => {
+  const buildingId = Number(c.req.param('buildingId'))
+  const fetcherId = Number(c.req.param('fetcherId'))
+  await db
+    .delete(sourceRelayFetchers)
+    .where(
+      and(
+        eq(sourceRelayFetchers.id, fetcherId),
+        eq(sourceRelayFetchers.buildingId, buildingId),
+      ),
+    )
+  return c.json({ ok: true })
+})
+
+// PUT /:buildingId/fetchers/:fetcherId/connectors/:connectorId — set/update file selection
+app.put('/:buildingId/fetchers/:fetcherId/connectors/:connectorId', async (c) => {
+  const fetcherId = Number(c.req.param('fetcherId'))
+  const connectorId = Number(c.req.param('connectorId'))
+  const body = await c.req.json()
+  const filePaths: string[] = Array.isArray(body.filePaths) ? body.filePaths : []
+
+  const existing = await db
+    .select()
+    .from(sourceRelayConnectorFiles)
+    .where(
+      and(
+        eq(sourceRelayConnectorFiles.fetcherId, fetcherId),
+        eq(sourceRelayConnectorFiles.connectorId, connectorId),
+      ),
+    )
+
+  if (existing.length > 0) {
+    const updated = await db
+      .update(sourceRelayConnectorFiles)
+      .set({ filePaths: JSON.stringify(filePaths) })
+      .where(eq(sourceRelayConnectorFiles.id, existing[0].id))
+      .returning()
+    return c.json(updated[0])
+  }
+
+  const result = await db
+    .insert(sourceRelayConnectorFiles)
+    .values({ connectorId, fetcherId, filePaths: JSON.stringify(filePaths) })
+    .returning()
+  return c.json(result[0], 201)
+})
+
+// DELETE /:buildingId/fetchers/:fetcherId/connectors/:connectorId — unlink connector
+app.delete('/:buildingId/fetchers/:fetcherId/connectors/:connectorId', async (c) => {
+  const fetcherId = Number(c.req.param('fetcherId'))
+  const connectorId = Number(c.req.param('connectorId'))
+  await db
+    .delete(sourceRelayConnectorFiles)
+    .where(
+      and(
+        eq(sourceRelayConnectorFiles.fetcherId, fetcherId),
+        eq(sourceRelayConnectorFiles.connectorId, connectorId),
+      ),
+    )
+  return c.json({ ok: true })
+})
+
+// ---------------------------------------------------------------------------
+// Public fetch endpoint — aggregates all connector content for a fetcher token
+// Mounted on sourceRelayPublicRouter at /source-relay
+// ---------------------------------------------------------------------------
+
+sourceRelayPublicRouter.get('/fetch/:token', async (c) => {
+  const token = c.req.param('token')
+
+  const [fetcher] = await db
+    .select()
+    .from(sourceRelayFetchers)
+    .where(eq(sourceRelayFetchers.uniqueToken, token))
+
+  if (!fetcher) {
+    return new Response('404 — Fetcher not found\n', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
+  }
+
+  const connFiles = await db
+    .select()
+    .from(sourceRelayConnectorFiles)
+    .where(eq(sourceRelayConnectorFiles.fetcherId, fetcher.id))
+
+  const connectors = await Promise.all(
+    connFiles.map(async (cf) => {
+      const [connector] = await db
+        .select()
+        .from(sourceRelayConnectors)
+        .where(eq(sourceRelayConnectors.id, cf.connectorId))
+      return {
+        connector,
+        filePaths: (JSON.parse(cf.filePaths ?? '[]') as string[]) ?? [],
+      }
+    }),
+  )
+
+  const parts: string[] = []
+  parts.push(`# ${fetcher.name}`)
+  parts.push(`\nGenerated at: ${new Date().toISOString()}\n`)
+
+  for (const { connector, filePaths } of connectors) {
+    if (!connector) continue
+    parts.push('='.repeat(80))
+    parts.push(`\n## Source: ${connector.name}`)
+    parts.push(`Type: ${connector.type}\n`)
+
+    let cfg: Record<string, unknown> = {}
+    try { cfg = JSON.parse(connector.configuration) } catch { /* empty */ }
+
+    if (connector.type === 'git' || connector.type === 'private_git') {
+      const repoUrl = cfg.url as string | undefined
+      const branch = (cfg.branch as string | undefined) ?? 'main'
+      const repoToken = cfg.token as string | undefined
+
+      parts.push(`Repository: ${repoUrl ?? '(unknown)'}`)
+      parts.push(`Branch: ${branch}`)
+
+      if (!repoUrl) {
+        parts.push('Error: no URL configured\n')
+        continue
+      }
+
+      const match = repoUrl.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/?$)/)
+      if (!match) {
+        parts.push('Error: only GitHub repository URLs are currently supported\n')
+        continue
+      }
+
+      const [, owner, repo] = match
+      const ghHeaders: Record<string, string> = {
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'vibe-and-conquer',
+      }
+      if (repoToken) ghHeaders['Authorization'] = `Bearer ${repoToken}`
+
+      let pathsToFetch = filePaths
+      if (!pathsToFetch || pathsToFetch.length === 0) {
+        const treeRes = await fetch(
+          `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`,
+          { headers: ghHeaders },
+        ).catch(() => null)
+        if (treeRes?.ok) {
+          const treeData = (await treeRes.json()) as {
+            tree: Array<{ path: string; type: string }>
+          }
+          pathsToFetch = treeData.tree
+            .filter((f) => f.type === 'blob')
+            .map((f) => f.path)
+        }
+      }
+
+      parts.push(`Files: ${pathsToFetch.length}\n`)
+
+      for (const filePath of pathsToFetch.slice(0, 100)) {
+        const contentsRes = await fetch(
+          `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`,
+          { headers: ghHeaders },
+        ).catch(() => null)
+        if (!contentsRes?.ok) continue
+        const fileData = (await contentsRes.json()) as {
+          content?: string
+          encoding?: string
+        }
+        if (!fileData.content || fileData.encoding !== 'base64') continue
+        const decoded = Buffer.from(
+          fileData.content.replace(/\n/g, ''),
+          'base64',
+        ).toString('utf-8')
+        const ext = filePath.split('.').pop() ?? ''
+        parts.push(`### File: ${filePath}\n`)
+        parts.push('```' + ext)
+        parts.push(decoded)
+        parts.push('```')
+        parts.push('---\n')
+      }
+    } else if (connector.type === 'website') {
+      const siteUrl = cfg.url as string | undefined
+      if (!siteUrl) {
+        parts.push('Error: no URL configured\n')
+        continue
+      }
+      parts.push(`URL: ${siteUrl}\n`)
+
+      const siteRes = await fetch(siteUrl, {
+        headers: { 'User-Agent': 'vibe-and-conquer' },
+      }).catch(() => null)
+
+      if (!siteRes?.ok) {
+        parts.push(`Error fetching page: ${siteRes?.status ?? 'network error'}\n`)
+        continue
+      }
+
+      const html = await siteRes.text()
+      const text = html
+        .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+        .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&nbsp;/g, ' ')
+        .replace(/\s{2,}/g, ' ')
+        .trim()
+      parts.push(text + '\n')
+    }
+  }
+
+  parts.push('='.repeat(80))
+
+  return new Response(parts.join('\n'), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+    },
+  })
+})
+
+export default app


### PR DESCRIPTION
Closes #328

Adds a new Source Relay building that ports the Resource Fetcher concept for self-hosted VPS deployments — no Supabase required.

**What's new:**
- Source Relay building with Connectors (GitHub repos, websites) and Fetchers (unique public URLs)
- 3 new SQLite tables (schema + auto-migration)
- Public fetch endpoint at `/source-relay/fetch/<token>` outside auth middleware
- Git tokens stored server-side, never exposed to frontend
- Interactive file-tree browser for scoping git repo sources

Generated with [Claude Code](https://claude.ai/code)