### PR TITLE
fix: prevent snailbox mail reload on battlefield pan/zoom

### DIFF
--- a/gh-ctrl/client/src/components/BattlefieldView.tsx
+++ b/gh-ctrl/client/src/components/BattlefieldView.tsx
@@ -141,6 +141,16 @@ export function BattlefieldView() {
     setShowCommandPalette(v => !v)
   }, [play])
 
+  const handleSelectBuilding = useCallback((id: number) => {
+    setSelectedBuildingId(prev => prev === id ? null : id)
+    setDetailEntry(null)
+    setBranchSiloEntry(null)
+  }, [])
+
+  const handleDeselectBuilding = useCallback(() => {
+    setSelectedBuildingId(null)
+  }, [])
+
   const keyboardShortcuts = useBattlefieldKeyboardShortcuts({
     entries,
     buildings: storeBuildings,
@@ -503,8 +513,8 @@ export function BattlefieldView() {
         onZoomToBase={handleZoomToBase}
         onBaseDetailOpen={(e) => { setDetailEntry(prev => prev?.repo.id === e.repo.id ? null : e); setBranchSiloEntry(null); setSelectedBuildingId(null) }}
         onStartBuildingRelocate={handleStartBuildingRelocate}
-        onSelectBuilding={(id) => { setSelectedBuildingId(prev => prev === id ? null : id); setDetailEntry(null); setBranchSiloEntry(null) }}
-        onDeselectBuilding={() => setSelectedBuildingId(null)}
+        onSelectBuilding={handleSelectBuilding}
+        onDeselectBuilding={handleDeselectBuilding}
         onStartBadgeRelocate={handleStartBadgeRelocate}
       />
 

--- a/gh-ctrl/client/src/components/MailboxBuilding.tsx
+++ b/gh-ctrl/client/src/components/MailboxBuilding.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, memo } from 'react'
 import { createPortal } from 'react-dom'
 import { api } from '../api'
 import { useAppStore } from '../store'
@@ -62,7 +62,7 @@ function useColorizedImage(src: string, color: string): string | null {
   return dataUrl
 }
 
-export function MailboxBuilding({
+export const MailboxBuilding = memo(function MailboxBuilding({
   building,
   position,
   isRelocateMode,
@@ -304,4 +304,4 @@ export function MailboxBuilding({
       )}
     </>
   )
-}
+})

--- a/gh-ctrl/client/src/components/MailboxInboxDialog.tsx
+++ b/gh-ctrl/client/src/components/MailboxInboxDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../api'
 import type { Building, MailMessage } from '../types'
 
@@ -46,17 +46,22 @@ export function MailboxInboxDialog({ building, onClose, onReconfigure, onError }
   const [compose, setCompose]             = useState<ComposeState>({ to: '', subject: '', body: '' })
   const [sending, setSending]             = useState(false)
 
+  // Use a ref so that onError identity changes (from parent re-renders) don't
+  // cause loadMessages to be recreated and trigger a spurious mail reload.
+  const onErrorRef = useRef(onError)
+  useEffect(() => { onErrorRef.current = onError })
+
   const loadMessages = useCallback(async () => {
     setLoading(true)
     try {
       const msgs = await api.getMailMessages(building.id)
       setMessages(msgs)
     } catch (err: unknown) {
-      onError(`Error loading: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      onErrorRef.current(`Error loading: ${err instanceof Error ? err.message : 'Unknown error'}`)
     } finally {
       setLoading(false)
     }
-  }, [building.id, onError])
+  }, [building.id])
 
   useEffect(() => {
     loadMessages()

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldMapLayer.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldMapLayer.tsx
@@ -1,3 +1,4 @@
+import { memo, useCallback } from 'react'
 import { useAppStore, selectBattlefieldUsers } from '../../store'
 import type { SoundName } from '../../hooks/useSound'
 import type { DashboardEntry, GameMap, Building, PlacedBadge } from '../../types'
@@ -16,6 +17,60 @@ import { BadgeMarker } from '../BadgeMarker'
 import { UserUnit } from './UserUnit'
 import { SourceRelayConnectionsLayer } from './SourceRelayConnectionsLayer'
 import type { Repo } from '../../types'
+
+interface BuildingRendererProps {
+  building: Building
+  position: { x: number; y: number }
+  isRelocateMode: boolean
+  isBeingRelocated: boolean
+  isSelected: boolean
+  addToast: (msg: string, type?: 'success' | 'error' | 'info') => void
+  play: (sound: SoundName) => void
+  onSelectBuilding: (id: number) => void
+  onDeselectBuilding: () => void
+  onStartBuildingRelocate: (id: number, mouseX: number, mouseY: number) => void
+}
+
+const BuildingRenderer = memo(function BuildingRenderer({
+  building,
+  position,
+  isRelocateMode,
+  isBeingRelocated,
+  isSelected,
+  addToast,
+  play,
+  onSelectBuilding,
+  onDeselectBuilding,
+  onStartBuildingRelocate,
+}: BuildingRendererProps) {
+  const handleSelect = useCallback(() => {
+    play('peep')
+    onSelectBuilding(building.id)
+  }, [play, onSelectBuilding, building.id])
+
+  const handleStartRelocate = useCallback((mouseX: number, mouseY: number) => {
+    onStartBuildingRelocate(building.id, mouseX, mouseY)
+  }, [onStartBuildingRelocate, building.id])
+
+  const commonProps = {
+    building,
+    position,
+    isRelocateMode,
+    isBeingRelocated,
+    addToast,
+    isSelected,
+    onSelect: handleSelect,
+    onDeselect: onDeselectBuilding,
+    onStartRelocate: handleStartRelocate,
+  }
+
+  if (building.type === 'healthcheck') return <HealthcheckBuilding {...commonProps} />
+  if (building.type === 'snailbox') return <MailboxBuilding {...commonProps} />
+  if (building.type === 'research') return <ResearchCenterBuilding {...commonProps} />
+  if (building.type === 'remoteShell') return <RemoteShellBuilding {...commonProps} />
+  if (building.type === 'sourceRelay') return <SourceRelayBuilding {...commonProps} />
+  return <ClawComBuilding {...commonProps} />
+})
 
 interface BattlefieldMapLayerProps {
   offset: Position
@@ -203,34 +258,21 @@ export function BattlefieldMapLayer({
             </div>
           )
         }
-        const commonProps = {
-          key: `building-${building.id}`,
-          building,
-          position: pos,
-          isRelocateMode,
-          isBeingRelocated: relocatingBuildingId === building.id,
-          onStartRelocate: (mouseX: number, mouseY: number) => onStartBuildingRelocate(building.id, mouseX, mouseY),
-          addToast,
-          isSelected: selectedBuildingId === building.id,
-          onSelect: () => { play('peep'); onSelectBuilding(building.id) },
-          onDeselect: onDeselectBuilding,
-        }
-        if (building.type === 'healthcheck') {
-          return <HealthcheckBuilding {...commonProps} />
-        }
-        if (building.type === 'snailbox') {
-          return <MailboxBuilding {...commonProps} />
-        }
-        if (building.type === 'research') {
-          return <ResearchCenterBuilding {...commonProps} />
-        }
-        if (building.type === 'remoteShell') {
-          return <RemoteShellBuilding {...commonProps} />
-        }
-        if (building.type === 'sourceRelay') {
-          return <SourceRelayBuilding {...commonProps} />
-        }
-        return <ClawComBuilding {...commonProps} />
+        return (
+          <BuildingRenderer
+            key={`building-${building.id}`}
+            building={building}
+            position={pos}
+            isRelocateMode={isRelocateMode}
+            isBeingRelocated={relocatingBuildingId === building.id}
+            isSelected={selectedBuildingId === building.id}
+            addToast={addToast}
+            play={play}
+            onSelectBuilding={onSelectBuilding}
+            onDeselectBuilding={onDeselectBuilding}
+            onStartBuildingRelocate={onStartBuildingRelocate}
+          />
+        )
       })}
 
       {placedBadges.map((pb) => {

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldMapLayer.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldMapLayer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { useAppStore, selectBattlefieldUsers } from '../../store'
 import type { SoundName } from '../../hooks/useSound'
 import type { DashboardEntry, GameMap, Building, PlacedBadge } from '../../types'
@@ -20,7 +20,8 @@ import type { Repo } from '../../types'
 
 interface BuildingRendererProps {
   building: Building
-  position: { x: number; y: number }
+  positionX: number
+  positionY: number
   isRelocateMode: boolean
   isBeingRelocated: boolean
   isSelected: boolean
@@ -33,7 +34,8 @@ interface BuildingRendererProps {
 
 const BuildingRenderer = memo(function BuildingRenderer({
   building,
-  position,
+  positionX,
+  positionY,
   isRelocateMode,
   isBeingRelocated,
   isSelected,
@@ -43,6 +45,8 @@ const BuildingRenderer = memo(function BuildingRenderer({
   onDeselectBuilding,
   onStartBuildingRelocate,
 }: BuildingRendererProps) {
+  const position = useMemo(() => ({ x: positionX, y: positionY }), [positionX, positionY])
+
   const handleSelect = useCallback(() => {
     play('peep')
     onSelectBuilding(building.id)
@@ -262,7 +266,8 @@ export function BattlefieldMapLayer({
           <BuildingRenderer
             key={`building-${building.id}`}
             building={building}
-            position={pos}
+            positionX={pos.x}
+            positionY={pos.y}
             isRelocateMode={isRelocateMode}
             isBeingRelocated={relocatingBuildingId === building.id}
             isSelected={selectedBuildingId === building.id}


### PR DESCRIPTION
Fixes #370

The mail inbox was re-fetching messages on every mouse move during battlefield panning due to an unstable callback chain:

- `MailboxInboxDialog`: use a ref for `onError` so `loadMessages` no longer depends on its identity
- `BattlefieldView`: memoize `onSelectBuilding`/`onDeselectBuilding` with `useCallback`
- `MailboxBuilding`: wrap with `React.memo` to skip re-renders when props haven't changed

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved battlefield rendering and interactions: selecting a building now toggles selection, deselect clears detail/branch views, and relocation start is more consistent (includes feedback).
  * Mailbox improvements: mailbox components memoized and inbox loading stabilized to avoid unnecessary message reloads during parent re-renders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->