### PR TITLE
fix: [Mobile] Build panel PLACE button no longer clipped on mobile

### DIFF
--- a/gh-ctrl/client/src/styles.css
+++ b/gh-ctrl/client/src/styles.css
@@ -3187,17 +3187,25 @@ select.input {
 
 @media (max-width: 480px) {
   .cnc-sidebar {
-    width: 160px;
+    width: 100vw;
+    left: 0;
   }
 
   .cnc-preview {
-    min-height: 100px;
+    min-height: 0;
+    max-height: 40vh;
+    overflow-y: auto;
+    flex-shrink: 1;
     padding: 8px;
   }
 
   .cnc-preview-img {
     width: 52px;
     height: 52px;
+  }
+
+  .cnc-grid {
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 
@@ -6417,6 +6425,18 @@ select.input {
   .hud-btn {
     min-height: 36px;
     min-width: 36px;
+  }
+
+  /* Build panel: wider and with scrollable preview to prevent footer clipping */
+  .cnc-sidebar {
+    width: 240px;
+  }
+
+  .cnc-preview {
+    min-height: 0;
+    max-height: 35vh;
+    overflow-y: auto;
+    flex-shrink: 1;
   }
 }
 


### PR DESCRIPTION
Fixes #372

**Root cause:** The `.cnc-preview` flex child had `flex-shrink: 0` and no height cap. When a building was selected, its description + form fields expanded the preview area beyond the panel's height on mobile, pushing the footer (PLACE/CREATE button) below the `overflow: hidden` boundary and making it unreachable.

**Changes in `styles.css`:**
- `≤480px`: Panel made full-width (`100vw`), preview capped at `40vh` with `overflow-y: auto` and `flex-shrink: 1`, 4-column building grid
- `481–768px` (landscape mobile): Panel widened to `240px`, preview capped at `35vh` with scroll so the footer always stays visible

Generated with [Claude Code](https://claude.ai/code)