### PR TITLE
feat: link ClawCom satellite windows to codebases

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -709,6 +709,17 @@ export const api = {
       }
     ),
 
+  updateShellWindowRepoLinks: (
+    buildingId: number,
+    connectionId: number,
+    windowIndex: number,
+    repoIds: number[],
+  ) =>
+    request<SshConnection>(
+      `/buildings/${buildingId}/shell/connections/${connectionId}/window-repo-links`,
+      { method: 'PATCH', body: JSON.stringify({ windowIndex, repoIds }) }
+    ),
+
   // ── Source Relay ──────────────────────────────────────────────────────────
 
   listSourceRelayConnectors: (buildingId: number) =>

--- a/gh-ctrl/client/src/components/ClawComBuilding.tsx
+++ b/gh-ctrl/client/src/components/ClawComBuilding.tsx
@@ -10,12 +10,12 @@ import { TmuxWindowSatellite } from './TmuxWindowSatellite'
 
 // Orbit radius for tmux-window satellites around a ClawCom building.
 // Tuned to clear the 100px building image and the labels below it.
-const SATELLITE_ORBIT_RADIUS = 130
+export const SATELLITE_ORBIT_RADIUS = 130
 // Switch to a wider second ring once the first orbit gets crowded.
-const SATELLITE_SECOND_RING_RADIUS = 200
-const SATELLITE_FIRST_RING_CAPACITY = 8
+export const SATELLITE_SECOND_RING_RADIUS = 200
+export const SATELLITE_FIRST_RING_CAPACITY = 8
 
-function satelliteOffset(index: number, count: number): { dx: number; dy: number } {
+export function satelliteOffset(index: number, count: number): { dx: number; dy: number } {
   // Place satellites preferentially on the upper ring so the label area
   // below the building stays readable. Satellites still complete the orbit
   // when count > capacity, just on a wider ring.

--- a/gh-ctrl/client/src/components/RemoteShellTerminalTab.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellTerminalTab.tsx
@@ -108,6 +108,7 @@ export function RemoteShellTerminalTab({
   pendingWindowIndex,
 }: RemoteShellTerminalTabProps) {
   const consumeTmuxJump = useAppStore((s) => s.consumeTmuxJump)
+  const repos = useAppStore((s) => s.repos)
   const containerRef   = useRef<HTMLDivElement>(null)
   const termRef        = useRef<Terminal | null>(null)
   const fitAddonRef    = useRef<FitAddon | null>(null)
@@ -135,6 +136,12 @@ export function RemoteShellTerminalTab({
   const [tmuxWindows, setTmuxWindows]     = useState<TmuxWindow[]>([])
   const [windowsLoading, setWindowsLoading] = useState(false)
   const windowsPollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Repo link picker
+  const [linkPickerWindow, setLinkPickerWindow] = useState<number | null>(null)
+  const [winRepoLinks, setWinRepoLinks] = useState<Record<string, number[]>>(
+    () => connection.windowRepoLinks ?? {}
+  )
 
   // Push current terminal dimensions to the server. Call after the WS reaches OPEN
   // — initial fit() runs while the WS is still CONNECTING, so the early resize is lost.
@@ -499,6 +506,28 @@ export function RemoteShellTerminalTab({
     }
   }
 
+  function toggleRepoLink(windowIndex: number, repoId: number) {
+    setWinRepoLinks((prev) => {
+      const key = String(windowIndex)
+      const current = prev[key] ?? []
+      const next = current.includes(repoId)
+        ? current.filter((id) => id !== repoId)
+        : [...current, repoId]
+      return { ...prev, [key]: next }
+    })
+  }
+
+  async function saveLinkForWindow(windowIndex: number) {
+    const repoIds = winRepoLinks[String(windowIndex)] ?? []
+    try {
+      const updated = await api.updateShellWindowRepoLinks(buildingId, connection.id, windowIndex, repoIds)
+      setWinRepoLinks(updated.windowRepoLinks ?? {})
+      setLinkPickerWindow(null)
+    } catch (err) {
+      window.alert(`Failed to save links: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
   const statusColor = {
     idle:         '#888',
     connecting:   '#ffaa00',
@@ -590,9 +619,24 @@ export function RemoteShellTerminalTab({
                         color: win.active ? '#00ff88' : '#666',
                         borderColor: win.active ? '#00ff88' : undefined,
                         borderTopLeftRadius: 0, borderBottomLeftRadius: 0,
+                        borderRight: 'none',
                       }}
                     >
                       ✎
+                    </button>
+                    <button
+                      className="hud-btn"
+                      title={`Link repos to window ${win.index}`}
+                      onClick={() => setLinkPickerWindow((p) => p === win.index ? null : win.index)}
+                      style={{
+                        fontSize: 9, padding: '1px 5px',
+                        color: (winRepoLinks[String(win.index)]?.length ?? 0) > 0 ? '#00aaff' : '#555',
+                        borderColor: (winRepoLinks[String(win.index)]?.length ?? 0) > 0 ? '#00aaff' : undefined,
+                        borderTopLeftRadius: 0, borderBottomLeftRadius: 0,
+                        borderLeft: 'none',
+                      }}
+                    >
+                      ⛓
                     </button>
                   </span>
                 ))
@@ -604,6 +648,51 @@ export function RemoteShellTerminalTab({
                 onClick={fetchTmuxWindows}
               >
                 ⟳
+              </button>
+            </div>
+          )}
+
+          {/* Repo link picker — expands below window list when ⛓ is clicked */}
+          {showWindows && linkPickerWindow !== null && (
+            <div style={{
+              display: 'flex', flexWrap: 'wrap', gap: 4, alignItems: 'center',
+              padding: '4px 10px', background: '#07071a', borderBottom: '1px solid #1a1a2e',
+              fontSize: 9, flexShrink: 0,
+            }}>
+              <span style={{ color: '#666', marginRight: 2 }}>win {linkPickerWindow} →</span>
+              {repos.length === 0 && (
+                <span style={{ color: '#444' }}>No repos configured</span>
+              )}
+              {repos.map((repo) => {
+                const linked = winRepoLinks[String(linkPickerWindow)]?.includes(repo.id) ?? false
+                return (
+                  <button
+                    key={repo.id}
+                    className="hud-btn"
+                    onClick={() => toggleRepoLink(linkPickerWindow, repo.id)}
+                    style={{
+                      fontSize: 9, padding: '1px 6px',
+                      color: linked ? '#00aaff' : '#555',
+                      borderColor: linked ? '#00aaff' : undefined,
+                    }}
+                  >
+                    {linked ? '✓ ' : ''}{repo.fullName}
+                  </button>
+                )
+              })}
+              <button
+                className="hud-btn"
+                onClick={() => saveLinkForWindow(linkPickerWindow)}
+                style={{ fontSize: 9, padding: '1px 6px', color: '#00ff88', marginLeft: 4 }}
+              >
+                Save
+              </button>
+              <button
+                className="hud-btn"
+                onClick={() => setLinkPickerWindow(null)}
+                style={{ fontSize: 9, padding: '1px 5px', color: '#888' }}
+              >
+                ✕
               </button>
             </div>
           )}

--- a/gh-ctrl/client/src/components/battlefield/BattlefieldMapLayer.tsx
+++ b/gh-ctrl/client/src/components/battlefield/BattlefieldMapLayer.tsx
@@ -16,6 +16,7 @@ import { SourceRelayBuilding } from '../SourceRelayBuilding'
 import { BadgeMarker } from '../BadgeMarker'
 import { UserUnit } from './UserUnit'
 import { SourceRelayConnectionsLayer } from './SourceRelayConnectionsLayer'
+import { ClawComSatelliteConnectionsLayer } from './ClawComSatelliteConnectionsLayer'
 import type { Repo } from '../../types'
 
 interface BuildingRendererProps {
@@ -301,6 +302,11 @@ export function BattlefieldMapLayer({
       <SourceRelayConnectionsLayer
         buildingPositions={buildingPositions}
         visibleEntries={visibleEntries}
+        positions={positions}
+      />
+      {/* ClawCom satellite→repo splines */}
+      <ClawComSatelliteConnectionsLayer
+        buildingPositions={buildingPositions}
         positions={positions}
       />
     </div>

--- a/gh-ctrl/client/src/components/battlefield/ClawComSatelliteConnectionsLayer.tsx
+++ b/gh-ctrl/client/src/components/battlefield/ClawComSatelliteConnectionsLayer.tsx
@@ -1,0 +1,154 @@
+import { useState, useEffect } from 'react'
+import { api } from '../../api'
+import { useAppStore } from '../../store'
+import type { SshConnection } from '../../types'
+import type { Position } from './battlefieldConstants'
+import { satelliteOffset } from '../ClawComBuilding'
+
+interface Props {
+  buildingPositions: Record<number, Position>
+  positions: Record<number, Position>
+}
+
+// BaseNode is 140px wide, positioned at top-left — use top-center of the node.
+const BASE_CENTER_X = 70
+const BASE_CENTER_Y = 40
+
+interface SatelliteLink {
+  key: string
+  from: Position
+  to: Position
+  color: string
+}
+
+export function ClawComSatelliteConnectionsLayer({ buildingPositions, positions }: Props) {
+  const storeBuildings = useAppStore((s) => s.buildings)
+  const [connectionsByBuilding, setConnectionsByBuilding] = useState<
+    Record<number, SshConnection[]>
+  >({})
+
+  const clawcomBuildings = storeBuildings.filter((b) => b.type === 'clawcom')
+  const buildingIdKey = clawcomBuildings.map((b) => b.id).join(',')
+
+  useEffect(() => {
+    if (clawcomBuildings.length === 0) {
+      setConnectionsByBuilding({})
+      return
+    }
+
+    let cancelled = false
+
+    async function fetchAll() {
+      const result: Record<number, SshConnection[]> = {}
+      await Promise.all(
+        clawcomBuildings.map(async (b) => {
+          try {
+            result[b.id] = await api.listShellConnections(b.id)
+          } catch {
+            result[b.id] = []
+          }
+        }),
+      )
+      if (!cancelled) setConnectionsByBuilding(result)
+    }
+
+    fetchAll()
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [buildingIdKey])
+
+  const links: SatelliteLink[] = []
+
+  for (const building of clawcomBuildings) {
+    const conns = connectionsByBuilding[building.id] ?? []
+    const bRaw = buildingPositions[building.id] ?? { x: building.posX, y: building.posY }
+    const color = building.color ?? '#00ff88'
+
+    // Collect all (windowIndex → repoIds) pairs across all connections,
+    // ordered by connection then by window index — this mirrors the flat
+    // satellite array ordering in ClawComBuilding.tsx.
+    type LinkedSat = { connId: number; windowIdx: number; repoIds: number[] }
+    const linkedSats: LinkedSat[] = []
+    for (const conn of conns) {
+      if (!conn.windowRepoLinks) continue
+      const sorted = Object.entries(conn.windowRepoLinks)
+        .map(([k, v]) => ({ windowIdx: Number(k), repoIds: v }))
+        .filter((e) => e.repoIds.length > 0)
+        .sort((a, b) => a.windowIdx - b.windowIdx)
+      for (const { windowIdx, repoIds } of sorted) {
+        linkedSats.push({ connId: conn.id, windowIdx, repoIds })
+      }
+    }
+
+    if (linkedSats.length === 0) continue
+
+    linkedSats.forEach(({ connId, windowIdx, repoIds }, idx) => {
+      const { dx, dy } = satelliteOffset(idx, linkedSats.length)
+      const satPos: Position = { x: bRaw.x + dx, y: bRaw.y + dy }
+
+      for (const repoId of repoIds) {
+        const rRaw = positions[repoId]
+        if (!rRaw) continue
+        links.push({
+          key: `${building.id}-${connId}-${windowIdx}-${repoId}`,
+          color,
+          from: satPos,
+          to: { x: rRaw.x + BASE_CENTER_X, y: rRaw.y + BASE_CENTER_Y },
+        })
+      }
+    })
+  }
+
+  if (links.length === 0) return null
+
+  return (
+    <svg
+      width={6000}
+      height={6000}
+      style={{
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        overflow: 'visible',
+        pointerEvents: 'none',
+        zIndex: 20,
+      }}
+    >
+      <defs>
+        <style>{`
+          @keyframes clawcom-sat-flow {
+            to { stroke-dashoffset: -20; }
+          }
+        `}</style>
+      </defs>
+      {links.map((link) => {
+        const { from, to } = link
+        const mx = (from.x + to.x) / 2
+        const my = Math.min(from.y, to.y) - 80
+        const d = `M ${from.x} ${from.y} Q ${mx} ${my} ${to.x} ${to.y}`
+        return (
+          <g key={link.key}>
+            <path
+              d={d}
+              fill="none"
+              stroke={link.color}
+              strokeWidth={6}
+              strokeOpacity={0.12}
+              strokeDasharray="8 6"
+              style={{ animation: 'clawcom-sat-flow 1.5s linear infinite' }}
+            />
+            <path
+              d={d}
+              fill="none"
+              stroke={link.color}
+              strokeWidth={1.5}
+              strokeOpacity={0.7}
+              strokeDasharray="8 6"
+              style={{ animation: 'clawcom-sat-flow 1.5s linear infinite' }}
+            />
+          </g>
+        )
+      })}
+    </svg>
+  )
+}

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -406,6 +406,7 @@ export interface SshConnection {
   authType: string | null
   hasCredentials: boolean
   tmuxSession: string | null
+  windowRepoLinks: Record<string, number[]> | null
   createdAt: string | number | null
   updatedAt: string | number | null
 }

--- a/gh-ctrl/src/db/schema.ts
+++ b/gh-ctrl/src/db/schema.ts
@@ -150,6 +150,7 @@ export const sshConnections = sqliteTable('ssh_connections', {
   authType:       text('auth_type').default('password'), // 'password' | 'key'
   encryptedCreds: text('encrypted_creds'),               // AES-256-GCM encrypted JSON
   tmuxSession:    text('tmux_session'),                  // null = no tmux, string = session name
+  windowRepoLinks: text('window_repo_links'),             // JSON: { [windowIndex: string]: number[] }
   createdAt:      integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
   updatedAt:      integer('updated_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
 })

--- a/gh-ctrl/src/routes/shell.ts
+++ b/gh-ctrl/src/routes/shell.ts
@@ -42,10 +42,12 @@ function decryptCreds(stored: string): string {
   return (decipher.update(Buffer.from(data, 'hex')) as Buffer).toString('utf8') + decipher.final('utf8')
 }
 
-// Return profile without secret fields
+// Return profile without secret fields; parse windowRepoLinks JSON for client convenience
 function maskProfile(p: typeof sshConnections.$inferSelect) {
-  const { encryptedCreds: _, ...rest } = p
-  return { ...rest, hasCredentials: !!_ }
+  const { encryptedCreds: _, windowRepoLinks: wrlRaw, ...rest } = p
+  let windowRepoLinks: Record<string, number[]> | null = null
+  try { if (wrlRaw) windowRepoLinks = JSON.parse(wrlRaw) } catch { /* ignore */ }
+  return { ...rest, windowRepoLinks, hasCredentials: !!_ }
 }
 
 // Building types that own SSH connection profiles (RemoteShell + ClawCom share this UI)
@@ -175,6 +177,42 @@ app.delete('/:id/shell/connections/:cid', async (c) => {
   }
 
   return c.json({ ok: true })
+})
+
+// PATCH /:id/shell/connections/:cid/window-repo-links — set repo links for one tmux window
+app.patch('/:id/shell/connections/:cid/window-repo-links', async (c) => {
+  const buildingId = Number(c.req.param('id'))
+  const cid        = Number(c.req.param('cid'))
+
+  const existing = await db.select().from(sshConnections)
+    .where(and(eq(sshConnections.id, cid), eq(sshConnections.buildingId, buildingId)))
+    .limit(1)
+  if (existing.length === 0) return c.json({ error: 'Connection not found' }, 404)
+
+  const body = await c.req.json()
+  const windowIndex = Number(body.windowIndex)
+  if (!Number.isInteger(windowIndex) || windowIndex < 0) {
+    return c.json({ error: 'Invalid window index' }, 400)
+  }
+  const repoIds: number[] = Array.isArray(body.repoIds)
+    ? body.repoIds.map(Number).filter((n: number) => Number.isInteger(n) && n > 0)
+    : []
+
+  let map: Record<string, number[]> = {}
+  try { if (existing[0].windowRepoLinks) map = JSON.parse(existing[0].windowRepoLinks) } catch { /* ignore */ }
+
+  if (repoIds.length === 0) {
+    delete map[String(windowIndex)]
+  } else {
+    map[String(windowIndex)] = repoIds
+  }
+
+  const [updated] = await db.update(sshConnections)
+    .set({ windowRepoLinks: JSON.stringify(map), updatedAt: new Date() })
+    .where(eq(sshConnections.id, cid))
+    .returning()
+
+  return c.json(maskProfile(updated))
 })
 
 // POST /:id/shell/connections/test — test a connection without opening a PTY


### PR DESCRIPTION
Closes #418

Links tmux session windows to codebases via spline visualization on the battlefield canvas, configurable from the ⛓ button next to each window's rename button.

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/svengraziani/vibe-and-conquer/actions/runs/25398490279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal windows can now be linked to repositories via a picker interface in the shell tab
  * Added visual satellite-to-repository connection lines on the battlefield map display
  * Repository associations are persisted per tmux window session

<!-- end of auto-generated comment: release notes by coderabbit.ai -->