### PR TITLE
fix: resolve 15 frontend bugs and inconsistencies (issue #349)

### DIFF
--- a/gh-ctrl/client/src/App.tsx
+++ b/gh-ctrl/client/src/App.tsx
@@ -174,7 +174,7 @@ export default function App() {
             className={({ isActive }) => `nav-btn${isActive ? ' active' : ''}`}
             onClick={() => setSidebarOpen(false)}
           >
-            <span className="nav-icon">&#x2699;</span><span className="nav-label"> Repositories</span>
+            <span className="nav-icon">&#x2699;</span><span className="nav-label"> Settings</span>
           </NavLink>
           <NavLink
             to="/contacts"

--- a/gh-ctrl/client/src/components/BaseNode.tsx
+++ b/gh-ctrl/client/src/components/BaseNode.tsx
@@ -9,6 +9,9 @@ import { useAppStore } from '../store'
 
 // ── Canvas color utilities ────────────────────────────────────────────────────
 
+// Module-level cache for processed ImageData, keyed by "src|color|pw|ph"
+const colorizedImageCache = new Map<string, ImageData>()
+
 function hexToRgb(hex: string): [number, number, number] {
   const clean = hex.replace('#', '')
   const full = clean.length === 3
@@ -47,6 +50,12 @@ function ColorizedBuilding({ src, fallback = src, width, height, color }: Colori
     canvas.height = ph
     ctx.scale(dpr, dpr)
 
+    const cacheKey = `${src}|${color}|${pw}|${ph}`
+    if (colorizedImageCache.has(cacheKey)) {
+      ctx.putImageData(colorizedImageCache.get(cacheKey)!, 0, 0)
+      return
+    }
+
     const applyColorReplacement = (source: string) => {
       const img = new Image()
       img.onload = () => {
@@ -71,6 +80,7 @@ function ColorizedBuilding({ src, fallback = src, width, height, color }: Colori
         }
 
         ctx.putImageData(imageData, 0, 0)
+        colorizedImageCache.set(cacheKey, imageData)
       }
       img.onerror = () => {
         // Fallback: draw the original building without color replacement

--- a/gh-ctrl/client/src/components/ClawComChatDialog.tsx
+++ b/gh-ctrl/client/src/components/ClawComChatDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import { api } from '../api'
 import { useAppStore } from '../store'
 import type { Building, ClawComConfig, ClawComMessage, ChannelEvent } from '../types'
@@ -27,8 +27,9 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
   const [submittingPermission, setSubmittingPermission] = useState<string | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
 
-  let config: Partial<ClawComConfig> = {}
-  try { config = JSON.parse(building.config) } catch { /* empty */ }
+  const config = useMemo<Partial<ClawComConfig>>(() => {
+    try { return JSON.parse(building.config) } catch { return {} }
+  }, [building.config])
 
   const isChannel = config.clawType === 'claudechannel'
 
@@ -36,7 +37,9 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
   useEffect(() => {
     api.getBuildingMessages(building.id)
       .then(setMessages)
-      .catch(() => {})
+      .catch((err: unknown) => {
+        onError(`Failed to load messages: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      })
       .finally(() => setLoading(false))
   }, [building.id])
 
@@ -51,7 +54,9 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
           setSseConnected(true)
         } else if (event.type === 'reply' && event.content) {
           // The backend already persisted this reply; refresh message list
-          api.getBuildingMessages(building.id).then(setMessages).catch(() => {})
+          api.getBuildingMessages(building.id).then(setMessages).catch((err: unknown) => {
+            onError(`Failed to refresh messages: ${err instanceof Error ? err.message : 'Unknown error'}`)
+          })
         } else if (event.type === 'permission_request' && event.id && event.toolName) {
           setPermissionPrompts((prev) => [
             ...prev,
@@ -83,8 +88,8 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
         const updated = await api.getBuildingMessages(building.id)
         setMessages(updated)
       }
-    } catch (err: any) {
-      onError(`Message could not be sent: ${err.message}`)
+    } catch (err: unknown) {
+      onError(`Message could not be sent: ${err instanceof Error ? err.message : 'Unknown error'}`)
     } finally {
       setSending(false)
     }
@@ -104,8 +109,8 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
       })
       await loadBuildings()
       onReconfigure()
-    } catch (err: any) {
-      onError(`Disconnect failed: ${err.message}`)
+    } catch (err: unknown) {
+      onError(`Disconnect failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
     }
   }
 
@@ -114,8 +119,8 @@ export function ClawComChatDialog({ building, onClose, onReconfigure, onError }:
     try {
       await api.submitPermissionVerdict(building.id, id, verdict)
       setPermissionPrompts((prev) => prev.filter((p) => p.id !== id))
-    } catch (err: any) {
-      onError(`Permission response failed: ${err.message}`)
+    } catch (err: unknown) {
+      onError(`Permission response failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
     } finally {
       setSubmittingPermission(null)
     }

--- a/gh-ctrl/client/src/components/DeadlineTimers.tsx
+++ b/gh-ctrl/client/src/components/DeadlineTimers.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import type { DeadlineTimer } from '../types'
 import { useAppStore } from '../store'
 import { SidePanel } from './SidePanel'
@@ -8,8 +8,7 @@ interface DeadlineTimersProps {
   onClose: () => void
 }
 
-function formatCountdown(deadline: string): { text: string; urgency: 'expired' | 'critical' | 'warning' | 'ok' } {
-  const now = Date.now()
+function formatCountdown(deadline: string, now: number): { text: string; urgency: 'expired' | 'critical' | 'warning' | 'ok' } {
   const end = new Date(deadline).getTime()
   const diff = end - now
 
@@ -52,19 +51,13 @@ function formatDeadlineDate(deadline: string): string {
 
 interface TimerCardProps {
   timer: DeadlineTimer
+  now: number
   onEdit: (timer: DeadlineTimer) => void
   onDelete: (id: number) => void
 }
 
-function TimerCard({ timer, onEdit, onDelete }: TimerCardProps) {
-  const [countdown, setCountdown] = useState(() => formatCountdown(timer.deadline))
-
-  useEffect(() => {
-    const tick = () => setCountdown(formatCountdown(timer.deadline))
-    tick()
-    const id = setInterval(tick, 1000)
-    return () => clearInterval(id)
-  }, [timer.deadline])
+function TimerCard({ timer, now, onEdit, onDelete }: TimerCardProps) {
+  const countdown = useMemo(() => formatCountdown(timer.deadline, now), [timer.deadline, now])
 
   const urgencyColor = {
     expired: '#888',
@@ -79,7 +72,13 @@ function TimerCard({ timer, onEdit, onDelete }: TimerCardProps) {
         <span className="dt-card-name" style={{ color: timer.color }}>{timer.name}</span>
         <div className="dt-card-actions">
           <button className="dt-icon-btn" onClick={() => onEdit(timer)} title="Edit timer">✎</button>
-          <button className="dt-icon-btn dt-icon-btn--danger" onClick={() => onDelete(timer.id)} title="Delete timer">✕</button>
+          <button
+            className="dt-icon-btn dt-icon-btn--danger"
+            onClick={() => {
+              if (window.confirm(`Delete timer "${timer.name}"?`)) onDelete(timer.id)
+            }}
+            title="Delete timer"
+          >✕</button>
         </div>
       </div>
       {timer.description && (
@@ -206,10 +205,17 @@ export function DeadlineTimers({ isOpen, onClose }: DeadlineTimersProps) {
   const { deadlineTimers, loadTimers, createTimer, updateTimer, deleteTimer, addToast } = useAppStore()
   const [showForm, setShowForm] = useState(false)
   const [editingTimer, setEditingTimer] = useState<DeadlineTimer | null>(null)
+  const [now, setNow] = useState(() => Date.now())
 
   useEffect(() => {
     if (isOpen) loadTimers()
   }, [isOpen, loadTimers])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [isOpen])
 
   if (!isOpen) return null
 
@@ -274,6 +280,7 @@ export function DeadlineTimers({ isOpen, onClose }: DeadlineTimersProps) {
           <TimerCard
             key={timer.id}
             timer={timer}
+            now={now}
             onEdit={(t) => { setEditingTimer(t); setShowForm(false) }}
             onDelete={handleDelete}
           />

--- a/gh-ctrl/client/src/components/FeedPanel.tsx
+++ b/gh-ctrl/client/src/components/FeedPanel.tsx
@@ -72,11 +72,16 @@ export function FeedPanel({ entries, isOpen, onClose }: FeedPanelProps) {
   const fetchMentions = useCallback(() => {
     setMentionsLoading(true)
     setMentionsError(null)
-    Promise.all([
-      api.getFeed().catch(() => ({ mentions: [] as FeedItem[] })),
-      api.getGitLabFeed().catch(() => ({ mentions: [] as FeedItem[] })),
+    Promise.allSettled([
+      api.getFeed(),
+      api.getGitLabFeed(),
     ])
-      .then(([ghData, glData]) => {
+      .then(([ghResult, glResult]) => {
+        const ghData = ghResult.status === 'fulfilled' ? ghResult.value : { mentions: [] as FeedItem[] }
+        const glData = glResult.status === 'fulfilled' ? glResult.value : { mentions: [] as FeedItem[] }
+        if (ghResult.status === 'rejected' && glResult.status === 'rejected') {
+          setMentionsError('Failed to load mentions from all sources')
+        }
         const all = [...(ghData.mentions || []), ...(glData.mentions || [])]
         all.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
         setMentions(all)

--- a/gh-ctrl/client/src/components/MailboxInboxDialog.tsx
+++ b/gh-ctrl/client/src/components/MailboxInboxDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { api } from '../api'
 import type { Building, MailMessage } from '../types'
 
@@ -46,29 +46,30 @@ export function MailboxInboxDialog({ building, onClose, onReconfigure, onError }
   const [compose, setCompose]             = useState<ComposeState>({ to: '', subject: '', body: '' })
   const [sending, setSending]             = useState(false)
 
-  async function loadMessages() {
+  const loadMessages = useCallback(async () => {
     setLoading(true)
     try {
       const msgs = await api.getMailMessages(building.id)
       setMessages(msgs)
-    } catch (err: any) {
-      onError(`Error loading: ${err.message}`)
+    } catch (err: unknown) {
+      onError(`Error loading: ${err instanceof Error ? err.message : 'Unknown error'}`)
     } finally {
       setLoading(false)
     }
-  }
+  }, [building.id, onError])
 
   useEffect(() => {
     loadMessages()
-  }, [building.id])
+  }, [loadMessages])
 
   async function handleSync() {
+    if (syncing) return
     setSyncing(true)
     try {
       await api.syncMail(building.id)
-      setTimeout(loadMessages, 2000)
-    } catch (err: any) {
-      onError(`Sync failed: ${err.message}`)
+      await loadMessages()
+    } catch (err: unknown) {
+      onError(`Sync failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
     } finally {
       setSyncing(false)
     }
@@ -91,17 +92,20 @@ export function MailboxInboxDialog({ building, onClose, onReconfigure, onError }
       const result = await api.toggleMailStar(building.id, msg.id)
       setMessages((prev) => prev.map((m) => m.id === msg.id ? { ...m, isStarred: result.isStarred } : m))
       if (selected?.id === msg.id) setSelected((s) => s ? { ...s, isStarred: result.isStarred } : s)
-    } catch { /* ignore */ }
+    } catch (err: unknown) {
+      onError(`Failed to update star: ${err instanceof Error ? err.message : 'Unknown error'}`)
+    }
   }
 
   async function handleDelete(msg: MailMessage, e: React.MouseEvent) {
     e.stopPropagation()
+    if (!window.confirm(`Delete message "${msg.subject ?? '(no subject)'}"?`)) return
     try {
       await api.deleteMailMessage(building.id, msg.id)
       setMessages((prev) => prev.filter((m) => m.id !== msg.id))
       if (selected?.id === msg.id) setSelected(null)
-    } catch (err: any) {
-      onError(`Delete failed: ${err.message}`)
+    } catch (err: unknown) {
+      onError(`Delete failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
     }
   }
 
@@ -112,8 +116,8 @@ export function MailboxInboxDialog({ building, onClose, onReconfigure, onError }
       await api.sendMail(building.id, compose)
       setComposing(false)
       setCompose({ to: '', subject: '', body: '' })
-    } catch (err: any) {
-      onError(`Send failed: ${err.message}`)
+    } catch (err: unknown) {
+      onError(`Send failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
     } finally {
       setSending(false)
     }
@@ -123,39 +127,37 @@ export function MailboxInboxDialog({ building, onClose, onReconfigure, onError }
   const unreadCount = messages.filter((m) => !m.isRead).length
 
   return (
-    <div className="map-dialog" style={{ width: 720, maxWidth: '95vw' }} onWheel={(e) => e.stopPropagation()}>
+    <div className="map-dialog mailbox-dialog" onWheel={(e) => e.stopPropagation()}>
       {/* Header */}
-      <div className="map-dialog-title" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div className="map-dialog-title mailbox-dialog-header">
         <span>&#x25a0; {building.name.toUpperCase()} — INBOX</span>
-        <div style={{ display: 'flex', gap: 6 }}>
-          <button className="hud-btn" style={{ fontSize: 9 }} onClick={handleSync} disabled={syncing}>
+        <div className="mailbox-header-actions">
+          <button className="hud-btn mailbox-sm-btn" onClick={handleSync} disabled={syncing}>
             {syncing ? '◌' : '↻'} SYNC
           </button>
-          <button className="hud-btn" style={{ fontSize: 9 }} onClick={() => { setComposing(true); setSelected(null) }}>
+          <button className="hud-btn mailbox-sm-btn" onClick={() => { setComposing(true); setSelected(null) }}>
             ✉ COMPOSE
           </button>
-          <button className="hud-btn" style={{ fontSize: 9 }} onClick={onReconfigure}>
+          <button className="hud-btn mailbox-sm-btn" onClick={onReconfigure}>
             ⚙
           </button>
         </div>
       </div>
 
       {/* Body */}
-      <div style={{ display: 'flex', height: 420, overflow: 'hidden' }}>
+      <div className="mailbox-body">
         {/* Left: message list */}
-        <div style={{ width: 280, borderRight: '1px solid var(--border)', display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
+        <div className="mailbox-list-panel">
           {/* Tabs */}
-          <div style={{ display: 'flex', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
+          <div className="mailbox-tabs">
             <button
-              className={`hud-btn${tab === 'inbox' ? ' active' : ''}`}
-              style={{ flex: 1, fontSize: 9, borderRadius: 0 }}
+              className={`hud-btn mailbox-tab-btn${tab === 'inbox' ? ' active' : ''}`}
               onClick={() => setTab('inbox')}
             >
-              INBOX {unreadCount > 0 && <span style={{ color: '#ff4444' }}>({unreadCount})</span>}
+              INBOX {unreadCount > 0 && <span className="mailbox-unread-count">({unreadCount})</span>}
             </button>
             <button
-              className={`hud-btn${tab === 'starred' ? ' active' : ''}`}
-              style={{ flex: 1, fontSize: 9, borderRadius: 0 }}
+              className={`hud-btn mailbox-tab-btn${tab === 'starred' ? ' active' : ''}`}
               onClick={() => setTab('starred')}
             >
               ★ STARRED
@@ -163,60 +165,39 @@ export function MailboxInboxDialog({ building, onClose, onReconfigure, onError }
           </div>
 
           {/* List */}
-          <div style={{ overflowY: 'auto', flex: 1 }}>
+          <div className="mailbox-message-list">
             {loading && (
-              <div style={{ padding: 12, fontSize: 10, color: 'var(--text-dim)', textAlign: 'center' }}>◌ Loading...</div>
+              <div className="mailbox-list-status">◌ Loading...</div>
             )}
             {!loading && displayed.length === 0 && (
-              <div style={{ padding: 12, fontSize: 10, color: 'var(--text-dim)', textAlign: 'center' }}>
-                No messages
-              </div>
+              <div className="mailbox-list-status">No messages</div>
             )}
             {displayed.map((msg) => (
               <div
                 key={msg.id}
                 onClick={() => handleSelect(msg)}
-                style={{
-                  padding: '8px 10px',
-                  borderBottom: '1px solid var(--border)',
-                  cursor: 'pointer',
-                  background: selected?.id === msg.id ? 'var(--bg-hover)' : 'transparent',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 2,
-                }}
+                className={`mailbox-message-row${selected?.id === msg.id ? ' mailbox-message-row--selected' : ''}`}
               >
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 4 }}>
-                  <span style={{
-                    fontSize: 10,
-                    fontWeight: msg.isRead ? 400 : 700,
-                    color: msg.isRead ? 'var(--text-dim)' : 'var(--text)',
-                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1,
-                  }}>
+                <div className="mailbox-row-header">
+                  <span className={`mailbox-sender${msg.isRead ? ' mailbox-sender--read' : ''}`}>
                     {parseFrom(msg.fromAddress)}
                   </span>
-                  <span style={{ fontSize: 9, color: 'var(--text-dim)', flexShrink: 0 }}>
+                  <span className="mailbox-date">
                     {formatDate(msg.date)}
                   </span>
                 </div>
-                <div style={{
-                  fontSize: 10,
-                  color: msg.isRead ? 'var(--text-dim)' : 'var(--text)',
-                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                }}>
+                <div className={`mailbox-subject${msg.isRead ? ' mailbox-subject--read' : ''}`}>
                   {msg.subject ?? '(no subject)'}
                 </div>
-                <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
-                  {!msg.isRead && (
-                    <span style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--green-neon)', display: 'inline-block' }} />
-                  )}
+                <div className="mailbox-row-meta">
+                  {!msg.isRead && <span className="mailbox-unread-dot" />}
                   <button
-                    style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 10, padding: 0, color: msg.isStarred ? '#ffaa00' : 'var(--text-dim)' }}
+                    className={`mailbox-icon-btn${msg.isStarred ? ' mailbox-icon-btn--starred' : ''}`}
                     onClick={(e) => handleToggleStar(msg, e)}
                     title="Star"
                   >★</button>
                   <button
-                    style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 10, padding: 0, color: 'var(--text-dim)', marginLeft: 'auto' }}
+                    className="mailbox-icon-btn mailbox-icon-btn--delete"
                     onClick={(e) => handleDelete(msg, e)}
                     title="Delete"
                   >✕</button>
@@ -227,33 +208,30 @@ export function MailboxInboxDialog({ building, onClose, onReconfigure, onError }
         </div>
 
         {/* Right: detail or compose */}
-        <div style={{ flex: 1, padding: 14, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <div className="mailbox-detail-panel">
           {composing ? (
             <>
-              <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--green-neon)' }}>✉ NEW EMAIL</div>
+              <div className="mailbox-compose-title">✉ NEW EMAIL</div>
               <input
-                className="hud-input"
+                className="hud-input mailbox-compose-input"
                 value={compose.to}
                 onChange={(e) => setCompose((c) => ({ ...c, to: e.target.value }))}
                 placeholder="To: recipient@example.com"
-                style={{ width: '100%' }}
               />
               <input
-                className="hud-input"
+                className="hud-input mailbox-compose-input"
                 value={compose.subject}
                 onChange={(e) => setCompose((c) => ({ ...c, subject: e.target.value }))}
                 placeholder="Subject"
-                style={{ width: '100%' }}
               />
               <textarea
-                className="hud-input"
+                className="hud-input mailbox-compose-textarea"
                 value={compose.body}
                 onChange={(e) => setCompose((c) => ({ ...c, body: e.target.value }))}
                 placeholder="Message..."
                 rows={8}
-                style={{ width: '100%', resize: 'vertical', fontFamily: 'inherit' }}
               />
-              <div style={{ display: 'flex', gap: 6 }}>
+              <div className="mailbox-compose-actions">
                 <button className="hud-btn" onClick={() => setComposing(false)}>CANCEL</button>
                 <button
                   className="hud-btn hud-btn-new-base"
@@ -267,28 +245,28 @@ export function MailboxInboxDialog({ building, onClose, onReconfigure, onError }
           ) : selected ? (
             <>
               <div>
-                <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--text)', marginBottom: 6 }}>
+                <div className="mailbox-detail-subject">
                   {selected.subject ?? '(no subject)'}
                 </div>
-                <div style={{ fontSize: 10, color: 'var(--text-dim)', marginBottom: 2 }}>
+                <div className="mailbox-detail-meta">
                   <strong>From:</strong> {selected.fromAddress ?? '—'}
                 </div>
                 {selected.toAddresses && (() => {
                   try {
                     const addrs = JSON.parse(selected.toAddresses) as string[]
                     return addrs.length > 0 ? (
-                      <div style={{ fontSize: 10, color: 'var(--text-dim)', marginBottom: 2 }}>
+                      <div className="mailbox-detail-meta">
                         <strong>To:</strong> {addrs.join(', ')}
                       </div>
                     ) : null
                   } catch { return null }
                 })()}
-                <div style={{ fontSize: 10, color: 'var(--text-dim)', marginBottom: 10 }}>
+                <div className="mailbox-detail-date">
                   <strong>Date:</strong> {selected.date ? new Date(selected.date).toLocaleString() : '—'}
                 </div>
-                <div style={{ borderTop: '1px solid var(--border)', paddingTop: 10, fontSize: 11, color: 'var(--text)', whiteSpace: 'pre-wrap', lineHeight: 1.5 }}>
+                <div className="mailbox-detail-body">
                   {selected.bodyText ?? selected.snippet ?? (
-                    <span style={{ color: 'var(--text-dim)', fontStyle: 'italic' }}>
+                    <span className="mailbox-detail-empty">
                       No text available. Start a sync to fetch the message content.
                     </span>
                   )}
@@ -296,7 +274,7 @@ export function MailboxInboxDialog({ building, onClose, onReconfigure, onError }
               </div>
             </>
           ) : (
-            <div style={{ color: 'var(--text-dim)', fontSize: 10, marginTop: 40, textAlign: 'center' }}>
+            <div className="mailbox-detail-placeholder">
               &#x25a6; Select a message
             </div>
           )}

--- a/gh-ctrl/client/src/components/Settings.tsx
+++ b/gh-ctrl/client/src/components/Settings.tsx
@@ -43,7 +43,9 @@ export function Settings() {
   const [githubTokenSet, setGithubTokenSet] = useState(false)
   const [gitlabTokenSet, setGitlabTokenSet] = useState(false)
   const [savingGithubToken, setSavingGithubToken] = useState(false)
+  const [clearingGithubToken, setClearingGithubToken] = useState(false)
   const [savingGitlabToken, setSavingGitlabToken] = useState(false)
+  const [clearingGitlabToken, setClearingGitlabToken] = useState(false)
 
   useEffect(() => {
     api.getAllSettings().then((s) => {
@@ -68,6 +70,8 @@ export function Settings() {
   }
 
   const handleClearGithubToken = async () => {
+    if (clearingGithubToken) return
+    setClearingGithubToken(true)
     try {
       await api.deleteSetting('GITHUB_TOKEN')
       setGithubTokenSet(false)
@@ -75,6 +79,8 @@ export function Settings() {
       addToast('GitHub token cleared', 'info')
     } catch (err: any) {
       addToast(`Failed to clear GitHub token: ${err.message}`, 'error')
+    } finally {
+      setClearingGithubToken(false)
     }
   }
 
@@ -94,6 +100,8 @@ export function Settings() {
   }
 
   const handleClearGitlabToken = async () => {
+    if (clearingGitlabToken) return
+    setClearingGitlabToken(true)
     try {
       await api.deleteSetting('GITLAB_TOKEN')
       setGitlabTokenSet(false)
@@ -101,6 +109,8 @@ export function Settings() {
       addToast('GitLab token cleared', 'info')
     } catch (err: any) {
       addToast(`Failed to clear GitLab token: ${err.message}`, 'error')
+    } finally {
+      setClearingGitlabToken(false)
     }
   }
 
@@ -491,9 +501,10 @@ export function Settings() {
                 <button
                   className="btn btn-danger"
                   onClick={handleClearGithubToken}
+                  disabled={clearingGithubToken}
                   style={{ whiteSpace: 'nowrap' }}
                 >
-                  Clear
+                  {clearingGithubToken ? '◌' : 'Clear'}
                 </button>
               )}
             </div>
@@ -536,9 +547,10 @@ export function Settings() {
                 <button
                   className="btn btn-danger"
                   onClick={handleClearGitlabToken}
+                  disabled={clearingGitlabToken}
                   style={{ whiteSpace: 'nowrap' }}
                 >
-                  Clear
+                  {clearingGitlabToken ? '◌' : 'Clear'}
                 </button>
               )}
             </div>

--- a/gh-ctrl/client/src/store.ts
+++ b/gh-ctrl/client/src/store.ts
@@ -2,6 +2,10 @@ import { create } from 'zustand'
 import type { Repo, DashboardEntry, RepoData, GameMap, Building, Badge, PlacedBadge, DeadlineTimer, BattlefieldUser, Contact } from './types'
 import { api } from './api'
 
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
 function avatarUrlForLogin(login: string, provider: 'github' | 'gitlab', instanceUrl?: string | null, knownAvatarUrl?: string): string {
   if (knownAvatarUrl) return knownAvatarUrl
   if (provider === 'gitlab') {
@@ -131,8 +135,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const data = await api.listRepos()
       set({ repos: data })
-    } catch (err: any) {
-      get().addToast(`Failed to load repos: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to load repos: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -172,8 +176,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
         ),
         lastRefresh: new Date(),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to refresh ${owner}/${name}: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to refresh ${owner}/${name}: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -203,8 +207,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
         repos: state.repos.map((r) => r.id === id ? { ...r, color: updated.color } : r),
         entries: state.entries.map((e) => e.repo.id === id ? { ...e, repo: { ...e.repo, color: updated.color } } : e),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to update color: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to update color: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -212,16 +216,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const data = await api.listMaps()
       set({ maps: data })
-    } catch (err: any) {
-      get().addToast(`Failed to load maps: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to load maps: ${errMsg(err)}`, 'error')
     }
   },
 
   assignRepoToMap: async (mapId: number, repoId: number) => {
     try {
       await api.assignRepoToMap(mapId, repoId)
-    } catch (err: any) {
-      get().addToast(`Failed to assign repo to map: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to assign repo to map: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -229,8 +233,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
   unassignRepoFromMap: async (mapId: number, repoId: number) => {
     try {
       await api.unassignRepoFromMap(mapId, repoId)
-    } catch (err: any) {
-      get().addToast(`Failed to unassign repo from map: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to unassign repo from map: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -239,8 +243,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const data = await api.listBuildings()
       set({ buildings: data })
-    } catch (err: any) {
-      get().addToast(`Failed to load buildings: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to load buildings: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -250,8 +254,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set((state) => ({
         buildings: state.buildings.map((b) => b.id === id ? { ...b, posX: updated.posX, posY: updated.posY } : b),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to update building position: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to update building position: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -261,8 +265,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set((state) => ({
         buildings: state.buildings.map((b) => b.id === id ? { ...b, color: updated.color } : b),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to update building color: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to update building color: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -272,8 +276,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set((state) => ({
         buildings: state.buildings.filter((b) => b.id !== id),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to delete building: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to delete building: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -282,8 +286,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const data = await api.listBadges()
       set({ badges: data })
-    } catch (err: any) {
-      get().addToast(`Failed to load badges: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to load badges: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -291,8 +295,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const data = await api.listPlacedBadges()
       set({ placedBadges: data })
-    } catch (err: any) {
-      get().addToast(`Failed to load placed badges: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to load placed badges: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -301,8 +305,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       const badge = await api.uploadBadge(file, name)
       set((state) => ({ badges: [...state.badges, badge] }))
       return badge
-    } catch (err: any) {
-      get().addToast(`Failed to upload badge: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to upload badge: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -311,8 +315,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const updated = await api.renameBadge(id, name)
       set((state) => ({ badges: state.badges.map((b) => b.id === id ? updated : b) }))
-    } catch (err: any) {
-      get().addToast(`Failed to rename badge: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to rename badge: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -324,8 +328,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
         badges: state.badges.filter((b) => b.id !== id),
         placedBadges: state.placedBadges.filter((pb) => pb.badgeId !== id),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to delete badge: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to delete badge: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -335,8 +339,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       const placed = await api.placeBadge(params)
       set((state) => ({ placedBadges: [...state.placedBadges, placed] }))
       return placed
-    } catch (err: any) {
-      get().addToast(`Failed to place badge: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to place badge: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -347,8 +351,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set((state) => ({
         placedBadges: state.placedBadges.map((pb) => pb.id === id ? { ...pb, posX: updated.posX, posY: updated.posY } : pb),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to update badge position: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to update badge position: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -358,8 +362,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set((state) => ({
         placedBadges: state.placedBadges.map((pb) => pb.id === id ? { ...pb, scale: updated.scale } : pb),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to update badge scale: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to update badge scale: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -369,8 +373,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set((state) => ({
         placedBadges: state.placedBadges.map((pb) => pb.id === id ? { ...pb, label: updated.label } : pb),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to update badge label: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to update badge label: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -380,8 +384,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set((state) => ({
         placedBadges: state.placedBadges.filter((pb) => pb.id !== id),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to remove badge: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to remove badge: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -390,8 +394,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const data = await api.listTimers()
       set({ deadlineTimers: data })
-    } catch (err: any) {
-      get().addToast(`Failed to load timers: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to load timers: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -400,8 +404,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       const timer = await api.createTimer(params)
       set((state) => ({ deadlineTimers: [...state.deadlineTimers, timer].sort((a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime()) }))
       return timer
-    } catch (err: any) {
-      get().addToast(`Failed to create timer: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to create timer: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -414,8 +418,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
           .map((t) => t.id === id ? updated : t)
           .sort((a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime()),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to update timer: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to update timer: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -424,8 +428,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       await api.deleteTimer(id)
       set((state) => ({ deadlineTimers: state.deadlineTimers.filter((t) => t.id !== id) }))
-    } catch (err: any) {
-      get().addToast(`Failed to delete timer: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to delete timer: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -434,8 +438,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const data = await api.listContacts()
       set({ contacts: data })
-    } catch (err: any) {
-      get().addToast(`Failed to load contacts: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to load contacts: ${errMsg(err)}`, 'error')
     }
   },
 
@@ -444,8 +448,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       const contact = await api.createContact(params)
       set((state) => ({ contacts: [...state.contacts, contact].sort((a, b) => a.username.localeCompare(b.username)) }))
       return contact
-    } catch (err: any) {
-      get().addToast(`Failed to create contact: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to create contact: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -458,8 +462,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
           .map((c) => c.id === id ? updated : c)
           .sort((a, b) => a.username.localeCompare(b.username)),
       }))
-    } catch (err: any) {
-      get().addToast(`Failed to update contact: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to update contact: ${errMsg(err)}`, 'error')
       throw err
     }
   },
@@ -468,8 +472,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       await api.deleteContact(id)
       set((state) => ({ contacts: state.contacts.filter((c) => c.id !== id) }))
-    } catch (err: any) {
-      get().addToast(`Failed to delete contact: ${err.message}`, 'error')
+    } catch (err: unknown) {
+      get().addToast(`Failed to delete contact: ${errMsg(err)}`, 'error')
       throw err
     }
   },

--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -6565,3 +6565,224 @@ select.input {
   color: var(--crt-red);
 }
 
+/* ── Mailbox Inbox Dialog ───────────────────────────────────────────────────── */
+
+.mailbox-dialog {
+  width: 720px;
+  max-width: 95vw;
+}
+
+.mailbox-dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mailbox-header-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.mailbox-sm-btn {
+  font-size: 9px;
+}
+
+.mailbox-body {
+  display: flex;
+  height: 420px;
+  overflow: hidden;
+}
+
+.mailbox-list-panel {
+  width: 280px;
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+.mailbox-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.mailbox-tab-btn {
+  flex: 1;
+  font-size: 9px;
+  border-radius: 0;
+}
+
+.mailbox-unread-count {
+  color: #ff4444;
+}
+
+.mailbox-message-list {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.mailbox-list-status {
+  padding: 12px;
+  font-size: 10px;
+  color: var(--text-dim);
+  text-align: center;
+}
+
+.mailbox-message-row {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mailbox-message-row--selected {
+  background: var(--bg-hover);
+}
+
+.mailbox-row-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 4px;
+}
+
+.mailbox-sender {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.mailbox-sender--read {
+  font-weight: 400;
+  color: var(--text-dim);
+}
+
+.mailbox-date {
+  font-size: 9px;
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.mailbox-subject {
+  font-size: 10px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mailbox-subject--read {
+  color: var(--text-dim);
+}
+
+.mailbox-row-meta {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.mailbox-unread-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green-neon);
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.mailbox-icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 10px;
+  padding: 0;
+  color: var(--text-dim);
+  line-height: 1;
+}
+
+.mailbox-icon-btn--starred {
+  color: #ffaa00;
+}
+
+.mailbox-icon-btn--delete {
+  margin-left: auto;
+}
+
+.mailbox-detail-panel {
+  flex: 1;
+  padding: 14px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mailbox-compose-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--green-neon);
+}
+
+.mailbox-compose-input {
+  width: 100%;
+}
+
+.mailbox-compose-textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.mailbox-compose-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.mailbox-detail-subject {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+
+.mailbox-detail-meta {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-bottom: 2px;
+}
+
+.mailbox-detail-date {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-bottom: 10px;
+}
+
+.mailbox-detail-body {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+  font-size: 11px;
+  color: var(--text);
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+
+.mailbox-detail-empty {
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+.mailbox-detail-placeholder {
+  color: var(--text-dim);
+  font-size: 10px;
+  margin-top: 40px;
+  text-align: center;
+}
+

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -101,13 +101,6 @@ export interface ClaudeIssuePRInfo {
   body: string
 }
 
-export interface ClaudeIssuePRInfo {
-  head: string
-  base: string
-  title: string
-  body: string
-}
-
 export interface RepoData {
   fullName: string
   prs: GHPR[]


### PR DESCRIPTION
Fixes all 15 frontend bugs and inconsistencies identified in #349.

**Bug fixes:**
- `types.ts`: remove duplicate `ClaudeIssuePRInfo` interface
- `ClawComChatDialog`: `useMemo` for config parse; surface load/refresh errors
- `MailboxInboxDialog`: `useCallback` for loadMessages + correct deps; replace fragile setTimeout with await; confirm before delete; surface star errors; replace inline styles with CSS classes
- `store.ts`: add `errMsg()` helper; replace all 28 `catch (err: any)` with `err: unknown`
- `DeadlineTimers`: confirm before delete; consolidate N setIntervals into one parent interval
- `App.tsx`: rename "Repositories" nav label to "Settings"
- `Settings.tsx`: loading guards on Clear token buttons
- `FeedPanel.tsx`: `Promise.allSettled` to surface error when both feeds fail
- `BaseNode.tsx`: module-level image processing cache

Closes #349

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added confirmation prompt before deleting deadline timers
  * Added loading indicators when clearing authentication tokens

* **Bug Fixes**
  * Improved reliability when fetching mentions from multiple sources
  * Optimized image rendering performance for colorized elements

* **Improvements**
  * Enhanced error messages across chat and mailbox features
  * Refined mailbox inbox dialog styling and layout
  * Updated navigation label from "Repositories" to "Settings"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->