### PR TITLE
chore(extension): suppress fallow unused-file for manifest entry points

### DIFF
--- a/gh-ctrl/extension/background.js
+++ b/gh-ctrl/extension/background.js
@@ -1,3 +1,4 @@
+// fallow-ignore-file unused-file
 chrome.action.onClicked.addListener((tab) => {
   chrome.sidePanel.open({ windowId: tab.windowId });
 });

--- a/gh-ctrl/extension/sidepanel.js
+++ b/gh-ctrl/extension/sidepanel.js
@@ -1,3 +1,4 @@
+// fallow-ignore-file unused-file
 const frame = document.getElementById("app-frame");
 const offline = document.getElementById("offline");
 


### PR DESCRIPTION
Add `// fallow-ignore-file unused-file` to `sidepanel.js` and `background.js`.

Both files are manifest-referenced extension entry points invisible to TS/JS entry-point analysis — confirmed false positives. The inline suppression is self-documenting and clears both fallow findings in one change.

Closes #391

Generated with [Claude Code](https://claude.ai/code)