### PR TITLE
fix(mobile): add missing panels to touch exclusion list

### DIFF
--- a/gh-ctrl/client/src/hooks/useBattlefieldCamera.ts
+++ b/gh-ctrl/client/src/hooks/useBattlefieldCamera.ts
@@ -65,7 +65,7 @@ export function useBattlefieldCamera(options?: BattlefieldCameraOptions) {
 
   const handleTouchStart = useCallback((e: TouchEvent) => {
     const target = e.target as HTMLElement
-    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .battlefield-placement-banner, .battlefield-relocate-banner, .hud-overflow-panel, .mph-cancel, .battlefield-context-backdrop, .battlefield-landscape-overlay')) return
+    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .battlefield-placement-banner, .battlefield-relocate-banner, .hud-overflow-panel, .mph-cancel, .battlefield-context-backdrop, .battlefield-landscape-overlay, .cnc-sidebar, .dt-panel, .base-detail-side-panel')) return
     e.preventDefault()
 
     const tc = touchMetaRef.current
@@ -100,7 +100,7 @@ export function useBattlefieldCamera(options?: BattlefieldCameraOptions) {
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
     const target = e.target as HTMLElement
-    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .mph-cancel, .battlefield-context-backdrop, .battlefield-landscape-overlay')) return
+    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .mph-cancel, .battlefield-context-backdrop, .battlefield-landscape-overlay, .cnc-sidebar, .dt-panel, .base-detail-side-panel')) return
     e.preventDefault()
 
     const tc = touchMetaRef.current


### PR DESCRIPTION
Fixes #373

The battlefield camera hook calls `e.preventDefault()` on `touchstart`/`touchmove` to prevent map panning, suppressing synthetic click events in the process. Panels not in the exclusion list had their onClick handlers silenced on mobile.

Adds `.cnc-sidebar` (BuildOptionsMenu), `.dt-panel` (DeadlineTimers), and `.base-detail-side-panel` to both `handleTouchStart` and `handleTouchMove` exclusion lists.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unintended camera interactions when touching UI panels. Camera controls no longer activate when interacting with sidebar or detail panel areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->