### PR TITLE
fix: Battlefield Tools & Panels on click show nothing

### DIFF
--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -458,7 +458,7 @@ export function BattlefieldView() {
         onScan={() => { play('peep'); onRefresh() }}
         onToggleRelocate={() => { play('hydraulic'); setIsRelocateMode(v => !v); setRelocatingId(null); setRelocatingStart(null) }}
         onShowBuildMenu={() => { play('hydraulic'); setShowBuildMenu(true) }}
-        onToggleBadgeLibrary={() => { play('peep'); setShowBadgeLibrary(true) }}
+        onToggleBadgeLibrary={() => { play('peep'); setShowBadgeLibrary(v => !v) }}
         onShowMapSelector={() => setShowMapSelector(true)}
         onClearMap={handleClearMap}
         onToggleFeed={() => { play('peep'); setShowFeedPanel(v => !v); setBranchSiloEntry(null); setDetailEntry(null); setSelectedBuildingId(null) }}

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldHUD.tsx
@@ -178,7 +178,7 @@ export function BattlefieldHUD({
               </button>
               <button
                 className={`hud-btn hud-dropdown-item${showBadgeLibrary ? ' active' : ''}`}
-                onClick={() => { onToggleBadgeLibrary() }}
+                onClick={() => { setShowToolsMenu(false); onToggleBadgeLibrary() }}
                 title="Badge Library — place custom markers on the battlefield"
                 aria-pressed={showBadgeLibrary}
               >
@@ -205,7 +205,7 @@ export function BattlefieldHUD({
             <div className="hud-dropdown-panel" onClick={(e) => e.stopPropagation()}>
               <button
                 className={`hud-btn hud-dropdown-item${showFeedPanel ? ' active' : ''}`}
-                onClick={onToggleFeed}
+                onClick={() => { setShowPanelsMenu(false); onToggleFeed() }}
                 title="Toggle Intel Feed"
                 aria-pressed={showFeedPanel}
               >
@@ -213,7 +213,7 @@ export function BattlefieldHUD({
               </button>
               <button
                 className={`hud-btn hud-dropdown-item${showTimers ? ' active' : ''}`}
-                onClick={onToggleTimers}
+                onClick={() => { setShowPanelsMenu(false); onToggleTimers() }}
                 title="Mission Timers — Deadline countdown"
                 aria-pressed={showTimers}
               >
@@ -221,7 +221,7 @@ export function BattlefieldHUD({
               </button>
               <button
                 className={`hud-btn hud-dropdown-item${showMinimap ? ' active' : ''}`}
-                onClick={onToggleMinimap}
+                onClick={() => { setShowPanelsMenu(false); onToggleMinimap() }}
                 title={showMinimap ? 'Hide minimap' : 'Show minimap'}
                 aria-pressed={showMinimap}
               >
@@ -229,7 +229,7 @@ export function BattlefieldHUD({
               </button>
               <button
                 className={`hud-btn hud-dropdown-item${showShortcuts ? ' active' : ''}`}
-                onClick={onToggleShortcuts}
+                onClick={() => { setShowPanelsMenu(false); onToggleShortcuts() }}
                 title="Keyboard Shortcuts [?]"
                 aria-pressed={showShortcuts}
               >


### PR DESCRIPTION
Fix Battlefield HUD TOOLS and PANELS dropdowns not closing when an item is clicked, which caused the toggled panel to appear behind the open dropdown making it seem like nothing happened.

Also fixes onToggleBadgeLibrary to properly toggle instead of always setting to true.

Closes #363

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Badge library toggle now correctly opens and closes the interface instead of remaining persistently open, allowing users to hide the library as intended.
  * Dropdown menus and UI panels now automatically close opposing menu states before opening, preventing menu overlap and providing clearer, more intuitive navigation behavior throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->