### PR TITLE
feat: Hide tracked repositories from Add Repository list

### DIFF
--- a/gh-ctrl/client/src/components/Settings.tsx
+++ b/gh-ctrl/client/src/components/Settings.tsx
@@ -743,30 +743,46 @@ export function Settings() {
                   <div className="browse-truncated-note">Showing top 100 matches — refine your search for more specific results.</div>
                 )}
                 <div className="browse-repo-list">
-                  {browseRepos.map((repo) => (
-                    <button
-                      key={repo.fullName}
-                      className="browse-repo-item"
-                      onClick={() => handleSelectBrowseRepo(repo.fullName)}
-                      type="button"
-                      disabled={adding}
-                    >
-                      <div className="browse-repo-info">
-                        <span className="browse-repo-name">{repo.fullName}</span>
-                        {repo.isPrivate && <span className="browse-repo-badge">private</span>}
-                        {repo.description && (
-                          <span className="browse-repo-desc">{repo.description}</span>
-                        )}
-                      </div>
-                      <span className="browse-repo-add">+ Add</span>
-                    </button>
-                  ))}
+                  {browseRepos
+                    .filter((repo) => {
+                      const currentProviderType = browseProvider === 'github' ? 'github' : 'gitlab'
+                      return !repos.some(
+                        (tracked) => tracked.fullName === repo.fullName && tracked.provider === currentProviderType
+                      )
+                    })
+                    .map((repo) => (
+                      <button
+                        key={repo.fullName}
+                        className="browse-repo-item"
+                        onClick={() => handleSelectBrowseRepo(repo.fullName)}
+                        type="button"
+                        disabled={adding}
+                      >
+                        <div className="browse-repo-info">
+                          <span className="browse-repo-name">{repo.fullName}</span>
+                          {repo.isPrivate && <span className="browse-repo-badge">private</span>}
+                          {repo.description && (
+                            <span className="browse-repo-desc">{repo.description}</span>
+                          )}
+                        </div>
+                        <span className="browse-repo-add">+ Add</span>
+                      </button>
+                    ))}
                   {browseLoading && (
                     <div className="browse-loading">Loading...</div>
                   )}
                   {!browseLoading && browseRepos.length === 0 && !browseError && (
                     <div className="empty-state"><p>No repositories found.</p></div>
                   )}
+                  {!browseLoading && browseRepos.length > 0 && !browseError && (() => {
+                    const currentProviderType = browseProvider === 'github' ? 'github' : 'gitlab'
+                    const visibleCount = browseRepos.filter(
+                      (repo) => !repos.some((tracked) => tracked.fullName === repo.fullName && tracked.provider === currentProviderType)
+                    ).length
+                    return visibleCount === 0 ? (
+                      <div className="empty-state"><p>All repositories are already tracked.</p></div>
+                    ) : null
+                  })()}
                 </div>
                 {!browseLoading && browseHasMore && browseRepos.length > 0 && !browseSearch && (
                   <div className="browse-load-more">

--- a/gh-ctrl/client/src/components/Settings.tsx
+++ b/gh-ctrl/client/src/components/Settings.tsx
@@ -746,8 +746,10 @@ export function Settings() {
                   {browseRepos
                     .filter((repo) => {
                       const currentProviderType = browseProvider === 'github' ? 'github' : 'gitlab'
+                      const currentInstance = browseProvider === 'github' ? null : (browseProvider === 'gitlab.com' ? null : `https://${browseProvider}`)
                       return !repos.some(
-                        (tracked) => tracked.fullName === repo.fullName && tracked.provider === currentProviderType
+                        (tracked) => tracked.fullName === repo.fullName && tracked.provider === currentProviderType &&
+                          (currentProviderType !== 'gitlab' || (tracked.instanceUrl ?? null) === currentInstance)
                       )
                     })
                     .map((repo) => (
@@ -776,8 +778,10 @@ export function Settings() {
                   )}
                   {!browseLoading && browseRepos.length > 0 && !browseError && (() => {
                     const currentProviderType = browseProvider === 'github' ? 'github' : 'gitlab'
+                    const currentInstance = browseProvider === 'github' ? null : (browseProvider === 'gitlab.com' ? null : `https://${browseProvider}`)
                     const visibleCount = browseRepos.filter(
-                      (repo) => !repos.some((tracked) => tracked.fullName === repo.fullName && tracked.provider === currentProviderType)
+                      (repo) => !repos.some((tracked) => tracked.fullName === repo.fullName && tracked.provider === currentProviderType &&
+                        (currentProviderType !== 'gitlab' || (tracked.instanceUrl ?? null) === currentInstance))
                     ).length
                     return visibleCount === 0 ? (
                       <div className="empty-state"><p>All repositories are already tracked.</p></div>

--- a/gh-ctrl/client/src/components/Settings.tsx
+++ b/gh-ctrl/client/src/components/Settings.tsx
@@ -742,52 +742,47 @@ export function Settings() {
                 {!browseLoading && browseSearch && browseTruncated && (
                   <div className="browse-truncated-note">Showing top 100 matches — refine your search for more specific results.</div>
                 )}
-                <div className="browse-repo-list">
-                  {browseRepos
-                    .filter((repo) => {
-                      const currentProviderType = browseProvider === 'github' ? 'github' : 'gitlab'
-                      const currentInstance = browseProvider === 'github' ? null : (browseProvider === 'gitlab.com' ? null : `https://${browseProvider}`)
-                      return !repos.some(
-                        (tracked) => tracked.fullName === repo.fullName && tracked.provider === currentProviderType &&
-                          (currentProviderType !== 'gitlab' || (tracked.instanceUrl ?? null) === currentInstance)
-                      )
-                    })
-                    .map((repo) => (
-                      <button
-                        key={repo.fullName}
-                        className="browse-repo-item"
-                        onClick={() => handleSelectBrowseRepo(repo.fullName)}
-                        type="button"
-                        disabled={adding}
-                      >
-                        <div className="browse-repo-info">
-                          <span className="browse-repo-name">{repo.fullName}</span>
-                          {repo.isPrivate && <span className="browse-repo-badge">private</span>}
-                          {repo.description && (
-                            <span className="browse-repo-desc">{repo.description}</span>
-                          )}
-                        </div>
-                        <span className="browse-repo-add">+ Add</span>
-                      </button>
-                    ))}
-                  {browseLoading && (
-                    <div className="browse-loading">Loading...</div>
-                  )}
-                  {!browseLoading && browseRepos.length === 0 && !browseError && (
-                    <div className="empty-state"><p>No repositories found.</p></div>
-                  )}
-                  {!browseLoading && browseRepos.length > 0 && !browseError && (() => {
-                    const currentProviderType = browseProvider === 'github' ? 'github' : 'gitlab'
-                    const currentInstance = browseProvider === 'github' ? null : (browseProvider === 'gitlab.com' ? null : `https://${browseProvider}`)
-                    const visibleCount = browseRepos.filter(
-                      (repo) => !repos.some((tracked) => tracked.fullName === repo.fullName && tracked.provider === currentProviderType &&
-                        (currentProviderType !== 'gitlab' || (tracked.instanceUrl ?? null) === currentInstance))
-                    ).length
-                    return visibleCount === 0 ? (
-                      <div className="empty-state"><p>All repositories are already tracked.</p></div>
-                    ) : null
-                  })()}
-                </div>
+                {(() => {
+                  const currentProviderType: Repo['provider'] = browseProvider === 'github' ? 'github' : 'gitlab'
+                  const currentInstance = browseProvider === 'github' ? null : (browseProvider === 'gitlab.com' ? null : `https://${browseProvider}`)
+                  const visibleBrowseRepos = browseRepos.filter(
+                    (repo) => !repos.some(
+                      (tracked) => tracked.fullName === repo.fullName && tracked.provider === currentProviderType &&
+                        (currentProviderType !== 'gitlab' || (tracked.instanceUrl ?? null) === currentInstance)
+                    )
+                  )
+                  return (
+                    <div className="browse-repo-list">
+                      {visibleBrowseRepos.map((repo) => (
+                        <button
+                          key={repo.fullName}
+                          className="browse-repo-item"
+                          onClick={() => handleSelectBrowseRepo(repo.fullName)}
+                          type="button"
+                          disabled={adding}
+                        >
+                          <div className="browse-repo-info">
+                            <span className="browse-repo-name">{repo.fullName}</span>
+                            {repo.isPrivate && <span className="browse-repo-badge">private</span>}
+                            {repo.description && (
+                              <span className="browse-repo-desc">{repo.description}</span>
+                            )}
+                          </div>
+                          <span className="browse-repo-add">+ Add</span>
+                        </button>
+                      ))}
+                      {browseLoading && (
+                        <div className="browse-loading">Loading...</div>
+                      )}
+                      {!browseLoading && browseRepos.length === 0 && !browseError && (
+                        <div className="empty-state"><p>No repositories found.</p></div>
+                      )}
+                      {!browseLoading && browseRepos.length > 0 && !browseError && visibleBrowseRepos.length === 0 && (
+                        <div className="empty-state"><p>All repositories are already tracked.</p></div>
+                      )}
+                    </div>
+                  )
+                })()}
                 {!browseLoading && browseHasMore && browseRepos.length > 0 && !browseSearch && (
                   <div className="browse-load-more">
                     <button className="btn btn-ghost" onClick={handleLoadMore} type="button">


### PR DESCRIPTION
Filter the browse repository list in Settings to exclude repos that are already tracked, matching on both `fullName` and `provider`. Shows a clear "All repositories are already tracked." message when all results are filtered out.

Closes #384

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Browse my repos" list now hides repositories already tracked for the selected provider, making it easier to find untracked projects.
  * When filtering removes all visible repos, the UI shows a clear empty-state message: "All repositories are already tracked."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->