### PR TITLE
fix: disable battlefield shortcuts while SSH terminal is open

### DIFF
--- a/gh-ctrl/client/src/components/RemoteShellTerminalDialog.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellTerminalDialog.tsx
@@ -77,6 +77,7 @@ export function RemoteShellTerminalDialog({
 
   return (
     <div
+      data-remote-shell-terminal="true"
       style={{
         position: 'fixed', inset: 0, zIndex: 1100,
         display: 'flex', flexDirection: 'column',

--- a/gh-ctrl/client/src/hooks/useBattlefieldKeyboardShortcuts.ts
+++ b/gh-ctrl/client/src/hooks/useBattlefieldKeyboardShortcuts.ts
@@ -126,6 +126,8 @@ export function useBattlefieldKeyboardShortcuts({
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable || target.getAttribute?.('contenteditable') === 'true') return
       // Don't fire if a modal/dialog is open
       if (target.closest?.('.modal-overlay, .map-dialog-overlay, [class*="dialog"], [class*="overlay"]')) return
+      // Don't fire if the SSH terminal dialog is open — all keystrokes belong to xterm
+      if (document.querySelector('[data-remote-shell-terminal]')) return
 
       // Handle assignment mode
       if (assigningFor) {


### PR DESCRIPTION
Fixes #407

Number keys were being intercepted by the global battlefield keyboard shortcut handler even when the SSH terminal dialog was active, preventing xterm.js from receiving keystrokes.

Added a `data-remote-shell-terminal` attribute to the dialog's root div and a corresponding guard in the keyboard shortcut hook to bail out when the terminal is open.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed keyboard shortcuts from triggering while the remote shell terminal is active. Keyboard shortcuts and custom actions are now properly suppressed during SSH terminal sessions, enabling seamless terminal interaction without background interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->