### PR TITLE
fix(mobile): restore close-button tap for all SidePanel-based panels

### DIFF
--- a/gh-ctrl/client/src/components/SidePanel.tsx
+++ b/gh-ctrl/client/src/components/SidePanel.tsx
@@ -32,7 +32,7 @@ export function SidePanel({ onClose, className, children }: SidePanelProps) {
   return (
     <div
       ref={panelRef}
-      className={className}
+      className={['side-panel-root', className].filter(Boolean).join(' ')}
       onClick={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
       onTouchStart={(e) => e.stopPropagation()}

--- a/gh-ctrl/client/src/hooks/useBattlefieldCamera.ts
+++ b/gh-ctrl/client/src/hooks/useBattlefieldCamera.ts
@@ -65,7 +65,7 @@ export function useBattlefieldCamera(options?: BattlefieldCameraOptions) {
 
   const handleTouchStart = useCallback((e: TouchEvent) => {
     const target = e.target as HTMLElement
-    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .battlefield-placement-banner, .battlefield-relocate-banner, .hud-overflow-panel, .mph-cancel, .battlefield-context-backdrop, .battlefield-landscape-overlay')) return
+    if (target.closest('.modal-overlay, .map-dialog-overlay, .side-panel-root, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .battlefield-placement-banner, .battlefield-relocate-banner, .hud-overflow-panel, .mph-cancel, .battlefield-context-backdrop, .battlefield-landscape-overlay')) return
     e.preventDefault()
 
     const tc = touchMetaRef.current
@@ -100,7 +100,7 @@ export function useBattlefieldCamera(options?: BattlefieldCameraOptions) {
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
     const target = e.target as HTMLElement
-    if (target.closest('.modal-overlay, .map-dialog-overlay, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .mph-cancel, .battlefield-context-backdrop, .battlefield-landscape-overlay')) return
+    if (target.closest('.modal-overlay, .map-dialog-overlay, .side-panel-root, .silo-panel, .feed-panel, [class*="dialog"], .battlefield-hud, .minimap, .battlefield-context-menu, .mph-cancel, .battlefield-context-backdrop, .battlefield-landscape-overlay')) return
     e.preventDefault()
 
     const tc = touchMetaRef.current


### PR DESCRIPTION
Fixes #374

## Problem

On mobile, tapping the close button in Mission Timers (and other side panels) did nothing. The battlefield camera hook attaches native touch listeners directly to the `battlefield-container` DOM element and calls `e.preventDefault()` on `touchstart` unless the target matches an exemption selector. Calling `e.preventDefault()` on `touchstart` suppresses the browser-synthesised click event, so `onClick={onClose}` never fires.

`.feed-panel` and `.silo-panel` worked because they were already in the list. `.dt-panel`, `.cnc-sidebar`, and `.base-detail-side-panel` were absent.

## Fix

- `SidePanel.tsx`: always prepend `side-panel-root` to the rendered div’s `className` (no CSS rules added, pure marker class).
- `useBattlefieldCamera.ts`: add `.side-panel-root` to both `handleTouchStart` and `handleTouchMove` exemption selectors. All current and future `SidePanel` instances are automatically covered.

Generated with [Claude Code](https://claude.ai/code)