### PR TITLE
feat: Prompt Toolbox for reusable terminal prompt templates

### DIFF
--- a/gh-ctrl/client/src/api.ts
+++ b/gh-ctrl/client/src/api.ts
@@ -839,6 +839,24 @@ export const api = {
     }
     return { exitCode: -1, truncated: false, error: 'Could not parse update result' }
   },
+
+  listPromptTemplates: (category?: string) =>
+    request<import('./types').PromptTemplate[]>(`/prompts${category ? `?category=${encodeURIComponent(category)}` : ''}`),
+
+  createPromptTemplate: (data: { title: string; content: string; category?: string; sortOrder?: number }) =>
+    request<import('./types').PromptTemplate>('/prompts', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
+  updatePromptTemplate: (id: number, data: Partial<{ title: string; content: string; category: string | null; sortOrder: number }>) =>
+    request<import('./types').PromptTemplate>(`/prompts/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+
+  deletePromptTemplate: (id: number) =>
+    request<{ ok: boolean }>(`/prompts/${id}`, { method: 'DELETE' }),
 }
 
 export async function exportBackup(): Promise<Blob> {

--- a/gh-ctrl/client/src/components/PromptToolboxPanel.tsx
+++ b/gh-ctrl/client/src/components/PromptToolboxPanel.tsx
@@ -1,0 +1,294 @@
+import { useState, useEffect } from 'react'
+import { api } from '../api'
+import type { PromptTemplate } from '../types'
+
+interface PromptToolboxPanelProps {
+  onSend?: (content: string) => void
+}
+
+const inputStyle: React.CSSProperties = {
+  background: '#0d0d0d',
+  border: '1px solid #333',
+  color: '#c8f0c8',
+  padding: '2px 6px',
+  borderRadius: 3,
+  outline: 'none',
+  fontFamily: 'monospace',
+  fontSize: 10,
+  width: '100%',
+  boxSizing: 'border-box',
+}
+
+interface EditRowProps {
+  template: PromptTemplate
+  onSave: (updates: { title: string; content: string; category: string | null }) => Promise<void>
+  onCancel: () => void
+}
+
+function EditRow({ template, onSave, onCancel }: EditRowProps) {
+  const [title, setTitle]       = useState(template.title)
+  const [content, setContent]   = useState(template.content)
+  const [category, setCategory] = useState(template.category ?? '')
+
+  async function handleSave() {
+    const t = title.trim()
+    const c = content.trim()
+    if (!t || !c) return
+    await onSave({ title: t, content: c, category: category.trim() || null })
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Title"
+        style={inputStyle}
+      />
+      <input
+        value={category}
+        onChange={(e) => setCategory(e.target.value)}
+        placeholder="Category (optional)"
+        style={inputStyle}
+      />
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Template content…"
+        rows={4}
+        style={{ ...inputStyle, resize: 'vertical' }}
+      />
+      <div style={{ display: 'flex', gap: 3 }}>
+        <button className="hud-btn" style={{ fontSize: 9, flex: 1 }} onClick={handleSave}>SAVE</button>
+        <button className="hud-btn" style={{ fontSize: 9, color: '#888' }} onClick={onCancel}>CANCEL</button>
+      </div>
+    </div>
+  )
+}
+
+export function PromptToolboxPanel({ onSend }: PromptToolboxPanelProps) {
+  const [templates, setTemplates]     = useState<PromptTemplate[]>([])
+  const [loading, setLoading]         = useState(true)
+  const [editingId, setEditingId]     = useState<number | null>(null)
+  const [showNew, setShowNew]         = useState(false)
+  const [newTitle, setNewTitle]       = useState('')
+  const [newContent, setNewContent]   = useState('')
+  const [newCategory, setNewCategory] = useState('')
+  const [copied, setCopied]           = useState<number | null>(null)
+
+  useEffect(() => {
+    api.listPromptTemplates()
+      .then(setTemplates)
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  // Group by category for display
+  const groups = new Map<string, PromptTemplate[]>()
+  for (const t of templates) {
+    const cat = t.category ?? 'General'
+    if (!groups.has(cat)) groups.set(cat, [])
+    groups.get(cat)!.push(t)
+  }
+
+  async function handleCreate() {
+    if (!newTitle.trim() || !newContent.trim()) return
+    try {
+      const created = await api.createPromptTemplate({
+        title: newTitle.trim(),
+        content: newContent.trim(),
+        category: newCategory.trim() || undefined,
+      })
+      setTemplates((prev) => [...prev, created])
+      setNewTitle('')
+      setNewContent('')
+      setNewCategory('')
+      setShowNew(false)
+    } catch { /* ignore */ }
+  }
+
+  async function handleDelete(id: number) {
+    try {
+      await api.deletePromptTemplate(id)
+      setTemplates((prev) => prev.filter((t) => t.id !== id))
+    } catch { /* ignore */ }
+  }
+
+  async function handleUpdate(id: number, updates: { title: string; content: string; category: string | null }) {
+    const updated = await api.updatePromptTemplate(id, updates)
+    setTemplates((prev) => prev.map((t) => (t.id === id ? updated : t)))
+    setEditingId(null)
+  }
+
+  function handleCopy(id: number, content: string) {
+    navigator.clipboard.writeText(content).catch(() => {})
+    setCopied(id)
+    setTimeout(() => setCopied((prev) => (prev === id ? null : prev)), 1500)
+  }
+
+  return (
+    <div style={{
+      width: 280,
+      display: 'flex',
+      flexDirection: 'column',
+      background: '#111',
+      borderLeft: '1px solid #1a1a1a',
+      fontFamily: 'monospace',
+      fontSize: 11,
+      flexShrink: 0,
+    }}>
+      {/* Panel header */}
+      <div style={{
+        padding: '4px 10px',
+        background: '#0f0f0f',
+        borderBottom: '1px solid #1a1a1a',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        flexShrink: 0,
+      }}>
+        <span style={{ color: '#00ff88', fontWeight: 700, fontSize: 10 }}>⬡ PROMPT TOOLBOX</span>
+        <div style={{ flex: 1 }} />
+        <button
+          className="hud-btn"
+          style={{ fontSize: 9, padding: '1px 6px' }}
+          onClick={() => { setShowNew((v) => !v); setEditingId(null) }}
+        >+ NEW</button>
+      </div>
+
+      {/* New template form */}
+      {showNew && (
+        <div style={{
+          padding: 8,
+          borderBottom: '1px solid #1a1a1a',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 4,
+          flexShrink: 0,
+        }}>
+          <input
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            placeholder="Title"
+            style={inputStyle}
+          />
+          <input
+            value={newCategory}
+            onChange={(e) => setNewCategory(e.target.value)}
+            placeholder="Category (optional)"
+            style={inputStyle}
+          />
+          <textarea
+            value={newContent}
+            onChange={(e) => setNewContent(e.target.value)}
+            placeholder="Template content…"
+            rows={4}
+            style={{ ...inputStyle, resize: 'vertical' }}
+          />
+          <div style={{ display: 'flex', gap: 4 }}>
+            <button
+              className="hud-btn"
+              style={{ fontSize: 9, flex: 1 }}
+              onClick={handleCreate}
+            >SAVE</button>
+            <button
+              className="hud-btn"
+              style={{ fontSize: 9, color: '#888' }}
+              onClick={() => setShowNew(false)}
+            >CANCEL</button>
+          </div>
+        </div>
+      )}
+
+      {/* Template list */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {loading ? (
+          <div style={{ padding: 10, color: '#555', fontSize: 10 }}>Loading…</div>
+        ) : templates.length === 0 ? (
+          <div style={{ padding: 10, color: '#555', fontSize: 10 }}>
+            No templates yet. Click + NEW to create one.
+          </div>
+        ) : (
+          Array.from(groups.entries()).map(([cat, items]) => (
+            <div key={cat}>
+              <div style={{
+                padding: '3px 8px',
+                color: '#4488ff',
+                fontSize: 9,
+                fontWeight: 700,
+                background: '#0a0a1a',
+                borderBottom: '1px solid #111',
+                letterSpacing: 1,
+              }}>
+                {cat.toUpperCase()}
+              </div>
+              {items.map((t) => (
+                <div
+                  key={t.id}
+                  style={{
+                    padding: '6px 8px',
+                    borderBottom: '1px solid #111',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 4,
+                  }}
+                >
+                  {editingId === t.id ? (
+                    <EditRow
+                      template={t}
+                      onSave={(updates) => handleUpdate(t.id, updates)}
+                      onCancel={() => setEditingId(null)}
+                    />
+                  ) : (
+                    <>
+                      <div style={{ color: '#c8f0c8', fontSize: 10, fontWeight: 600 }}>{t.title}</div>
+                      <div style={{
+                        color: '#666',
+                        fontSize: 9,
+                        maxHeight: 44,
+                        overflow: 'hidden',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-all',
+                        lineHeight: 1.4,
+                      }}>
+                        {t.content}
+                      </div>
+                      <div style={{ display: 'flex', gap: 3, flexWrap: 'wrap' }}>
+                        {onSend && (
+                          <button
+                            className="hud-btn"
+                            style={{ fontSize: 9, padding: '1px 6px', color: '#00ff88' }}
+                            onClick={() => onSend(t.content)}
+                            title="Send to active terminal"
+                          >▶ SEND</button>
+                        )}
+                        <button
+                          className="hud-btn"
+                          style={{ fontSize: 9, padding: '1px 6px', color: copied === t.id ? '#00ff88' : undefined }}
+                          onClick={() => handleCopy(t.id, t.content)}
+                          title="Copy to clipboard"
+                        >{copied === t.id ? '✓ COPIED' : '⎘ COPY'}</button>
+                        <button
+                          className="hud-btn"
+                          style={{ fontSize: 9, padding: '1px 5px', color: '#888' }}
+                          onClick={() => { setEditingId(t.id); setShowNew(false) }}
+                          title="Edit template"
+                        >✎</button>
+                        <button
+                          className="hud-btn"
+                          style={{ fontSize: 9, padding: '1px 5px', color: '#ff4444' }}
+                          onClick={() => handleDelete(t.id)}
+                          title="Delete template"
+                        >✕</button>
+                      </div>
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/gh-ctrl/client/src/components/RemoteShellTerminalDialog.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellTerminalDialog.tsx
@@ -3,7 +3,8 @@ import { createPortal } from 'react-dom'
 import { api } from '../api'
 import { useAppStore } from '../store'
 import type { Building, SshConnection, RemoteShellConfig } from '../types'
-import { RemoteShellTerminalTab } from './RemoteShellTerminalTab'
+import { RemoteShellTerminalTab, type RemoteShellTerminalTabHandle } from './RemoteShellTerminalTab'
+import { PromptToolboxPanel } from './PromptToolboxPanel'
 
 interface RemoteShellTerminalDialogProps {
   building: Building
@@ -28,10 +29,13 @@ export function RemoteShellTerminalDialog({
   const [activeTabId, setActiveTabId]     = useState<string>('')
   const [loading, setLoading]             = useState(true)
   const [showNewTabMenu, setShowNewTabMenu] = useState(false)
+  const [showToolbox, setShowToolbox]     = useState(false)
   // Anchor for the +TAB dropdown — the menu is portaled to body to escape
   // the tab bar's overflow:auto, so it needs an absolute screen position.
   const newTabBtnRef = useRef<HTMLButtonElement>(null)
   const [newTabMenuPos, setNewTabMenuPos] = useState<{ left: number; top: number } | null>(null)
+  // Map tabId -> tab handle for sending text to the active terminal
+  const tabHandles = useRef<Map<string, RemoteShellTerminalTabHandle>>(new Map())
 
   const pendingTmuxJump = useAppStore((s) => s.pendingTmuxJump)
   const matchingJump = pendingTmuxJump?.buildingId === building.id ? pendingTmuxJump : null
@@ -191,6 +195,12 @@ export function RemoteShellTerminalDialog({
         <div style={{ flex: 1 }} />
         <button
           className="hud-btn"
+          style={{ fontSize: 10, color: showToolbox ? '#00ff88' : undefined, borderColor: showToolbox ? '#00ff88' : undefined }}
+          onClick={() => setShowToolbox((v) => !v)}
+          title="Toggle Prompt Toolbox"
+        >⬡ TOOLBOX</button>
+        <button
+          className="hud-btn"
           style={{ fontSize: 10 }}
           onClick={onReconfigure}
           title="Manage connections"
@@ -270,53 +280,67 @@ export function RemoteShellTerminalDialog({
         )}
       </div>
 
-      {/* Terminal area */}
-      <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
-        {loading && (
-          <div style={{
-            position: 'absolute', inset: 0, display: 'flex',
-            alignItems: 'center', justifyContent: 'center',
-            color: '#00ff88', fontSize: 12,
-          }}>
-            Loading connections...
-          </div>
-        )}
+      {/* Terminal area + optional toolbox side panel */}
+      <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'row' }}>
+        <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
+          {loading && (
+            <div style={{
+              position: 'absolute', inset: 0, display: 'flex',
+              alignItems: 'center', justifyContent: 'center',
+              color: '#00ff88', fontSize: 12,
+            }}>
+              Loading connections...
+            </div>
+          )}
 
-        {!loading && tabs.length === 0 && (
-          <div style={{
-            position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column',
-            alignItems: 'center', justifyContent: 'center',
-            color: '#555', fontSize: 12, gap: 10,
-          }}>
-            <div>No connections available.</div>
-            <button className="hud-btn" onClick={onReconfigure}>⚙ Manage Connections</button>
-          </div>
-        )}
+          {!loading && tabs.length === 0 && (
+            <div style={{
+              position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column',
+              alignItems: 'center', justifyContent: 'center',
+              color: '#555', fontSize: 12, gap: 10,
+            }}>
+              <div>No connections available.</div>
+              <button className="hud-btn" onClick={onReconfigure}>⚙ Manage Connections</button>
+            </div>
+          )}
 
-        {tabs.map((tab) => (
-          <div
-            key={tab.id}
-            style={{
-              position: 'absolute', inset: 0,
-              display: activeTabId === tab.id ? 'flex' : 'none',
-              flexDirection: 'column',
+          {tabs.map((tab) => (
+            <div
+              key={tab.id}
+              style={{
+                position: 'absolute', inset: 0,
+                display: activeTabId === tab.id ? 'flex' : 'none',
+                flexDirection: 'column',
+              }}
+            >
+              <RemoteShellTerminalTab
+                ref={(handle) => {
+                  if (handle) tabHandles.current.set(tab.id, handle)
+                  else tabHandles.current.delete(tab.id)
+                }}
+                buildingId={building.id}
+                connection={tab.connection}
+                theme={config.theme}
+                fontSize={config.fontSize}
+                fontFamily={config.fontFamily}
+                isActive={activeTabId === tab.id}
+                pendingWindowIndex={
+                  matchingJump && matchingJump.connectionId === tab.connection.id && activeTabId === tab.id
+                    ? matchingJump.windowIndex
+                    : undefined
+                }
+              />
+            </div>
+          ))}
+        </div>
+
+        {showToolbox && (
+          <PromptToolboxPanel
+            onSend={(content) => {
+              tabHandles.current.get(activeTabId)?.send(content)
             }}
-          >
-            <RemoteShellTerminalTab
-              buildingId={building.id}
-              connection={tab.connection}
-              theme={config.theme}
-              fontSize={config.fontSize}
-              fontFamily={config.fontFamily}
-              isActive={activeTabId === tab.id}
-              pendingWindowIndex={
-                matchingJump && matchingJump.connectionId === tab.connection.id && activeTabId === tab.id
-                  ? matchingJump.windowIndex
-                  : undefined
-              }
-            />
-          </div>
-        ))}
+          />
+        )}
       </div>
 
       {/* +TAB dropdown — portaled so it isn't clipped by the tab bar's

--- a/gh-ctrl/client/src/components/RemoteShellTerminalTab.tsx
+++ b/gh-ctrl/client/src/components/RemoteShellTerminalTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandle } from 'react'
 import { getShellWsUrl, api } from '../api'
 import { useAppStore } from '../store'
 import type { SshConnection, ShellStatus, TmuxWindow } from '../types'
@@ -11,6 +11,10 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 // @ts-ignore
 import { SearchAddon } from '@xterm/addon-search'
 import '@xterm/xterm/css/xterm.css'
+
+export interface RemoteShellTerminalTabHandle {
+  send(text: string): void
+}
 
 interface RemoteShellTerminalTabProps {
   buildingId: number
@@ -98,7 +102,8 @@ const TMUX_ACTIONS = [
   { label: '⏏ DETACH', title: 'Detach tmux session (Ctrl+B d)',  seq: '\x02d' },
 ]
 
-export function RemoteShellTerminalTab({
+export const RemoteShellTerminalTab = forwardRef<RemoteShellTerminalTabHandle, RemoteShellTerminalTabProps>(
+function RemoteShellTerminalTab({
   buildingId,
   connection,
   theme = 'dark',
@@ -106,13 +111,23 @@ export function RemoteShellTerminalTab({
   fontFamily = 'monospace',
   isActive,
   pendingWindowIndex,
-}: RemoteShellTerminalTabProps) {
+}: RemoteShellTerminalTabProps, ref) {
   const consumeTmuxJump = useAppStore((s) => s.consumeTmuxJump)
   const containerRef   = useRef<HTMLDivElement>(null)
   const termRef        = useRef<Terminal | null>(null)
   const fitAddonRef    = useRef<FitAddon | null>(null)
   const searchAddonRef = useRef<SearchAddon | null>(null)
   const wsRef          = useRef<WebSocket | null>(null)
+
+  useImperativeHandle(ref, () => ({
+    send(text: string) {
+      const ws = wsRef.current
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(text)
+        termRef.current?.focus()
+      }
+    },
+  }))
   const [status, setStatus] = useState<ShellStatus>('connecting')
   const [statusMsg, setStatusMsg] = useState('')
   // Timestamp of when the SSH/PTY went 'connected'. The backend writes the
@@ -708,4 +723,4 @@ export function RemoteShellTerminalTab({
       <div ref={containerRef} style={{ flex: 1, overflow: 'hidden' }} />
     </div>
   )
-}
+})

--- a/gh-ctrl/client/src/types.ts
+++ b/gh-ctrl/client/src/types.ts
@@ -471,3 +471,13 @@ export interface SourceRelayGitFile {
   path: string
   size?: number
 }
+
+export interface PromptTemplate {
+  id: number
+  title: string
+  content: string
+  category: string | null
+  sortOrder: number | null
+  createdAt: string | number | null
+  updatedAt: string | number | null
+}

--- a/gh-ctrl/src/db/index.ts
+++ b/gh-ctrl/src/db/index.ts
@@ -250,5 +250,17 @@ sqlite.exec(`
   )
 `)
 
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS prompt_templates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    category TEXT,
+    sort_order INTEGER DEFAULT 0,
+    created_at INTEGER DEFAULT (unixepoch()),
+    updated_at INTEGER DEFAULT (unixepoch())
+  )
+`)
+
 export const db = drizzle(sqlite, { schema })
 export const sqliteDb = sqlite

--- a/gh-ctrl/src/db/schema.ts
+++ b/gh-ctrl/src/db/schema.ts
@@ -192,3 +192,14 @@ export const sourceRelayConnectorFiles = sqliteTable('source_relay_connector_fil
   filePaths:   text('file_paths').notNull().default('[]'), // JSON array; empty = include all files
   createdAt:   integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
 })
+
+// Prompt Toolbox: reusable prompt/command templates for terminal sessions
+export const promptTemplates = sqliteTable('prompt_templates', {
+  id:        integer('id').primaryKey({ autoIncrement: true }),
+  title:     text('title').notNull(),
+  content:   text('content').notNull(),
+  category:  text('category'),
+  sortOrder: integer('sort_order').default(0),
+  createdAt: integer('created_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).$defaultFn(() => new Date()),
+})

--- a/gh-ctrl/src/index.ts
+++ b/gh-ctrl/src/index.ts
@@ -14,6 +14,7 @@ import contactsRouter from './routes/contacts'
 import settingsRouter from './routes/settings'
 import shellRouter, { shellWebsocket } from './routes/shell'
 import sourceRelayRouter, { sourceRelayPublicRouter } from './routes/source-relay'
+import promptTemplatesRouter from './routes/promptTemplates'
 import versionRouter from './routes/version'
 import backupRouter from './routes/backup'
 import { existsSync, mkdirSync } from 'node:fs'
@@ -65,6 +66,7 @@ app.route('/api/contacts', contactsRouter)
 app.route('/api/settings', settingsRouter)
 app.route('/api/buildings', shellRouter)
 app.route('/api/source-relay', sourceRelayRouter)
+app.route('/api/prompts', promptTemplatesRouter)
 
 // Public source-relay fetch endpoint — no auth required
 app.route('/source-relay', sourceRelayPublicRouter)

--- a/gh-ctrl/src/routes/promptTemplates.ts
+++ b/gh-ctrl/src/routes/promptTemplates.ts
@@ -1,0 +1,84 @@
+import { Hono } from 'hono'
+import { db } from '../db'
+import { promptTemplates } from '../db/schema'
+import { eq, asc } from 'drizzle-orm'
+
+const router = new Hono()
+
+router.get('/', async (c) => {
+  const category = c.req.query('category')
+  const rows = await db
+    .select()
+    .from(promptTemplates)
+    .orderBy(asc(promptTemplates.sortOrder), asc(promptTemplates.createdAt))
+  const filtered = category ? rows.filter((r) => r.category === category) : rows
+  return c.json(filtered)
+})
+
+router.post('/', async (c) => {
+  const body = await c.req.json()
+  const { title, content, category, sortOrder } = body
+
+  if (!title || typeof title !== 'string' || !title.trim()) {
+    return c.json({ error: 'title is required' }, 400)
+  }
+  if (!content || typeof content !== 'string' || !content.trim()) {
+    return c.json({ error: 'content is required' }, 400)
+  }
+
+  const [created] = await db.insert(promptTemplates).values({
+    title: title.trim(),
+    content: content.trim(),
+    category: category?.trim() || null,
+    sortOrder: typeof sortOrder === 'number' ? sortOrder : 0,
+  }).returning()
+
+  return c.json(created, 201)
+})
+
+router.get('/:id', async (c) => {
+  const id = parseInt(c.req.param('id'), 10)
+  if (isNaN(id)) return c.json({ error: 'invalid id' }, 400)
+
+  const [row] = await db.select().from(promptTemplates).where(eq(promptTemplates.id, id))
+  if (!row) return c.json({ error: 'not found' }, 404)
+  return c.json(row)
+})
+
+router.patch('/:id', async (c) => {
+  const id = parseInt(c.req.param('id'), 10)
+  if (isNaN(id)) return c.json({ error: 'invalid id' }, 400)
+
+  const body = await c.req.json()
+  const updates: Partial<{
+    title: string
+    content: string
+    category: string | null
+    sortOrder: number
+    updatedAt: Date
+  }> = { updatedAt: new Date() }
+
+  if (body.title !== undefined) updates.title = String(body.title).trim()
+  if (body.content !== undefined) updates.content = String(body.content).trim()
+  if ('category' in body) updates.category = body.category?.trim() || null
+  if (body.sortOrder !== undefined) updates.sortOrder = Number(body.sortOrder)
+
+  const [updated] = await db
+    .update(promptTemplates)
+    .set(updates)
+    .where(eq(promptTemplates.id, id))
+    .returning()
+
+  if (!updated) return c.json({ error: 'not found' }, 404)
+  return c.json(updated)
+})
+
+router.delete('/:id', async (c) => {
+  const id = parseInt(c.req.param('id'), 10)
+  if (isNaN(id)) return c.json({ error: 'invalid id' }, 400)
+
+  await db.delete(promptTemplates).where(eq(promptTemplates.id, id))
+  return c.json({ ok: true })
+})
+
+export default router


### PR DESCRIPTION
Implements a Prompt Toolbox feature for the RemotePost terminal.

## Changes

- New `prompt_templates` SQLite table (auto-created on startup)
- CRUD REST API at `/api/prompts`
- `PromptToolboxPanel` component with create, edit, delete, copy, and send-to-terminal actions
- `RemoteShellTerminalTab` exposes `send()` via `forwardRef` so the panel can write directly into the active PTY
- Toggle button (⬡ TOOLBOX) added to the terminal dialog header

Closes #417

Generated with [Claude Code](https://claude.ai/code)