### PR TITLE
feat: add tmux window panel to RemoteShell/ClawCom terminal

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData, SetupStatus, Building, ClawComMessage, Badge, PlacedBadge, HealthcheckResult, DeadlineTimer, ChannelEvent, MailMessage, ResearchJob, Contact, SshConnection, SshSessionLog, SourceRelayConnector, SourceRelayFetcher, SourceRelayGitFile } from './types'
+import type { Repo, DashboardEntry, RepoData, GHLabel, BranchesData, IssueDetail, PRDetail, GameMap, RepoMeta, FeedData, SetupStatus, Building, ClawComMessage, Badge, PlacedBadge, HealthcheckResult, DeadlineTimer, ChannelEvent, MailMessage, ResearchJob, Contact, SshConnection, SshSessionLog, TmuxWindow, SourceRelayConnector, SourceRelayFetcher, SourceRelayGitFile } from './types'
 
 export function getServerUrl(): string {
   return localStorage.getItem('serverUrl')?.replace(/\/$/, '') ?? ''
@@ -687,6 +687,11 @@ export const api = {
   getShellTmuxSessions: (buildingId: number, connectionId: number) =>
     request<{ ok: boolean; sessions: string[]; error?: string }>(
       `/buildings/${buildingId}/shell/connections/${connectionId}/tmux-sessions`
+    ),
+
+  getShellTmuxWindows: (buildingId: number, connectionId: number, session?: string) =>
+    request<{ ok: boolean; windows: TmuxWindow[]; error?: string }>(
+      `/buildings/${buildingId}/shell/connections/${connectionId}/tmux-windows${session ? `?session=${encodeURIComponent(session)}` : ''}`
     ),
 
   // ── Source Relay ──────────────────────────────────────────────────────────

--- a/gh-ctrl/client/src/components/RemoteShellTerminalTab.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellTerminalTab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { getShellWsUrl } from '../api'
-import type { SshConnection, ShellStatus } from '../types'
+import { getShellWsUrl, api } from '../api'
+import type { SshConnection, ShellStatus, TmuxWindow } from '../types'
 // @ts-ignore — installed via npm, types included
 import { Terminal } from '@xterm/xterm'
 // @ts-ignore
@@ -119,6 +119,12 @@ export function RemoteShellTerminalTab({
   const [searchQuery, setSearchQuery]     = useState('')
   const searchInputRef = useRef<HTMLInputElement>(null)
 
+  // Tmux windows panel
+  const [showWindows, setShowWindows]     = useState(false)
+  const [tmuxWindows, setTmuxWindows]     = useState<TmuxWindow[]>([])
+  const [windowsLoading, setWindowsLoading] = useState(false)
+  const windowsPollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
   // Push current terminal dimensions to the server. Call after the WS reaches OPEN
   // — initial fit() runs while the WS is still CONNECTING, so the early resize is lost.
   const sendCurrentSize = useCallback((ws: WebSocket) => {
@@ -130,6 +136,28 @@ export function RemoteShellTerminalTab({
       }
     } catch { /* ignore */ }
   }, [])
+
+  // ── Tmux window list ───────────────────────────────────────────────────────
+  const fetchTmuxWindows = useCallback(async () => {
+    if (!connection.tmuxSession) return
+    setWindowsLoading(true)
+    try {
+      const res = await api.getShellTmuxWindows(buildingId, connection.id, connection.tmuxSession)
+      if (res.ok) setTmuxWindows(res.windows)
+    } catch { /* ignore */ } finally {
+      setWindowsLoading(false)
+    }
+  }, [buildingId, connection.id, connection.tmuxSession])
+
+  // Poll for window list while panel is open and terminal is connected
+  useEffect(() => {
+    if (!showWindows || !connection.tmuxSession) return
+    fetchTmuxWindows()
+    windowsPollRef.current = setInterval(fetchTmuxWindows, 5_000)
+    return () => {
+      if (windowsPollRef.current) clearInterval(windowsPollRef.current)
+    }
+  }, [showWindows, connection.tmuxSession, fetchTmuxWindows])
 
   // ── Connect / Reconnect ────────────────────────────────────────────────────
   const connectWS = useCallback(() => {
@@ -383,6 +411,12 @@ export function RemoteShellTerminalTab({
     }
   }
 
+  function jumpToWindow(index: number) {
+    // Ctrl+B + window-index number (supports 0–9 via \x020...\x029)
+    sendTmux(`\x02${index}`)
+    termRef.current?.focus()
+  }
+
   const statusColor = {
     idle:         '#888',
     connecting:   '#ffaa00',
@@ -398,27 +432,83 @@ export function RemoteShellTerminalTab({
 
       {/* Tmux quick-action toolbar — only shown when tmuxSession is configured */}
       {connection.tmuxSession && (
-        <div style={{
-          display: 'flex', alignItems: 'center', gap: 4,
-          padding: '2px 10px', background: '#0a0a1a', borderBottom: '1px solid #1a1a2e',
-          flexShrink: 0,
-        }}>
-          <span style={{ fontSize: 9, color: '#4488ff', marginRight: 4, fontWeight: 700 }}>
-            TMUX:{connection.tmuxSession}
-          </span>
-          {TMUX_ACTIONS.map((action) => (
+        <>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 4,
+            padding: '2px 10px', background: '#0a0a1a', borderBottom: showWindows ? 'none' : '1px solid #1a1a2e',
+            flexShrink: 0,
+          }}>
+            <span style={{ fontSize: 9, color: '#4488ff', marginRight: 4, fontWeight: 700 }}>
+              TMUX:{connection.tmuxSession}
+            </span>
+            {TMUX_ACTIONS.map((action) => (
+              <button
+                key={action.seq}
+                className="hud-btn"
+                style={{ fontSize: 9, padding: '1px 6px', color: '#88aaff' }}
+                title={action.title}
+                disabled={!isActive || status !== 'connected'}
+                onClick={() => sendTmux(action.seq)}
+              >
+                {action.label}
+              </button>
+            ))}
+            {/* Window list toggle */}
             <button
-              key={action.seq}
               className="hud-btn"
-              style={{ fontSize: 9, padding: '1px 6px', color: '#88aaff' }}
-              title={action.title}
-              disabled={!isActive || status !== 'connected'}
-              onClick={() => sendTmux(action.seq)}
+              style={{
+                fontSize: 9, padding: '1px 6px', marginLeft: 4,
+                color: showWindows ? '#00ff88' : '#88aaff',
+                borderColor: showWindows ? '#00ff88' : undefined,
+              }}
+              title="Show tmux windows"
+              onClick={() => setShowWindows((v) => !v)}
             >
-              {action.label}
+              WINS {showWindows ? '▲' : '▼'}
             </button>
-          ))}
-        </div>
+          </div>
+
+          {/* Tmux window list panel */}
+          {showWindows && (
+            <div style={{
+              display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 4,
+              padding: '4px 10px', background: '#060616', borderBottom: '1px solid #1a1a2e',
+              flexShrink: 0,
+            }}>
+              {windowsLoading && tmuxWindows.length === 0 ? (
+                <span style={{ fontSize: 9, color: '#4488ff' }}>Loading…</span>
+              ) : tmuxWindows.length === 0 ? (
+                <span style={{ fontSize: 9, color: '#444' }}>No windows found</span>
+              ) : (
+                tmuxWindows.map((win) => (
+                  <button
+                    key={win.index}
+                    className="hud-btn"
+                    title={`Jump to window ${win.index}: ${win.name} (Ctrl+B ${win.index})`}
+                    disabled={!isActive || status !== 'connected'}
+                    onClick={() => jumpToWindow(win.index)}
+                    style={{
+                      fontSize: 9, padding: '1px 7px',
+                      color: win.active ? '#00ff88' : '#88aaff',
+                      borderColor: win.active ? '#00ff88' : undefined,
+                      fontWeight: win.active ? 700 : undefined,
+                    }}
+                  >
+                    {win.index}:{win.name}{win.active ? ' ●' : ''}
+                  </button>
+                ))
+              )}
+              <button
+                className="hud-btn"
+                style={{ fontSize: 9, padding: '1px 5px', color: '#444', marginLeft: 'auto' }}
+                title="Refresh window list"
+                onClick={fetchTmuxWindows}
+              >
+                ⟳
+              </button>
+            </div>
+          )}
+        </>
       )}
 
       {/* Status bar */}

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -422,6 +422,12 @@ export interface SshSessionLog {
 
 export type ShellStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error'
 
+export interface TmuxWindow {
+  index: number
+  name: string
+  active: boolean
+}
+
 interface SourceRelayConfig {
   configured: boolean
 }

--- a/gh-ctrl/src/routes/shell.ts
+++ b/gh-ctrl/src/routes/shell.ts
@@ -317,6 +317,93 @@ app.get('/:id/shell/connections/:cid/tmux-sessions', async (c) => {
   })
 })
 
+// GET /:id/shell/connections/:cid/tmux-windows — list windows in a tmux session
+app.get('/:id/shell/connections/:cid/tmux-windows', async (c) => {
+  const buildingId = Number(c.req.param('id'))
+  const cid        = Number(c.req.param('cid'))
+  const session    = c.req.query('session') ?? null
+
+  const profiles = await db.select().from(sshConnections)
+    .where(and(eq(sshConnections.id, cid), eq(sshConnections.buildingId, buildingId)))
+    .limit(1)
+  if (profiles.length === 0) return c.json({ error: 'Connection not found' }, 404)
+
+  const profile = profiles[0]
+  let creds: { password?: string; privateKey?: string } = {}
+  if (profile.encryptedCreds) {
+    try { creds = JSON.parse(decryptCreds(profile.encryptedCreds)) } catch { /* ignore */ }
+  }
+
+  const targetSession = session ?? profile.tmuxSession ?? null
+  const safeSession   = targetSession ? targetSession.replace(/[^a-zA-Z0-9_-]/g, '') : null
+  const cmd = safeSession
+    ? `tmux list-windows -t '${safeSession}' -F '#{window_index} #{window_name} #{window_active}' 2>/dev/null || echo "__NO_TMUX__"`
+    : `tmux list-windows -F '#{window_index} #{window_name} #{window_active}' 2>/dev/null || echo "__NO_TMUX__"`
+
+  return new Promise((resolve) => {
+    const conn = new Client()
+    const timeout = setTimeout(() => {
+      conn.end()
+      resolve(c.json({ ok: false, error: 'Connection timed out', windows: [] }))
+    }, 10_000)
+
+    conn.on('ready', () => {
+      conn.exec(cmd, (err, stream) => {
+        if (err) {
+          clearTimeout(timeout)
+          conn.end()
+          resolve(c.json({ ok: false, error: err.message, windows: [] }))
+          return
+        }
+        let output = ''
+        stream.on('data', (data: Buffer) => { output += data.toString() })
+        stream.stderr.on('data', (data: Buffer) => { output += data.toString() })
+        stream.on('close', () => {
+          clearTimeout(timeout)
+          conn.end()
+          if (output.includes('__NO_TMUX__') || output.includes('no server running')) {
+            resolve(c.json({ ok: true, windows: [] }))
+            return
+          }
+          const windows = output.trim().split('\n')
+            .filter((line) => line.trim() && !line.startsWith('error:'))
+            .map((line) => {
+              const parts = line.trim().split(' ')
+              const index  = parseInt(parts[0] ?? '0', 10)
+              const active = parts[parts.length - 1] === '1'
+              const name   = parts.slice(1, active ? parts.length - 1 : undefined).join(' ') || `win${index}`
+              return { index, name, active }
+            })
+            .filter((w) => !isNaN(w.index))
+          resolve(c.json({ ok: true, windows }))
+        })
+      })
+    })
+
+    conn.on('error', (err) => {
+      clearTimeout(timeout)
+      resolve(c.json({ ok: false, error: err.message, windows: [] }))
+    })
+
+    const authOptions: ConnectConfig = {
+      host:         profile.host,
+      port:         profile.port ?? 22,
+      username:     profile.username,
+      readyTimeout: 10_000,
+    }
+    if (profile.authType === 'key' && creds.privateKey) {
+      authOptions.privateKey = creds.privateKey
+    } else if (creds.password) {
+      authOptions.password = creds.password
+    }
+
+    try { conn.connect(authOptions) } catch (err: any) {
+      clearTimeout(timeout)
+      resolve(c.json({ ok: false, error: err.message, windows: [] }))
+    }
+  })
+})
+
 // ── WebSocket PTY bridge ─────────────────────────────────────────────────────
 
 app.get(


### PR DESCRIPTION
Adds a WINS toggle to the tmux toolbar that shows all open tmux windows and allows jumping directly to any window via Ctrl+B+index.

Closes #412

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tmux windows panel to the remote shell terminal, enabling users to view and switch between active tmux windows
  * Windows list auto-refreshes periodically with a manual refresh button
  * Toggle panel visibility with a dedicated button
  * Select a window to instantly jump to it in the terminal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->