### PR TITLE
fix: remove unused route import from gitlab provider (breaks circular dep)

### DIFF
--- a/gh-ctrl/src/providers/gitlab.ts
+++ b/gh-ctrl/src/providers/gitlab.ts
@@ -16,7 +16,6 @@ import type {
 import {db} from "../db";
 import {repos} from "../db/schema";
 import {eq} from "drizzle-orm";
-import app from "../routes/gitlab";
 
 const CLAUDE_LABELS = ['claude', 'ai', 'ai-fix', 'ai-feature']
 


### PR DESCRIPTION
Fixes #395

Removes the dead `import app from "../routes/gitlab"` from `providers/gitlab.ts`. `app` was never used in the provider, so the import was pure dead code that created a circular dependency caught by fallow static analysis.

Generated with [Claude Code](https://claude.ai/code)