### PR TITLE
feat: tabbed layout for repositories screen

### DIFF
--- a/gh-ctrl/client/src/components/Settings.tsx
+++ b/gh-ctrl/client/src/components/Settings.tsx
@@ -197,6 +197,8 @@ export function Settings() {
     }
   }
 
+  const [activeSection, setActiveSection] = useState<'repositories' | 'setup' | 'preferences' | 'backup'>('repositories')
+
   const [fullName, setFullName] = useState('')
   const [selectedColor, setSelectedColor] = useState(COLORS[0])
   const [adding, setAdding] = useState(false)
@@ -381,6 +383,39 @@ export function Settings() {
         <h1>Repositories</h1>
       </div>
 
+      <div className="settings-section-tabs">
+        <button
+          className={`settings-section-tab${activeSection === 'repositories' ? ' active' : ''}`}
+          onClick={() => setActiveSection('repositories')}
+          type="button"
+        >
+          Repositories
+        </button>
+        <button
+          className={`settings-section-tab${activeSection === 'setup' ? ' active' : ''}`}
+          onClick={() => setActiveSection('setup')}
+          type="button"
+        >
+          Setup
+        </button>
+        <button
+          className={`settings-section-tab${activeSection === 'preferences' ? ' active' : ''}`}
+          onClick={() => setActiveSection('preferences')}
+          type="button"
+        >
+          Preferences
+        </button>
+        <button
+          className={`settings-section-tab${activeSection === 'backup' ? ' active' : ''}`}
+          onClick={() => setActiveSection('backup')}
+          type="button"
+        >
+          Backup
+        </button>
+      </div>
+
+      {activeSection === 'setup' && (
+      <>
       <div className="settings-section">
         <h2>Server Connection</h2>
         <p style={{ color: 'var(--text-2)', fontSize: '0.85rem', margin: '0 0 0.75rem' }}>
@@ -513,7 +548,10 @@ export function Settings() {
           </div>
         </div>
       </div>
+      </>
+      )}
 
+      {activeSection === 'preferences' && (
       <div className="settings-section">
         <h2>Preferences</h2>
         <div className="form-row">
@@ -530,7 +568,10 @@ export function Settings() {
           </select>
         </div>
       </div>
+      )}
 
+      {activeSection === 'repositories' && (
+      <>
       <div className="settings-section">
         <h2>Add Repository</h2>
         <div className="tab-bar">
@@ -891,8 +932,12 @@ export function Settings() {
           </div>
         )}
       </div>
+      </>
+      )}
 
-      <BackupPanel />
+      {activeSection === 'backup' && (
+        <BackupPanel />
+      )}
     </div>
   )
 }

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -600,6 +600,39 @@ a:hover { text-decoration: underline; }
   margin-bottom: 16px;
 }
 
+/* Page-level section tabs */
+.settings-section-tabs {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0;
+}
+
+.settings-section-tab {
+  background: none;
+  border: none;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-family: var(--font-display);
+  color: var(--text-2);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+  letter-spacing: 0.02em;
+}
+
+.settings-section-tab:hover {
+  color: var(--text);
+}
+
+.settings-section-tab.active {
+  color: var(--green);
+  border-bottom-color: var(--green);
+  font-weight: 600;
+}
+
 .repo-list-settings {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Reorganizes the repositories screen into four tabs (Repositories, Setup, Preferences, Backup) so settings and configuration concerns are separated and the page scales cleanly as new options are added.

Closes #350

Generated with [Claude Code](https://claude.ai/code)