### PR TITLE
feat: Battlefield top bar - TOOLS and PANELS dropdown menus

### DIFF
--- a/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import type { DashboardEntry, GameMap } from '../../types'
 import { CloseIcon, RelocateIcon, ScanIcon, BuildIcon, MapIcon, FeedIcon, TimerIcon } from '../Icons'
 import { ZOOM_MIN, ZOOM_MAX } from './battlefieldConstants'
@@ -65,6 +65,27 @@ export function BattlefieldHUD({
   showShortcuts,
 }: BattlefieldHUDProps) {
   const [showOverflow, setShowOverflow] = useState(false)
+  const [showPanelsMenu, setShowPanelsMenu] = useState(false)
+  const [showToolsMenu, setShowToolsMenu] = useState(false)
+  const panelsRef = useRef<HTMLDivElement>(null)
+  const toolsRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!showPanelsMenu && !showToolsMenu) return
+    const handler = (e: MouseEvent) => {
+      if (panelsRef.current && !panelsRef.current.contains(e.target as Node)) {
+        setShowPanelsMenu(false)
+      }
+      if (toolsRef.current && !toolsRef.current.contains(e.target as Node)) {
+        setShowToolsMenu(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [showPanelsMenu, showToolsMenu])
+
+  const anyPanelActive = showFeedPanel || showTimers || showMinimap || showShortcuts
+  const anyToolActive = showBadgeLibrary
 
   return (
     <div className="battlefield-hud">
@@ -113,24 +134,7 @@ export function BattlefieldHUD({
           <span className="hud-label"> {isRelocateMode ? 'CANCEL' : 'RELOCATE'}</span>
         </button>
 
-        {/* Desktop-only buttons — hidden on mobile via .hud-desktop-only */}
-        <button
-          className="hud-btn hud-desktop-only"
-          onClick={onShowBuildMenu}
-          title="Build options (ClawCom, etc.)"
-          aria-label="Open build options"
-        >
-          <BuildIcon size={11} /><span className="hud-label"> BUILD</span>
-        </button>
-        <button
-          className={`hud-btn hud-desktop-only${showBadgeLibrary ? ' active' : ''}`}
-          onClick={onToggleBadgeLibrary}
-          title="Badge Library — place custom markers on the battlefield"
-          aria-label="Open badge library"
-          aria-pressed={showBadgeLibrary}
-        >
-          ◈<span className="hud-label"> BADGES</span>
-        </button>
+        {/* Desktop-only: MAP selector */}
         <span className="hud-zoom-sep hud-desktop-only" />
         <button
           className="hud-btn hud-desktop-only"
@@ -148,51 +152,97 @@ export function BattlefieldHUD({
             <CloseIcon size={9} />
           </button>
         )}
-        <span className="hud-zoom-sep" />
-        <button
-          className={`hud-btn hud-desktop-only${showFeedPanel ? ' active' : ''}`}
-          onClick={onToggleFeed}
-          title="Toggle Intel Feed"
-          aria-label="Toggle Intel Feed"
-          aria-pressed={showFeedPanel}
-        >
-          <FeedIcon size={11} /><span className="hud-label"> FEED</span>
-        </button>
-        <button
-          className={`hud-btn hud-desktop-only${showTimers ? ' active' : ''}`}
-          onClick={onToggleTimers}
-          title="Mission Timers — Deadline countdown for all maps"
-          aria-label="Toggle mission timers"
-          aria-pressed={showTimers}
-        >
-          <TimerIcon size={11} /><span className="hud-label"> TIMERS</span>
-        </button>
+
+        {/* Desktop-only: TOOLS dropdown */}
+        <span className="hud-zoom-sep hud-desktop-only" />
+        <div className="hud-dropdown-wrap hud-desktop-only" ref={toolsRef}>
+          <button
+            className="hud-btn"
+            onClick={(e) => { e.stopPropagation(); setShowToolsMenu(v => !v); setShowPanelsMenu(false) }}
+            title="Tools menu — Build, Badges"
+            aria-label="Open tools menu"
+            aria-expanded={showToolsMenu}
+          >
+            <BuildIcon size={11} /><span className="hud-label"> TOOLS</span>
+            {anyToolActive && <span className="hud-active-dot" />}
+            <span className="hud-dropdown-arrow">{showToolsMenu ? '▲' : '▼'}</span>
+          </button>
+          {showToolsMenu && (
+            <div className="hud-dropdown-panel" onClick={(e) => e.stopPropagation()}>
+              <button
+                className="hud-btn hud-dropdown-item"
+                onClick={() => { setShowToolsMenu(false); onShowBuildMenu() }}
+                title="Build options (ClawCom, etc.)"
+              >
+                <BuildIcon size={11} /> BUILD
+              </button>
+              <button
+                className={`hud-btn hud-dropdown-item${showBadgeLibrary ? ' active' : ''}`}
+                onClick={() => { onToggleBadgeLibrary() }}
+                title="Badge Library — place custom markers on the battlefield"
+                aria-pressed={showBadgeLibrary}
+              >
+                ◈ BADGES
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Desktop-only: PANELS dropdown */}
+        <div className="hud-dropdown-wrap hud-desktop-only" ref={panelsRef}>
+          <button
+            className="hud-btn"
+            onClick={(e) => { e.stopPropagation(); setShowPanelsMenu(v => !v); setShowToolsMenu(false) }}
+            title="Panels menu — Feed, Timers, Minimap, Shortcuts"
+            aria-label="Open panels menu"
+            aria-expanded={showPanelsMenu}
+          >
+            <FeedIcon size={11} /><span className="hud-label"> PANELS</span>
+            {anyPanelActive && <span className="hud-active-dot" />}
+            <span className="hud-dropdown-arrow">{showPanelsMenu ? '▲' : '▼'}</span>
+          </button>
+          {showPanelsMenu && (
+            <div className="hud-dropdown-panel" onClick={(e) => e.stopPropagation()}>
+              <button
+                className={`hud-btn hud-dropdown-item${showFeedPanel ? ' active' : ''}`}
+                onClick={onToggleFeed}
+                title="Toggle Intel Feed"
+                aria-pressed={showFeedPanel}
+              >
+                <FeedIcon size={11} /> INTEL FEED
+              </button>
+              <button
+                className={`hud-btn hud-dropdown-item${showTimers ? ' active' : ''}`}
+                onClick={onToggleTimers}
+                title="Mission Timers — Deadline countdown"
+                aria-pressed={showTimers}
+              >
+                <TimerIcon size={11} /> MISSION TIMERS
+              </button>
+              <button
+                className={`hud-btn hud-dropdown-item${showMinimap ? ' active' : ''}`}
+                onClick={onToggleMinimap}
+                title={showMinimap ? 'Hide minimap' : 'Show minimap'}
+                aria-pressed={showMinimap}
+              >
+                &#x25A1; MINIMAP
+              </button>
+              <button
+                className={`hud-btn hud-dropdown-item${showShortcuts ? ' active' : ''}`}
+                onClick={onToggleShortcuts}
+                title="Keyboard Shortcuts [?]"
+                aria-pressed={showShortcuts}
+              >
+                ⌨ KEYBOARD SHORTCUTS
+              </button>
+            </div>
+          )}
+        </div>
+
         <span className="hud-zoom-sep" />
         <button className="hud-btn hud-zoom-btn" onClick={onZoomOut} disabled={zoom <= ZOOM_MIN} title="Zoom out [−]" aria-label="Zoom out">−</button>
         <span className="hud-zoom-level" title="Click to reset zoom [0]" onClick={onZoomReset} role="button" aria-label={`Current zoom ${Math.round(zoom * 100)}%, click to reset`}>{Math.round(zoom * 100)}%</span>
         <button className="hud-btn hud-zoom-btn" onClick={onZoomIn} disabled={zoom >= ZOOM_MAX} title="Zoom in [+]" aria-label="Zoom in">+</button>
-        <span className="hud-zoom-sep" />
-
-        {/* Minimap toggle — visible on all screen sizes */}
-        <button
-          className={`hud-btn${showMinimap ? ' active' : ''}`}
-          onClick={onToggleMinimap}
-          title={showMinimap ? 'Hide minimap' : 'Show minimap'}
-          aria-label="Toggle minimap"
-          aria-pressed={showMinimap}
-        >
-          &#x25A1;<span className="hud-label"> MAP</span>
-        </button>
-
-        <button
-          className={`hud-btn hud-desktop-only${showShortcuts ? ' active' : ''}`}
-          onClick={onToggleShortcuts}
-          title="Keyboard Shortcuts [?]"
-          aria-label="Toggle keyboard shortcuts overlay"
-          aria-pressed={showShortcuts}
-        >
-          ⌨<span className="hud-label"> KEYS</span>
-        </button>
 
         {/* Mobile overflow menu — visible only on mobile */}
         <div className="hud-overflow-wrap hud-mobile-only">
@@ -221,10 +271,16 @@ export function BattlefieldHUD({
                 </button>
               )}
               <button className={`hud-btn hud-overflow-item${showFeedPanel ? ' active' : ''}`} onClick={() => { setShowOverflow(false); onToggleFeed() }}>
-                <FeedIcon size={11} /> FEED
+                <FeedIcon size={11} /> INTEL FEED
               </button>
               <button className={`hud-btn hud-overflow-item${showTimers ? ' active' : ''}`} onClick={() => { setShowOverflow(false); onToggleTimers() }}>
-                <TimerIcon size={11} /> TIMERS
+                <TimerIcon size={11} /> MISSION TIMERS
+              </button>
+              <button className={`hud-btn hud-overflow-item${showMinimap ? ' active' : ''}`} onClick={() => { setShowOverflow(false); onToggleMinimap() }}>
+                &#x25A1; MINIMAP
+              </button>
+              <button className={`hud-btn hud-overflow-item${showShortcuts ? ' active' : ''}`} onClick={() => { setShowOverflow(false); onToggleShortcuts() }}>
+                ⌨ KEYBOARD SHORTCUTS
               </button>
             </div>
           )}

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -6188,6 +6188,55 @@ select.input {
   min-height: 36px;
 }
 
+/* ── HUD Dropdown Menus (desktop) ── */
+.hud-dropdown-wrap {
+  position: relative;
+}
+
+.hud-dropdown-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  background: rgba(4, 10, 6, 0.98);
+  border: 1px solid rgba(57, 255, 20, 0.4);
+  border-radius: 6px;
+  padding: 4px;
+  min-width: 170px;
+  z-index: 30;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.8);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hud-dropdown-item {
+  width: 100%;
+  justify-content: flex-start !important;
+  padding: 6px 10px !important;
+  font-size: 10px !important;
+  gap: 6px;
+  display: flex;
+  align-items: center;
+}
+
+.hud-active-dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--crt-green);
+  box-shadow: 0 0 4px var(--crt-green);
+  flex-shrink: 0;
+  margin-left: 2px;
+}
+
+.hud-dropdown-arrow {
+  font-size: 7px;
+  opacity: 0.55;
+  margin-left: 2px;
+  flex-shrink: 0;
+}
+
 /* ── MapEditor mobile block ── */
 .map-editor-mobile-block {
   display: flex;


### PR DESCRIPTION
Closes #351

## Summary

- Replaced 6 individual HUD buttons with two dropdown menus: **TOOLS ▼** (Build, Badges) and **PANELS ▼** (Intel Feed, Mission Timers, Minimap, Keyboard Shortcuts)
- Active-state dot indicator on each dropdown trigger when any sub-panel is open
- Click-outside detection closes dropdowns automatically
- Desktop top bar reduced from ~11 elements to ~6
- Mobile overflow menu updated to include Minimap and Keyboard Shortcuts

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized desktop HUD controls into two dropdown menus: **TOOL** (Build, Badges) and **PANELS** (Intel Feed, Mission Timers, Minimap, Keyboard Shortcuts)
  * Updated control labels for clarity ("FEED" → "INTEL FEED", "TIMERS" → "MISSION TIMERS")
  * Dropdowns automatically close when clicking outside them

<!-- end of auto-generated comment: release notes by coderabbit.ai -->