### PR TITLE
fix: remove export from 4 unused exported types

### DIFF
--- a/gh-ctrl/client/src/components/battlefield/CommandPalette.tsx
+++ b/gh-ctrl/client/src/components/battlefield/CommandPalette.tsx
@@ -8,7 +8,7 @@ import type { Position } from './battlefieldConstants'
 
 export type CommandCategory = 'BASE' | 'BUILDING' | 'ACTION' | 'NAV' | 'CREATE'
 
-export interface PaletteCommand {
+interface PaletteCommand {
   id: string
   category: CommandCategory
   label: string

--- a/gh-ctrl/client/src/store.ts
+++ b/gh-ctrl/client/src/store.ts
@@ -39,7 +39,7 @@ export function selectBattlefieldUsers(entries: DashboardEntry[]): BattlefieldUs
 
 type ToastType = 'success' | 'error' | 'info'
 
-export interface Toast {
+interface Toast {
   id: number
   message: string
   type: ToastType

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -436,13 +436,13 @@ export interface SshSessionLog {
 
 export type ShellStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error'
 
-export interface SourceRelayConfig {
+interface SourceRelayConfig {
   configured: boolean
 }
 
 export type SourceRelayConnectorType = 'git' | 'private_git' | 'website'
 
-export interface SourceRelayConnectorConfig {
+interface SourceRelayConnectorConfig {
   url: string
   branch?: string
   token?: string | true // true = token exists but is redacted by API


### PR DESCRIPTION
Removes the `export` keyword from four types that are not imported outside their declaring file:

- `PaletteCommand` in `CommandPalette.tsx`
- `Toast` in `store.ts`
- `SourceRelayConfig` in `types.ts`
- `SourceRelayConnectorConfig` in `types.ts`

All declarations are kept in place; only the `export` keyword is dropped.

Fixes #394

Generated with [Claude Code](https://claude.ai/code)