### PR TITLE
suppress fallow unused-file false positive on MCP server

### DIFF
--- a/gh-ctrl/src/mcp/claude-channel-server.ts
+++ b/gh-ctrl/src/mcp/claude-channel-server.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// fallow-ignore-file unused-file
 /**
  * Claude Channel Server for ClawCom
  *


### PR DESCRIPTION
Adds `// fallow-ignore-file unused-file` to `gh-ctrl/src/mcp/claude-channel-server.ts`.

The file is a standalone MCP server registered in `mcp.example.json` and invoked by Claude Code over stdio — not importable by static analysis. The fallow warning is a false positive.

Closes #392

Generated with [Claude Code](https://claude.ai/code)