### PR TITLE
suppress(fallow): ignore unused-file false positive for extension/background.js

### DIFF
--- a/gh-ctrl/extension/background.js
+++ b/gh-ctrl/extension/background.js
@@ -1,3 +1,4 @@
+// fallow-ignore-file unused-file
 chrome.action.onClicked.addListener((tab) => {
   chrome.sidePanel.open({ windowId: tab.windowId });
 });


### PR DESCRIPTION
Adds a `// fallow-ignore-file unused-file` comment to `background.js` to suppress the false positive from fallow static analysis.

The file is registered as a Manifest V3 service worker in `manifest.json` under `background.service_worker`, which fallow does not parse as an entry point.

Closes #390

Generated with [Claude Code](https://claude.ai/code)